### PR TITLE
4 maxreadinpackets

### DIFF
--- a/cHERMES/inc/dataPacketProcessor.h
+++ b/cHERMES/inc/dataPacketProcessor.h
@@ -23,13 +23,16 @@ void writeRawSignals(const configParameters& configParams, std::ofstream& rawSig
 void clusterSignals(const configParameters& configParams, signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo);
 
 // Processes a TDC packet and updates the provided signalData structure.
-void processTDCPacket(unsigned long long datapacket, signalData &signalData);
+void processTDCPacket(unsigned long long dataPacket, signalData &signalData);
 
 // Processes a Pixel packet and updates the provided signalData structure.
-void processPixelPacket(unsigned long long datapacket, signalData &signalData);
+void processPixelPacket(unsigned long long dataPacket, signalData &signalData);
 
 // Processes a Global Time packet and updates the provided signalData structure.
-void processGlobalTimePacket(unsigned long long datapacket, signalData &signalData);
+void processGlobalTimePacket(unsigned long long dataPacket, signalData &signalData);
+
+void processSPIDRControlPacket(unsigned long long dataPacket, signalData &signalData);
+void processTPX3ControlPacket(unsigned long long dataPacket, signalData &signalData);
 
 // Unpack and process entire TPX3File
 tpx3FileDiagnostics unpackAndSortTPX3File(configParameters configParams);

--- a/cHERMES/inc/structures.h
+++ b/cHERMES/inc/structures.h
@@ -34,16 +34,17 @@ struct configParameters {
                                     // 3 = Buffer diagnostics
 };
 
-// This structure is used to contain various dianostic info used during the unpacking processes (in dataPacketProcessor class)
+// This structure is used to contain various diagnostic info used during the unpacking processes (in dataPacketProcessor class)
 struct tpx3FileDiagnostics {
-    uintmax_t filesize = 0;             // size in bytes of tpx3 file
-    uint64_t numberOfDataPackets = 0;    // number of data packets
-    uint32_t numberOfBuffers = 0;        // number of buffers 
-    uint32_t numberOfPixelHits = 0;      // number of pixel hits
-    uint32_t numberOfTDC1s = 0;          // number of TDC1 triggers
-    uint32_t numberOfTDC2s = 0;          // number of TDC2 triggers
-    uint32_t numberOfGTS = 0;            // number of global time stamps.
-    uint32_t numberOfTXP3Controls = 0;   // number of TPX3 Control packets.
+    size_t filesize = 0;                 // size in bytes of tpx3 file
+    size_t numberOfDataPackets = 0;       // number of data packets
+    size_t numberOfProcessedPackets = 0;  // number of processed data packets
+    size_t numberOfBuffers = 0;           // number of buffers 
+    size_t numberOfPixelHits = 0;         // number of pixel hits
+    size_t numberOfTDC1s = 0;             // number of TDC1 triggers
+    size_t numberOfTDC2s = 0;             // number of TDC2 triggers
+    size_t numberOfGTS = 0;               // number of global time stamps.
+    size_t numberOfTXP3Controls = 0;      // number of TPX3 Control packets.
 
     double totalHermesTime = 0;
     double totalUnpackingTime = 0;

--- a/cHERMES/inc/structures.h
+++ b/cHERMES/inc/structures.h
@@ -29,9 +29,11 @@ struct configParameters {
     uint32_t maxPacketsToRead = 0;  // Number of buffer to read in. 0 means read all buffers. 
     bool fillHistograms = false;     // Flag to fill histograms
     int verboseLevel = 1;           // Verbosity Level
+                                    // 0 = be quite, print nothing!
                                     // 1 = General file input/output
                                     // 2 = Config and event diagnostics
                                     // 3 = Buffer diagnostics
+                                    // 4 = packet diagnostics
 };
 
 // This structure is used to contain various diagnostic info used during the unpacking processes (in dataPacketProcessor class)

--- a/cHERMES/src/dataPacketProcessor.cpp
+++ b/cHERMES/src/dataPacketProcessor.cpp
@@ -394,7 +394,6 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
     memcpy(&tpx3Signature, tpx3SignatureStr, sizeof(uint32_t));
 
     size_t currentPacket = 0;       // Initialize the counter outside the while loop
-    size_t processedPackets = 0;    // Track the number of processed packets
     
     // Continue to loop through dataPacket array until you hit the numberOfDataPackets 
     while (currentPacket < configParams.maxPacketsToRead) {
@@ -475,7 +474,8 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
                                 if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" << chunkPacketIndex << ": Unknown SPIDR control packet subtype detected." << std::endl;}
                                 break;
                         }
-                        //processSPIDRControlPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        processSPIDRControlPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
                         break;
                     }
                     case 0x7: { // TPX3 control packets, again note the added braces
@@ -498,7 +498,8 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
                             }
                         }
                         tpx3FileInfo.numberOfTXP3Controls++;
-                        //processTPX3ControlPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        processTPX3ControlPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
                         break;
                     }
                 }
@@ -506,7 +507,7 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
                 currentPacket++;
 
                 // Break out of the loop if processedPackets reaches maxPacketsToRead
-                if (processedPackets >= configParams.maxPacketsToRead) {break;}
+                if (tpx3FileInfo.numberOfProcessedPackets >= configParams.maxPacketsToRead) {break;}
             }
             
             // Update number of buffers processed. instead
@@ -522,7 +523,7 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
     bufferUnpackTime = stopUnpackTime - startUnpackTime;
     tpx3FileInfo.totalUnpackingTime = tpx3FileInfo.totalUnpackingTime + bufferUnpackTime.count();
     tpx3FileInfo.numberOfDataPackets = currentPacket;
-    if(configParams.verboseLevel >= 3){std::cout << "Unpacked "<< currentPacket << " data packets, processed "<< processedPackets << " data packets" << std::endl;}
+    if(configParams.verboseLevel >= 3){std::cout << "Unpacked "<< currentPacket << " data packets, processed "<< tpx3FileInfo.numberOfProcessedPackets << " data packets" << std::endl;}
 }
 
 

--- a/cHERMES/src/dataPacketProcessor.cpp
+++ b/cHERMES/src/dataPacketProcessor.cpp
@@ -71,7 +71,7 @@ void sortSignals(const configParameters& configParams, signalData* signalDataArr
     auto startSortTime = std::chrono::high_resolution_clock::now(); // Grab a start time for sorting
         
     // Print info depending on verbosity level
-    if (configParams.verboseLevel>=2) {std::cout <<"Sorting raw signal data. " << std::endl;}
+    if (configParams.verboseLevel>=2) {std::cout <<"Sorting " << tpx3FileInfo.numberOfDataPackets << " raw signal data. " << std::endl;}
 
     // Sort the signalDataArray based on ToaFinal
     std::sort(signalDataArray, signalDataArray + tpx3FileInfo.numberOfDataPackets,[](const signalData &a, const signalData &b) -> bool {return a.ToaFinal < b.ToaFinal;});
@@ -80,7 +80,7 @@ void sortSignals(const configParameters& configParams, signalData* signalDataArr
     auto stopSortTime = std::chrono::high_resolution_clock::now();
     bufferSortTime = stopSortTime - startSortTime;
     tpx3FileInfo.totalSortingTime = bufferSortTime.count();
-    if (configParams.verboseLevel>=2) {std::cout <<"Finished sorting all "<< tpx3FileInfo.numberOfDataPackets << " signal data. " << std::endl;}
+    if (configParams.verboseLevel>=2) {std::cout <<"Finished sorting "<< tpx3FileInfo.numberOfDataPackets << " raw signals. " << std::endl;}
 }
 
 
@@ -109,7 +109,7 @@ void clusterSignals(const configParameters& configParams, signalData* signalData
     auto stopClusterTime = std::chrono::high_resolution_clock::now();
     bufferClusterTime = stopClusterTime - startClusterTime;
     tpx3FileInfo.totalClusteringTime = bufferClusterTime.count();
-    if (configParams.verboseLevel >= 2) {std::cout << "Finished clustering of all " << tpx3FileInfo.numberOfDataPackets << "pixels based on DBSCAN " << std::endl;}
+    if (configParams.verboseLevel >= 2) {std::cout << "Finished clustering of " << tpx3FileInfo.numberOfDataPackets << " pixels based on DBSCAN " << std::endl;}
 }
 
 
@@ -334,6 +334,54 @@ void processGlobalTimePacket(uint64_t dataPacket, signalData &signalData) {
 	
 }
 
+/**
+ * @brief Takes a SPIDR control packet from a tpx3 file, processes it, 
+ * and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing of 
+ * the SPIDR control flag. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * TODO: Need to get logic for unpacking from ASI.  
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */ 
+void processSPIDRControlPacket(uint64_t dataPacket, signalData &signalData) {
+
+    // Set info in signalData 
+    signalData.signalType = 4;
+    signalData.xPixel = 0;
+    signalData.yPixel = 0;
+    signalData.ToaFinal = 0;
+    signalData.TotFinal = 0;
+	
+}
+
+/**
+ * @brief Takes a TPX3 control packet from a tpx3 file, processes it, 
+ * and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing of 
+ * the TPX3 control flag. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * TODO: Need to get logic for unpacking from ASI.  
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */ 
+void processTPX3ControlPacket(uint64_t dataPacket, signalData &signalData) {
+
+    // Set info in signalData 
+    signalData.signalType = 5;
+    signalData.xPixel = 0;
+    signalData.yPixel = 0;
+    signalData.ToaFinal = 0;
+    signalData.TotFinal = 0;
+	
+}
+
 
 void processDataPackets(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo, const uint64_t* dataPackets, signalData* signalDataArray) {
     
@@ -345,12 +393,12 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
     uint32_t tpx3Signature;
     memcpy(&tpx3Signature, tpx3SignatureStr, sizeof(uint32_t));
 
-    // Initialize the counter outside the while loop
-    size_t currentPacket = 0; 
-
+    size_t currentPacket = 0;       // Initialize the counter outside the while loop
+    size_t processedPackets = 0;    // Track the number of processed packets
     
     // Continue to loop through dataPacket array until you hit the numberOfDataPackets 
     while (currentPacket < configParams.maxPacketsToRead) {
+        
         // Grab last 32 bits of current packet
         uint32_t tpx3flag = static_cast<uint32_t>(dataPackets[currentPacket]);
         
@@ -360,61 +408,78 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
             // Start processing the chuck header to get size and number of data packets in chuck. 
             uint16_t chunkSize = static_cast<uint16_t>((dataPackets[currentPacket] >> 48) & 0xFFFF);
             uint16_t numPacketsInChunk = chunkSize / 8;
-            if(configParams.verboseLevel >= 3){std::cout << "Found TPX3 chunk header with " << numPacketsInChunk << " packets."<<std::endl;}
+            if(configParams.verboseLevel >= 3){std::cout << std::dec << currentPacket << ":-: Found TPX3 chunk header with " << numPacketsInChunk << " packets."<<std::endl;}
+
+            tpx3FileInfo.numberOfProcessedPackets++; // processed a chunk header packet so increment processed packets
+            currentPacket++;    // move onto the next packet
+
+            // Ensure we do not process more packets than the maxPacketsToRead limit
+            if (tpx3FileInfo.numberOfProcessedPackets + numPacketsInChunk > configParams.maxPacketsToRead) {
+                numPacketsInChunk = configParams.maxPacketsToRead - tpx3FileInfo.numberOfProcessedPackets;
+                if(configParams.verboseLevel >= 3){std::cout << "MESSAGE: Shortening numPacketsInChunk to " << numPacketsInChunk << std::endl;}
+            }
 
             // Iterate through each data packet in the current chunk
-            for (uint16_t chunkPacketIndex = 1; chunkPacketIndex <= numPacketsInChunk; ++chunkPacketIndex) {
-                
-                // Calculate the actual index of the current data packet within the entire array
-                uint64_t actualPacketIndex = currentPacket + chunkPacketIndex;
+            for (uint16_t chunkPacketIndex = 0; chunkPacketIndex < numPacketsInChunk; ++chunkPacketIndex) {
+
+                // Checking to make sure we are not reading a TPX3 chunk header packet
+                // Grab last 32 bits of current packet
+                uint32_t tpx3flag = static_cast<uint32_t>(dataPackets[currentPacket]);
+                if (tpx3flag == tpx3Signature){ std::cout << "ERROR: FOUND a TPX3 chunk header before finishing with current buffer...";}
 
                 // Safeguard against going beyond the allocated memory
-                if (actualPacketIndex >= tpx3FileInfo.numberOfDataPackets) break;
+                if (currentPacket >= tpx3FileInfo.numberOfDataPackets){ 
+                    if(configParams.verboseLevel >= 3){std::cout << "Current Packet beyond " <<  tpx3FileInfo.numberOfDataPackets << ". Breaking out of process loop." << std::endl;}
+                    break;
+                }
 
                 // Extract the packet type from the most significant nibble
-                uint8_t packetType = static_cast<uint8_t>((dataPackets[actualPacketIndex] >> 60) & 0xF);
+                uint8_t packetType = static_cast<uint8_t>((dataPackets[currentPacket] >> 60) & 0xF);
 
                 switch (packetType) {
                     case 0xA: // Integrated ToT mode
-                        // Process Integrated ToT mode packet
                         std::cout << "Integrated ToT mode packet detected." << std::endl;
                         break;
                     case 0xB: // Time of Arrival mode
-                        if(configParams.verboseLevel >= 4){std::cout << "Pixel data packet" << std::endl;}
-                        processPixelPacket(dataPackets[actualPacketIndex], signalDataArray[actualPacketIndex]);
+                        if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" <<chunkPacketIndex << ": Pixel data packet" << std::endl;}
+                        processPixelPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
                         tpx3FileInfo.numberOfPixelHits++;
                         break;
                     case 0x6: // TDC data packets
-                        if(configParams.verboseLevel >= 4){std::cout << "TDC data packet" << std::endl;}
-                        processTDCPacket(dataPackets[actualPacketIndex], signalDataArray[actualPacketIndex]);
+                        if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" << chunkPacketIndex << ": TDC data packet" << std::endl;}
+                        processTDCPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
                         tpx3FileInfo.numberOfTDC1s++;
                         break;
                     case 0x4: // Global time data packets
-                        if(configParams.verboseLevel >= 4){std::cout << "Global time stamp data packet" << std::endl;}
-                        processGlobalTimePacket(dataPackets[actualPacketIndex], signalDataArray[actualPacketIndex]);
+                        if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" << chunkPacketIndex << ": Global time stamp data packet" << std::endl;}
+                        processGlobalTimePacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
                         tpx3FileInfo.numberOfGTS++;
                         break;
                         
                     case 0x5: { // SPIDR control packets, note the added braces to introduce a new block scope
-                        uint8_t subType = static_cast<uint8_t>((dataPackets[actualPacketIndex] >> 56) & 0xF);
+                        uint8_t subType = static_cast<uint8_t>((dataPackets[currentPacket] >> 56) & 0xF);
                         switch (subType) {
                             case 0xF:
-                                if(configParams.verboseLevel >= 4){std::cout << "Open shutter packet detected." << std::endl;}
+                                if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" << chunkPacketIndex << ": Open shutter packet detected." << std::endl;}
                                 break;
                             case 0xA:
-                                if(configParams.verboseLevel >= 4){std::cout << "Close shutter packet detected." << std::endl;}
+                                if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" << chunkPacketIndex << ": Close shutter packet detected." << std::endl;}
                                 break;
                             case 0xC:
-                                if(configParams.verboseLevel >= 4){std::cout << "Heartbeat packet detected." << std::endl;}
+                                if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" << chunkPacketIndex << ": Heartbeat packet detected." << std::endl;}
                                 break;
                             default:
-                                if(configParams.verboseLevel >= 4){std::cout << "Unknown SPIDR control packet subtype detected." << std::endl;}
+                                if(configParams.verboseLevel >= 4){std::cout << std::dec << currentPacket << ":" << chunkPacketIndex << ": Unknown SPIDR control packet subtype detected." << std::endl;}
                                 break;
                         }
+                        //processSPIDRControlPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
                         break;
                     }
                     case 0x7: { // TPX3 control packets, again note the added braces
-                        uint8_t controlType = static_cast<uint8_t>((dataPackets[actualPacketIndex] >> 48) & 0xFF);
+                        uint8_t controlType = static_cast<uint8_t>((dataPackets[currentPacket] >> 48) & 0xFF);
                         if (controlType ==0xA0) {
                             if(configParams.verboseLevel >= 4){
                                 std::cout << "End of sequential readout detected with "<< std::hex << "packetType: 0x" << +packetType << "\t"<< "controlType: 0x" << +controlType << std::endl;
@@ -427,22 +492,29 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
                         } else {
                             if(configParams.verboseLevel >= 4){
                             // Print out the hex value of controlType
-                                std::cout << "Unkown TPX3 control packets detected with "
+                                std::cout << currentPacket << ":" << chunkPacketIndex << ": Unkown TPX3 control packets detected with "
                                 << "packetType: 0x"<< std::hex << +packetType << "\t"
                                 << "controlType: 0x" << controlType << std::endl;
                             }
                         }
                         tpx3FileInfo.numberOfTXP3Controls++;
+                        //processTPX3ControlPacket(dataPackets[currentPacket], signalDataArray[currentPacket]);
                         break;
                     }
                 }
-            }
 
-            // Move to the next chunk by skipping over the packets in the current chunk
-            currentPacket += numPacketsInChunk - 1; // -1 because the loop increment will add 1 more
+                currentPacket++;
+
+                // Break out of the loop if processedPackets reaches maxPacketsToRead
+                if (processedPackets >= configParams.maxPacketsToRead) {break;}
+            }
+            
+            // Update number of buffers processed. instead
             tpx3FileInfo.numberOfBuffers++;
-        } 
-        currentPacket++;
+        } else {
+            std::cout << "ERROR: Could not find TPX3 Flag, instead found " << std::hex << +tpx3flag << endl;
+            currentPacket++;
+        }
     }
 
     // Grab stop time, calculate buffer unpacking duration, and append to total unpacking time.
@@ -450,7 +522,7 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
     bufferUnpackTime = stopUnpackTime - startUnpackTime;
     tpx3FileInfo.totalUnpackingTime = tpx3FileInfo.totalUnpackingTime + bufferUnpackTime.count();
     tpx3FileInfo.numberOfDataPackets = currentPacket;
-    if(configParams.verboseLevel >= 3){std::cout << "Finished unpacking all "<< currentPacket << " data packets" << std::endl;}
+    if(configParams.verboseLevel >= 3){std::cout << "Unpacked "<< currentPacket << " data packets, processed "<< processedPackets << " data packets" << std::endl;}
 }
 
 


### PR DESCRIPTION
Had to include a processedPacket variable that was updated when each type of signal was processed. Added two dummy functions of processSPIDRControlPacket() and processTPX3ControlPacket() to account for non-pixel and non-TDC signals that should end up in the signalData array. 
