### PR TITLE
24 modular unpackers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,6 @@ ipython_config.py
 
 # ignore anything in .deprecated directory
 .deprecated/
+
+# ignore scratch directory
+.scratch/

--- a/backends/unpackers/tpx3-spidr/cpp/Makefile
+++ b/backends/unpackers/tpx3-spidr/cpp/Makefile
@@ -1,0 +1,69 @@
+# Compiler and flags
+CXX = g++
+CFLAGS = -Wall -O2
+CXXFLAGS = $(CFLAGS) -std=c++17
+
+# Directories
+SRC_DIR = ./src
+INC_DIR = ./inc
+OBJ_DIR = ./obj
+BIN_DIR = ./bin
+
+# Include directories
+CXXFLAGS += -I$(INC_DIR)
+
+# Files
+MAIN_SRC = tpx3SpidrUnpacker.cpp
+TARGET = tpx3SpidrUnpacker
+BIN_TARGET = $(BIN_DIR)/$(TARGET)
+
+# Source files (excluding histgrams.cpp as in original Makefile)
+LIB_SRCS = $(filter-out $(SRC_DIR)/histgrams.cpp, $(wildcard $(SRC_DIR)/*.cpp))
+LIB_SRCS := $(filter-out $(SRC_DIR)/$(MAIN_SRC), $(LIB_SRCS))
+
+# Object files
+MAIN_OBJ = $(OBJ_DIR)/$(MAIN_SRC:.cpp=.o)
+LIB_OBJS = $(LIB_SRCS:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.o)
+ALL_OBJS = $(MAIN_OBJ) $(LIB_OBJS)
+
+# Header dependencies
+DEPS = $(wildcard $(INC_DIR)/*.h)
+
+# Default target
+all: $(BIN_TARGET)
+
+# Create necessary directories
+$(OBJ_DIR):
+	mkdir -p $(OBJ_DIR)
+
+$(BIN_DIR):
+	mkdir -p $(BIN_DIR)
+
+# Link object files to create the binary and move to bin directory
+$(BIN_TARGET): $(ALL_OBJS) | $(BIN_DIR)
+	$(CXX) $(LDFLAGS) -o $@ $(ALL_OBJS)
+	@echo "Binary created and moved to $(BIN_DIR)/$(TARGET)"
+
+# Compile source files into object files
+$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp $(DEPS) | $(OBJ_DIR)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJ_DIR)/*.o $(BIN_TARGET)
+	@echo "Cleaned object files and binary"
+
+# Install target (same as all for this case)
+install: $(BIN_TARGET)
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  all      - Build the tpx3SpidrUnpacker binary (default)"
+	@echo "  clean    - Remove object files and binary"
+	@echo "  install  - Build and install the binary"
+	@echo "  help     - Show this help message"
+	@echo ""
+	@echo "Binary will be created at: $(BIN_DIR)/$(TARGET)"
+
+.PHONY: all clean install help

--- a/backends/unpackers/tpx3-spidr/cpp/Notes.md
+++ b/backends/unpackers/tpx3-spidr/cpp/Notes.md
@@ -1,0 +1,224 @@
+# TPX3 SPIDR raw packet reference
+
+This file records the raw fields that the HERMES TPX3 SPIDR unpacker must
+preserve. It is based primarily on:
+
+- `.agent/resources/20231023_ASIServer_TPX3_manual_V3.3.pdf`;
+- `.agent/resources/TPX3CAM_manual_V2.3.pdf`;
+- `.agent/examples/TPX3_read_and_convert.cpp`.
+
+PymePix, tpx3HitParser, and mcpevent2hist/Sophiread are useful independent
+implementations, but none of them preserves every packet family. The vendor
+manuals define the raw file contract.
+
+## General rules
+
+- A `.tpx3` file is a sequence of chunks.
+- Every chunk starts with one 8-byte header.
+- The chunk content contains 8-byte words in little-endian byte order.
+- Bit ranges below are inclusive and numbered from the least-significant bit.
+- The most-significant nibble normally identifies the packet family.
+- Raw integer fields are the source of truth. Derived times must not replace
+  them.
+- The raw 64-bit word, chip index, chunk index, and packet index should be
+  retained for packet families whose meaning is incomplete or uncertain.
+
+## Chunk header
+
+| Bits | Field | Notes |
+| --- | --- | --- |
+| 63-48 | `chunk_size_bytes` | Number of content bytes following the header. It must be divisible by 8. |
+| 47-40 | `mode_or_reserved` | Called reserved by SERVAL V3.3 and mode by the older TPX3Cam manual. Preserve it without assuming a meaning. |
+| 39-32 | `chip_index` | Identifies the Timepix3 chip that produced the chunk. |
+| 31-0 | signature | Little-endian bytes `TPX3`, integer value `0x33585054`. |
+
+The number of content packets is `chunk_size_bytes / 8`. A decoder must reject
+or report a truncated chunk rather than reading beyond the input buffer.
+
+## Pixel packets
+
+### Integrated-ToT packet (`0xA`)
+
+| Bits | Field | Type |
+| --- | --- | --- |
+| 63-60 | packet type `0xA` | `uint8` |
+| 59-44 | `pixel_address` | `uint16` |
+| 43-30 | `integrated_tot_raw` | `uint16`, 25 ns ticks |
+| 29-20 | `event_count` | `uint16` |
+| 19-16 | `hit_count` | `uint8` |
+| 15-0 | `spidr_time_raw` | `uint16`, 409.6 us ticks |
+
+Integrated-ToT packets must not be silently discarded, even when the first
+workflow normally records data-driven `0xB` packets.
+
+### ToA/ToT pixel-hit packet (`0xB`)
+
+| Bits | Field | Type |
+| --- | --- | --- |
+| 63-60 | packet type `0xB` | `uint8` |
+| 59-44 | `pixel_address` | `uint16` |
+| 43-30 | `toa_raw` | `uint16`, 25 ns ticks |
+| 29-20 | `tot_raw` | `uint16`, 25 ns ticks |
+| 19-16 | `ftoa_raw` | `uint8`, negative 1.5625 ns correction |
+| 15-0 | `spidr_time_raw` | `uint16`, 409.6 us ticks |
+
+The pixel address is decoded as:
+
+```text
+double_column = (pixel_address & 0xFE00) >> 8
+super_pixel   = (pixel_address & 0x01F8) >> 1
+pixel_index   =  pixel_address & 0x0007
+x             = double_column + (pixel_index >> 2)
+y             = super_pixel + (pixel_index & 0x3)
+```
+
+These are local chip coordinates. Detector-wide coordinates require the
+`chip_index` and detector-layout information and should not replace the local
+coordinates in the unpacker output.
+
+The exact fine pixel time in units of 1.5625 ns is:
+
+```text
+pixel_time_1p5625ns =
+    (((spidr_time_raw << 14) + toa_raw) << 4) - ftoa_raw
+```
+
+Do not use `(toa_raw << 4) | (~ftoa_raw & 0xF)`. That expression adds 15 fine
+ticks and shifts every pixel timestamp by 23.4375 ns.
+
+The 16-bit SPIDR timer advances in 409.6 us steps. Its rollover period is:
+
+```text
+65536 * 409.6 us = 26.8435456 s
+```
+
+The largest encoded value occurs one tick before that rollover.
+
+## TDC packet (`0x6`)
+
+| Bits | Field | Type |
+| --- | --- | --- |
+| 63-60 | packet type `0x6` | `uint8` |
+| 59-56 | `edge_code` | `uint8` |
+| 55-44 | `trigger_counter` | `uint16` |
+| 43-9 | `tdc_timestamp_raw` | `uint64`, 3.125 ns ticks |
+| 8-5 | `tdc_fine_raw` | `uint8`, values 1-12 |
+| 4-0 | reserved | `uint8` |
+
+Edge codes are:
+
+| Code | Meaning |
+| --- | --- |
+| `0xF` | TDC1 rising edge |
+| `0xA` | TDC1 falling edge |
+| `0xE` | TDC2 rising edge |
+| `0xB` | TDC2 falling edge |
+
+Fine value 0 is a decoder error state. Value 1 represents zero fine offset;
+values 2 through 12 advance in exact steps of `25 ns / 96`.
+
+```text
+tdc_time =
+    tdc_timestamp_raw * 3.125 ns
+    + (tdc_fine_raw - 1) * (25 ns / 96)
+```
+
+The decoder must preserve the edge code, trigger counter, timestamp, and fine
+value independently. It must not count every `0x6` packet as a TDC1 event.
+
+## Global-time packets (`0x4`)
+
+### Time-low packet (`0x44`)
+
+| Bits | Field | Type |
+| --- | --- | --- |
+| 63-56 | packet ID `0x44` | `uint8` |
+| 55-48 | reserved | `uint8` |
+| 47-16 | `global_time_low_raw` | `uint32`, 25 ns ticks |
+| 15-0 | `spidr_time_raw` | `uint16`, 409.6 us ticks |
+
+### Time-high packet (`0x45`)
+
+| Bits | Field | Type |
+| --- | --- | --- |
+| 63-56 | packet ID `0x45` | `uint8` |
+| 55-32 | reserved | 24 bits |
+| 31-16 | `global_time_high_raw` | `uint16`, high bits of the 25 ns timer |
+| 15-0 | `spidr_time_raw` | `uint16`, 409.6 us ticks |
+
+When a matching low and high value are available, the 48-bit timer is:
+
+```text
+global_time_raw =
+    (global_time_high_raw << 32) | global_time_low_raw
+```
+
+One global tick is 25 ns. The high field advances in exact steps of
+`2^32 * 25 ns = 107.3741824 s`. The 48-bit timer rollover period is about
+`7,036,874.4177664 s`, or 81.45 days.
+
+The low packet, high packet, and paired 48-bit value should remain
+distinguishable. Do not store either raw part only as floating-point seconds.
+
+## SPIDR control packets (`0x5`)
+
+### Packet-count packet (`0x50`)
+
+| Bits | Field |
+| --- | --- |
+| 63-56 | packet ID `0x50` |
+| 55-48 | reserved |
+| 47-0 | `packet_count` |
+
+### Shutter and heartbeat packets
+
+| Bits | Field |
+| --- | --- |
+| 63-60 | packet type `0x5` |
+| 59-56 | subtype: `0xF` open shutter, `0xA` close shutter, `0xC` heartbeat |
+| 55-46 | reserved |
+| 45-12 | `timestamp_raw`, 25 ns ticks |
+| 11-0 | reserved |
+
+The subtype, timestamp, reserved fields, and raw packet must be preserved. A
+control packet must not be replaced with a zero-filled generic signal row.
+
+## TPX3 control packets (`0x7`)
+
+The SERVAL V3.3 table identifies `0x71` in bits 63-56 and lists `0xA0` and
+`0xB0` as end-of-sequential-readout and end-of-data-driven-readout subtypes.
+The table's stated reserved range overlaps the subtype, and other readers also
+recognize additional `0x71xx` and `0x72xx` values.
+
+Until every subtype is confirmed, preserve:
+
+- the upper 16-bit control value;
+- the lower 48 payload bits;
+- the complete raw 64-bit word;
+- chip and chunk provenance;
+- an `unknown` classification for unrecognized values.
+
+## Unknown packets
+
+Unknown packets are part of the diagnostic record. Preserve their raw word,
+most-significant byte, chip index, chunk index, and packet index, and add a
+warning to the decode summary. Do not silently discard them.
+
+## HERMES output representation
+
+The unpacker should preserve and write the detector's native integer fields.
+Each packet type should have its own clearly defined output columns so no raw
+packet information is forced into unrelated generic fields or discarded.
+
+Packet decoding should use integer masks, shifts, and arithmetic. Required
+derived timestamps, such as the combined pixel or 48-bit global timestamp,
+should also remain integers with their exact units recorded as metadata.
+
+The first implementation should not write derived floating-point time columns.
+Conversions to seconds or nanoseconds belong in later analysis and
+visualization code and should be calculated only when needed.
+
+The existing `signalData` memory dump should not be used as the output format.
+It writes the program's internal C++ memory layout, which may include compiler
+padding and machine-specific byte ordering, and it cannot retain all fields
+from every packet type.

--- a/backends/unpackers/tpx3-spidr/cpp/inc/commandLineParser.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/commandLineParser.h
@@ -1,0 +1,80 @@
+/**
+ * @file commandLineParser.h
+ * @brief Header file for command-line parsing utilities
+ */
+
+#ifndef COMMANDLINEPARSER_H
+#define COMMANDLINEPARSER_H
+
+#include <string>
+#include "structures.h"
+
+/**
+ * @brief Creates default configuration parameters
+ * @return configParameters struct with default values
+ */
+configParameters createDefaultConfig();
+
+/**
+ * @brief Check if a file exists
+ * @param filepath Path to the file
+ * @return true if file exists
+ */
+bool fileExists(const std::string& filepath);
+
+/**
+ * @brief Check if a file has a specific extension
+ * @param filepath Path to the file
+ * @param extension Expected extension (e.g., ".tpx3", ".config")
+ * @return true if file has the expected extension
+ */
+bool hasExtension(const std::string& filepath, const std::string& extension);
+
+/**
+ * @brief Check if a file exists and has a specific extension
+ * @param filepath Path to the file
+ * @param extension Expected extension (e.g., ".tpx3", ".config")
+ * @return true if file exists and has the expected extension
+ */
+bool isFileWithExtension(const std::string& filepath, const std::string& extension);
+
+/**
+ * @brief Extract directory path from file path
+ * @param filepath Full path to file
+ * @return Directory path (empty string if no directory)
+ */
+std::string getDirectoryPath(const std::string& filepath);
+
+/**
+ * @brief Extract filename from file path
+ * @param filepath Full path to file
+ * @return Filename only
+ */
+std::string getFilename(const std::string& filepath);
+
+/**
+ * @brief Safely parse integer from string
+ * @param str String to parse
+ * @param defaultValue Default value if parsing fails
+ * @return Parsed integer or default value
+ */
+int parseIntOrDefault(const std::string& str, int defaultValue);
+
+/**
+ * @brief Parse command-line flags and populate configuration
+ * @param argc Number of arguments
+ * @param argv Array of arguments
+ * @param configParams Configuration parameters to populate
+ * @param helpLevel Output parameter for help level (if help requested)
+ * @return true if parsing successful, false if help requested or error
+ */
+bool parseCommandLineFlags(int argc, char* argv[], configParameters& configParams, int& helpLevel);
+
+/**
+ * @brief Print usage information with different detail levels
+ * @param programName Name of the program
+ * @param helpLevel Level of help detail (1=basic, 2=with examples)
+ */
+void printUsage(const char* programName, int helpLevel = 1);
+
+#endif // COMMANDLINEPARSER_H

--- a/backends/unpackers/tpx3-spidr/cpp/inc/configReader.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/configReader.h
@@ -1,0 +1,14 @@
+#ifndef CONFIG_READER_H
+#define CONFIG_READER_H
+
+#include "structures.h"
+#include <string>
+
+std::string trim(const std::string& str);
+std::string grabRunHandle(const std::string& str);
+bool stringToBool(const std::string& str);
+template<typename T> T stringToNumber(const std::string& str);
+bool readConfigFile(const std::string &filename, configParameters &params);
+void printParameters(const configParameters &params) ;
+
+#endif // CONFIG_READER_H

--- a/backends/unpackers/tpx3-spidr/cpp/inc/dataPacketProcessor.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/dataPacketProcessor.h
@@ -1,0 +1,47 @@
+// dataPacketProcessor.h
+#include <stdio.h>
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <vector>
+#include <cstring>
+#include <stdint.h>
+#include <chrono>
+#include <filesystem> // For std::filesystem::file_size
+
+#ifndef DATAPACKETPROCESSOR_H
+#define DATAPACKETPROCESSOR_H
+
+#include "structures.h"
+#include "photonRecon.h"
+
+std::vector<std::string> getFilesInDirectory(configParameters configParams);
+void resetGlobalVariables();
+std::ifstream openTPX3File(const std::string& path, tpx3FileDiagnostics& tpx3FileInfo);
+std::ofstream openRawSignalsOutputFile(const configParameters& configParams);
+void processDataPackets(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo, const uint64_t* packets, signalData* signalDataArray);
+void sortSignals(const configParameters& configParams, signalData* signalDataArray, size_t numberOfDataPackets);
+void writeRawSignals(const configParameters& configParams, std::ofstream& rawSignalsFile, const signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo);
+void clusterSignals(const configParameters& configParams, signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo);
+
+// Processes a TDC packet and updates the provided signalData structure.
+void processTDCPacket(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData);
+
+// Processes a Pixel packet and updates the provided signalData structure.
+void processPixelPacket(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData);
+
+// Processes a Global Time packet and updates the provided signalData structure.
+void processGlobalTimePacket(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData);
+
+void processSPIDRControlPacket(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData);
+void processTPX3ControlPacket(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData);
+
+// Unpack and process entire TPX3File
+void processTPX3Files(configParameters configParams);
+tpx3FileDiagnostics unpackAndSortTPX3File(configParameters configParams);
+
+// Unpack and process TPX3Files buffer by buffer
+//tpx3FileDiagnostics unpackandSortTPX3FileInSequentialBuffers(configParameters configParams);
+
+#endif
+

--- a/backends/unpackers/tpx3-spidr/cpp/inc/dataPacketProcessor.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/dataPacketProcessor.h
@@ -17,7 +17,7 @@
 
 std::vector<std::string> getFilesInDirectory(configParameters configParams);
 void resetGlobalVariables();
-std::ifstream openTPX3File(const std::string& path, tpx3FileDiagnostics& tpx3FileInfo);
+std::ifstream openTPX3File(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo);
 std::ofstream openRawSignalsOutputFile(const configParameters& configParams);
 void processDataPackets(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo, const uint64_t* packets, signalData* signalDataArray);
 void sortSignals(const configParameters& configParams, signalData* signalDataArray, size_t numberOfDataPackets);

--- a/backends/unpackers/tpx3-spidr/cpp/inc/dataPacketProcessor.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/dataPacketProcessor.h
@@ -20,7 +20,7 @@ void resetGlobalVariables();
 std::ifstream openTPX3File(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo);
 std::ofstream openRawSignalsOutputFile(const configParameters& configParams);
 void processDataPackets(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo, const uint64_t* packets, signalData* signalDataArray);
-void sortSignals(const configParameters& configParams, signalData* signalDataArray, size_t numberOfDataPackets);
+void sortSignals(const configParameters& configParams, signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo);
 void writeRawSignals(const configParameters& configParams, std::ofstream& rawSignalsFile, const signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo);
 void clusterSignals(const configParameters& configParams, signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo);
 

--- a/backends/unpackers/tpx3-spidr/cpp/inc/diagnostics.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/diagnostics.h
@@ -1,0 +1,27 @@
+// diagnostics.h
+
+#ifndef DIAGNOSTICS_H
+#define DIAGNOSTICS_H
+
+// libraries
+#include <stdint.h>
+#include <cstddef>
+#include <stdio.h>
+#include <iostream>
+
+// User defined libraries
+#include "structures.h"
+
+// Declarations of variables
+extern int numberOfHeaders;
+extern int numberOfBuffers;
+extern int numberOfTDCPackets;
+extern int numberOfPixelPackets;
+extern int numberOfGlobalTSPackets;
+extern int numberOfPhotons;
+
+// Function prototypes
+void printGroupIDs(int numberOfBuffers, signalData* signalDataArray, int16_t* signalGroupID,size_t dataPacketsInBuffer);
+void printOutUnpackingDiagnostics(tpx3FileDiagnostics tpxFileInfo);
+
+#endif

--- a/backends/unpackers/tpx3-spidr/cpp/inc/histograms.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/histograms.h
@@ -1,0 +1,23 @@
+// histograms.h
+
+#ifndef HISTOGRAM_H
+#define HISTOGRAM_H
+
+#include <TH1F.h>
+#include <TH2C.h>
+#include "structures.h"
+
+// Declaration of histograms
+extern TH1F *pixelToA_1D;
+extern TH1F *tdcToA_1D;
+extern TH1F *gtsToA_1D;
+extern TH2C *pixelHits_2D;
+
+// Function prototypes
+void fillRawTDCHistogram(signalData &data);
+void fillRawPixelHistogram(signalData &data);
+void fillRawGTSHistogram(signalData &data);
+void fillRawHistograms(int dataPacketsInBuffer, signalData* signalDataArray);
+void writeHistograms();
+
+#endif

--- a/backends/unpackers/tpx3-spidr/cpp/inc/photonRecon.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/photonRecon.h
@@ -1,0 +1,25 @@
+// photonRecon.h
+
+#ifndef PHOTONRECON_H
+#define PHOTONRECON_H
+
+#include <stdint.h>
+#include <cstddef>
+#include <vector>
+#include <unordered_map>
+#include <cstddef>
+#include <cmath>
+
+// User defined libraries
+#include "structures.h"
+
+
+double spatialDistance(const signalData& p1, const signalData& p2);
+double temporalDistance(const signalData& p1, const signalData& p2);
+bool isNeighbor(const signalData& p1, const signalData& p2, double epsSpatial, double epsTemporal); 
+std::vector<size_t> regionQuery(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray, const size_t homeIndex);
+photonData expandCluster(configParameters configParams,tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray, size_t pIndex, std::vector<size_t>& neighbors, int clusterId, size_t dataPacketsInBuffer);
+void ST_DBSCAN(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray);
+
+
+#endif // PHOTONRECON_H

--- a/backends/unpackers/tpx3-spidr/cpp/inc/photonRecon.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/photonRecon.h
@@ -18,7 +18,7 @@ double spatialDistance(const signalData& p1, const signalData& p2);
 double temporalDistance(const signalData& p1, const signalData& p2);
 bool isNeighbor(const signalData& p1, const signalData& p2, double epsSpatial, double epsTemporal); 
 std::vector<size_t> regionQuery(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray, const size_t homeIndex);
-photonData expandCluster(configParameters configParams,tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray, size_t pIndex, std::vector<size_t>& neighbors, int clusterId, size_t dataPacketsInBuffer);
+photonData expandCluster(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray, size_t homeIndex, std::vector<size_t>& neighbors, size_t clusterId);
 void ST_DBSCAN(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray);
 
 

--- a/backends/unpackers/tpx3-spidr/cpp/inc/structures.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/structures.h
@@ -1,0 +1,89 @@
+#ifndef STRUCTURES_H
+#define STRUCTURES_H
+
+#include <cstdint>
+#include <string>
+
+struct configParameters {
+    // Input options
+    std::string rawTPX3Folder;  // Directory where raw TPX3 files are located
+    std::string rawTPX3File;    // Specific TPX3 file to process
+    std::string runHandle;      // Name of the run number that is being processed.
+    bool batchMode = false;     // Flag to run in batch mode
+    
+    // Output options
+    bool writeRawSignals = true;    // Flag to write out rawsignals in binrary
+    std::string outputFolder = "."; // Default to current directory
+    
+    // Sorting options
+    bool sortSignals = true;        // Flag to sort signals
+    
+    // Basic Clustering Options
+    bool clusterPixels = false;
+    uint8_t epsSpatial = 0;
+    double epsTemporal = 0;
+    uint8_t minPts = 0;
+    uint16_t queryRegion = 0;
+    bool writeOutPhotons = true;    // Flag to write out Photon data in binrary
+
+    //Diagnostic options
+    uint32_t maxPacketsToRead = 0;  // Number of buffer to read in. 0 means read all buffers. 
+    bool fillHistograms = false;    // Flag to fill histograms
+    int verboseLevel = 1;           // Verbosity Level
+                                    // 0 = be quite, print nothing!
+                                    // 1 = General file input/output
+                                    // 2 = Config and event diagnostics
+                                    // 3 = Buffer diagnostics
+                                    // 4 = packet diagnostics
+};
+
+// This structure is used to contain various diagnostic info used during the unpacking processes (in dataPacketProcessor class)
+struct tpx3FileDiagnostics {
+    size_t filesize = 0;                 // size in bytes of tpx3 file
+    size_t numberOfDataPackets = 0;       // number of data packets
+    size_t numberOfProcessedPackets = 0;  // number of processed data packets
+    size_t numberOfBuffers = 0;           // number of buffers 
+    size_t numberOfPixelHits = 0;         // number of pixel hits
+    size_t numberOfTDC1s = 0;             // number of TDC1 triggers
+    size_t numberOfTDC2s = 0;             // number of TDC2 triggers
+    size_t numberOfGTS = 0;               // number of global time stamps.
+    size_t numberOfTXP3Controls = 0;      // number of TPX3 Control packets.
+
+    double totalHermesTime = 0;
+    double totalUnpackingTime = 0;
+    double totalSortingTime = 0;
+    double totalClusteringTime = 0;
+    double totalWritingTime = 0;
+};
+
+// Represents the data for a single raw signal.
+struct signalData {
+    uint32_t bufferNumber;  // Buffer number from where signal was recorded
+    uint8_t signalType;     // Type of the signal (TDC=1,Pixel=2,GTS=3)
+    uint8_t xPixel;         // X-coordinate of the pixel
+    uint8_t yPixel;         // Y-coordinate of the pixel
+    double ToaFinal;        // Time of Arrival in seconds (final value)
+    uint16_t TotFinal;      // Time over Threshold in nano seconds (final value)
+    uint32_t groupID;       // Group ID for clustering. 
+};
+
+// Represents the data for a single reconstructed photon.
+struct photonData{
+    float photonX = 0;
+    float photonY = 0;
+    double photonToa = 0;
+    uint16_t integratedTot = 0;
+    uint8_t multiplicity = 0;
+};
+
+
+// Represents the data for a single raw pixel signal. Currently not in use, planned for future.
+struct pixelData{
+    uint8_t xPixel;
+    uint8_t yPixel;
+    uint64_t ToaFinal;
+    uint16_t TotFinal;
+};
+
+
+#endif

--- a/backends/unpackers/tpx3-spidr/cpp/src/commandLineParser.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/commandLineParser.cpp
@@ -1,0 +1,374 @@
+/**
+ * @file commandLineParser.cpp
+ * @brief Implementation of command-line parsing utilities
+ */
+
+#include <fstream>
+#include <iostream>
+#include "commandLineParser.h"
+#include "configReader.h"
+#include "diagnostics.h"
+
+using namespace std;
+
+/**
+ * @brief Creates default configuration parameters
+ * @return configParameters struct with default values
+ */
+configParameters createDefaultConfig() {
+    configParameters params;
+    // Default values are already set in the struct definition
+    // Just ensure some sensible defaults for common use cases
+    params.writeRawSignals = true;
+    params.sortSignals = true;
+    params.outputFolder = ".";
+    params.verboseLevel = 1;
+    params.clusterPixels = false;
+    params.writeOutPhotons = false;
+    params.maxPacketsToRead = 0;
+    params.epsSpatial = 2;
+    params.epsTemporal = 500.0;
+    params.minPts = 3;
+    params.queryRegion = 0;
+    
+    return params;
+}
+
+/**
+ * @brief Check if a file exists
+ * @param filepath Path to the file
+ * @return true if file exists
+ */
+bool fileExists(const string& filepath) {
+    ifstream file(filepath);
+    return file.good();
+}
+
+/**
+ * @brief Check if a file has a specific extension
+ * @param filepath Path to the file
+ * @param extension Expected extension (e.g., ".tpx3", ".config")
+ * @return true if file has the expected extension
+ */
+bool hasExtension(const string& filepath, const string& extension) {
+    size_t pos = filepath.find_last_of('.');
+    if (pos == string::npos) return false;
+    
+    string fileExt = filepath.substr(pos);
+    return fileExt == extension;
+}
+
+/**
+ * @brief Check if a file exists and has a specific extension
+ * @param filepath Path to the file
+ * @param extension Expected extension (e.g., ".tpx3", ".config")
+ * @return true if file exists and has the expected extension
+ */
+bool isFileWithExtension(const string& filepath, const string& extension) {
+    return fileExists(filepath) && hasExtension(filepath, extension);
+}
+
+/**
+ * @brief Extract directory path from file path
+ * @param filepath Full path to file
+ * @return Directory path (empty string if no directory)
+ */
+string getDirectoryPath(const string& filepath) {
+    size_t pos = filepath.find_last_of("/\\");
+    if (pos == string::npos) return "";
+    return filepath.substr(0, pos);
+}
+
+/**
+ * @brief Extract filename from file path
+ * @param filepath Full path to file
+ * @return Filename only
+ */
+string getFilename(const string& filepath) {
+    size_t pos = filepath.find_last_of("/\\");
+    if (pos == string::npos) return filepath;
+    return filepath.substr(pos + 1);
+}
+
+/**
+ * @brief Safely parse integer from string
+ * @param str String to parse
+ * @param defaultValue Default value if parsing fails
+ * @return Parsed integer or default value
+ */
+int parseIntOrDefault(const string& str, int defaultValue) {
+    try {
+        return stoi(str);
+    } catch (const exception&) {
+        return defaultValue;
+    }
+}
+
+/**
+ * @brief Parse command-line flags and populate configuration
+ * @param argc Number of arguments
+ * @param argv Array of arguments
+ * @param configParams Configuration parameters to populate
+ * @param helpLevel Output parameter for help level (if help requested)
+ * @return true if parsing successful, false if help requested or error
+ */
+bool parseCommandLineFlags(int argc, char* argv[], configParameters& configParams, int& helpLevel) {
+    configParams = createDefaultConfig();
+    helpLevel = 0;  // 0 = no help, 1 = basic help, 2 = help with examples
+    
+    string inputFile, inputDir, outputDir, configFile;
+    bool sortSignals = false;
+    bool sortSpecified = false;
+    bool clusterPixels = false;
+    bool clusterPixelsSpecified = false;
+    bool writeOutPhotons = false;
+    bool writeOutPhotonsSpecified = false;
+    bool batchModeSpecified = false;
+    int verboseLevel = 1;
+    uint32_t maxPackets = 0;
+    uint8_t epsSpatial = 0;
+    double epsTemporal = 0.0;
+    uint8_t minPts = 0;
+    uint16_t queryRegion = 0;
+    
+    for (int i = 1; i < argc; i++) {
+        string arg = argv[i];
+        
+        if (arg == "-h" || arg == "--help") {
+            // Check if next argument is a number for help level
+            if (i + 1 < argc && argv[i + 1][0] != '-') {
+                helpLevel = parseIntOrDefault(argv[++i], 1);
+                if (helpLevel < 1 || helpLevel > 2) {
+                    helpLevel = 1;  // Default to level 1 if invalid
+                }
+            } else {
+                helpLevel = 1;  // Default help level
+            }
+            return false;  // Help requested
+        }
+        else if ((arg == "-i" || arg == "--inputFile") && i + 1 < argc) {
+            inputFile = argv[++i];
+        }
+        else if ((arg == "-I" || arg == "--inputDir") && i + 1 < argc) {
+            inputDir = argv[++i];
+        }
+        else if ((arg == "-o" || arg == "--outputDir") && i + 1 < argc) {
+            outputDir = argv[++i];
+        }
+        else if ((arg == "-c" || arg == "--configFile") && i + 1 < argc) {
+            configFile = argv[++i];
+        }
+        else if (arg == "-s" || arg == "--sort") {
+            sortSignals = true;
+            sortSpecified = true;
+        }
+        else if ((arg == "-v" || arg == "--verbose") && i + 1 < argc) {
+            verboseLevel = parseIntOrDefault(argv[++i], 1);
+        }
+        else if (arg == "-w" || arg == "--writeRawSignals") {
+            configParams.writeRawSignals = true;
+            cout << "Write raw signals: enabled" << endl;
+        }
+        else if (arg == "-C" || arg == "--clusterPixels") {
+            clusterPixels = true;
+            clusterPixelsSpecified = true;
+        }
+        else if (arg == "-p" || arg == "--writeOutPhotons") {
+            writeOutPhotons = true;
+            writeOutPhotonsSpecified = true;
+        }
+        else if ((arg == "-m" || arg == "--maxPackets") && i + 1 < argc) {
+            maxPackets = static_cast<uint32_t>(parseIntOrDefault(argv[++i], 0));
+        }
+        else if ((arg == "-S" || arg == "--epsSpatial") && i + 1 < argc) {
+            epsSpatial = static_cast<uint8_t>(parseIntOrDefault(argv[++i], 0));
+        }
+        else if ((arg == "-T" || arg == "--epsTemporal") && i + 1 < argc) {
+            try {
+                epsTemporal = stod(argv[++i]);
+            } catch (const exception&) {
+                epsTemporal = 0.0;
+            }
+        }
+        else if ((arg == "-P" || arg == "--minPts") && i + 1 < argc) {
+            minPts = static_cast<uint8_t>(parseIntOrDefault(argv[++i], 0));
+        }
+        else if ((arg == "-q" || arg == "--queryRegion") && i + 1 < argc) {
+            queryRegion = static_cast<uint16_t>(parseIntOrDefault(argv[++i], 0));
+        }
+        else {
+            cerr << "Error: Unknown option: " << arg << endl;
+            return false;
+        }
+    }
+    
+    // If config file is specified, read it first
+    if (!configFile.empty()) {
+        if (!readConfigFile(configFile, configParams)) {
+            cerr << "Error: Failed to read configuration file: " << configFile << endl;
+            return false;
+        }
+        cout << "Loaded configuration from: " << configFile << endl;
+    }
+    
+    // Validate required parameters
+    if (inputFile.empty() && inputDir.empty() && !batchModeSpecified && configFile.empty()) {
+        cerr << "Error: Must specify either -i <input_file>, -I <input_dir>, -b (batch mode), or -c <config_file>" << endl;
+        return false;
+    }
+    
+    // Handle conflicts between input options
+    if (!inputFile.empty() && !inputDir.empty()) {
+        cerr << "Error: Cannot specify both -i and -I options" << endl;
+        return false;
+    }
+    
+    if (!inputFile.empty() && batchModeSpecified) {
+        cout << "Warning: Both input file (-i) and batch mode (-b) specified. Processing single file only: " << inputFile << endl;
+        // Single file mode will be set in the configuration section below
+    }
+    
+    // Check if batch mode is specified without input directory
+    if (batchModeSpecified && inputDir.empty() && inputFile.empty()) {
+        cerr << "Error: Batch mode (-b) requires an input directory. Use -I <directory> to specify the directory." << endl;
+        return false;
+    }
+    
+    // Configure parameters (override config file if specified)
+    if (!inputFile.empty()) {
+        // Single file mode (takes priority over batch mode)
+        if (!fileExists(inputFile)) {
+            cerr << "Error: Input file does not exist: " << inputFile << endl;
+            return false;
+        }
+        if (!hasExtension(inputFile, ".tpx3")) {
+            cerr << "Error: Input file must have .tpx3 extension: " << inputFile << endl;
+            return false;
+        }
+        configParams.rawTPX3File = getFilename(inputFile);
+        configParams.rawTPX3Folder = getDirectoryPath(inputFile);
+        configParams.runHandle = grabRunHandle(configParams.rawTPX3File);
+        configParams.batchMode = false;
+    } else if (!inputDir.empty()) {
+        // Directory-based batch mode (works with or without -b flag)
+        configParams.rawTPX3Folder = inputDir;
+        configParams.rawTPX3File = "ALL";
+        configParams.batchMode = true;
+    }
+    
+    // Set output directory (override config if specified)
+    if (!outputDir.empty()) {
+        configParams.outputFolder = outputDir;
+    } else if (configFile.empty()) {
+        // Only set default if no config file was used
+        configParams.outputFolder = configParams.rawTPX3Folder.empty() ? "." : configParams.rawTPX3Folder;
+    }
+    
+    // Set verbose level (override config if specified)
+    if (verboseLevel >= 0 && verboseLevel <= 3) {
+        configParams.verboseLevel = verboseLevel;
+    } else {
+        cout << "Warning: Invalid verbose level " << verboseLevel 
+                 << ". Using default: " << configParams.verboseLevel << endl;
+    }
+    
+    // Set sorting option (override config if specified)
+    if (sortSpecified) {
+        configParams.sortSignals = sortSignals;
+        cout << "Signal sorting: " << (sortSignals ? "enabled" : "disabled") << endl;
+    }
+    
+    // Set other boolean options (override config if specified)
+    if (clusterPixelsSpecified) {
+        configParams.clusterPixels = clusterPixels;
+        cout << "Cluster pixels: " << (clusterPixels ? "enabled" : "disabled") << endl;
+    }
+    
+    if (writeOutPhotonsSpecified) {
+        configParams.writeOutPhotons = writeOutPhotons;
+        cout << "Write out photons: " << (writeOutPhotons ? "enabled" : "disabled") << endl;
+    }
+    
+    // Set numeric parameters (override config if specified)
+    if (maxPackets > 0) {
+        configParams.maxPacketsToRead = maxPackets;
+        cout << "Max packets to read: " << maxPackets << endl;
+    }
+    
+    if (epsSpatial > 0) {
+        configParams.epsSpatial = epsSpatial;
+        cout << "Epsilon spatial: " << static_cast<int>(epsSpatial) << endl;
+    }
+    
+    if (epsTemporal > 0.0) {
+        configParams.epsTemporal = epsTemporal;
+        cout << "Epsilon temporal: " << epsTemporal << endl;
+    }
+    
+    if (minPts > 0) {
+        configParams.minPts = minPts;
+        cout << "Minimum points: " << static_cast<int>(minPts) << endl;
+    }
+    
+    if (queryRegion > 0) {
+        configParams.queryRegion = queryRegion;
+        cout << "Query region: " << queryRegion << endl;
+    }
+    
+    return true;
+}
+
+/**
+ * @brief Print usage information with different detail levels
+ * @param programName Name of the program
+ * @param helpLevel Level of help detail (1=basic, 2=with examples)
+ */
+void printUsage(const char* programName, int helpLevel) {
+    cout << "Input/Output Options:" << endl;
+    cout << "  -i, --inputFile <file>     Input TPX3 file" << endl;
+    cout << "  -I, --inputDir <dir>       Input directory (for batch mode)" << endl;
+    cout << "  -b, --batch                Enable batch mode (requires -I <directory>)" << endl;
+    cout << "  -o, --outputDir <dir>      Output directory" << endl;
+    cout << "  -c, --configFile <file>    Configuration file" << endl;
+    cout << endl;
+    cout << "Processing Options:" << endl;
+    cout << "  -s, --sort                 Enable signal sorting" << endl;
+    cout << "  -w, --writeRawSignals      Enable writing raw signals" << endl;
+    cout << "  -C, --clusterPixels        Enable pixel clustering" << endl;
+    cout << "  -p, --writeOutPhotons      Enable writing photon data" << endl;
+    cout << endl;
+    cout << "Clustering Parameters:" << endl;
+    cout << "  -S, --epsSpatial <n>       Spatial epsilon for clustering (pixels)" << endl;
+    cout << "  -T, --epsTemporal <n>      Temporal epsilon for clustering (seconds)" << endl;
+    cout << "  -P, --minPts <n>           Minimum points for clustering" << endl;
+    cout << "  -q, --queryRegion <n>      Query region for clustering" << endl;
+    cout << endl;
+    cout << "Diagnostic Options:" << endl;
+    cout << "  -m, --maxPackets <n>       Maximum packets to read (0=all)" << endl;
+    cout << "  -v, --verbose <level>      Verbose level (0-3, default: 1)" << endl;
+    cout << "  -h, --help                 Show this help message" << endl;
+    
+    // Only show examples and additional info for helpLevel >= 2
+    if (helpLevel >= 2) {
+        cout << endl;
+        cout << "Examples:" << endl;
+        cout << "  # Use config file as-is:" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -c settings.config" << endl;
+        cout << endl;
+        cout << "  # Direct file processing:" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -i data.tpx3 -o /path/to/output -v 2" << endl;
+        cout << endl;
+        cout << "  # Config file with overrides:" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -c settings.config -o /different/output -v 3 -W" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -c settings.config --clusterPixels -S 5 -T 100.0" << endl;
+        cout << endl;
+        cout << "  # Compact clustering setup:" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -i data.tpx3 -o /tmp -C -S 2 -T 250.5 -p -v 2" << endl;
+        cout << endl;
+        cout << "  # Batch processing with limits:" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -I /path/to/tpx3/files -o /path/to/output -s -m 1000" << endl;
+        cout << endl;
+        cout << "  # Explicit batch mode with directory:" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -b -I /path/to/tpx3/files -o /path/to/output -v 2" << endl;
+    }
+}

--- a/backends/unpackers/tpx3-spidr/cpp/src/commandLineParser.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/commandLineParser.cpp
@@ -362,7 +362,7 @@ void printUsage(const char* programName, int helpLevel) {
         cout << "  ./bin/tpx3SpidrUnpacker -i data.tpx3 -o /path/to/output -v 2" << endl;
         cout << endl;
         cout << "  # Config file with overrides:" << endl;
-        cout << "  ./bin/tpx3SpidrUnpacker -c settings.config -o /different/output -v 3 -W" << endl;
+        cout << "  ./bin/tpx3SpidrUnpacker -c settings.config -o /different/output -v 3 -w" << endl;
         cout << "  ./bin/tpx3SpidrUnpacker -c settings.config --clusterPixels -S 5 -T 100.0" << endl;
         cout << endl;
         cout << "  # Compact clustering setup:" << endl;

--- a/backends/unpackers/tpx3-spidr/cpp/src/commandLineParser.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/commandLineParser.cpp
@@ -146,6 +146,9 @@ bool parseCommandLineFlags(int argc, char* argv[], configParameters& configParam
             }
             return false;  // Help requested
         }
+        else if (arg == "-b" || arg == "--batch") {
+            batchModeSpecified = true;
+        }
         else if ((arg == "-i" || arg == "--inputFile") && i + 1 < argc) {
             inputFile = argv[++i];
         }

--- a/backends/unpackers/tpx3-spidr/cpp/src/configReader.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/configReader.cpp
@@ -1,0 +1,152 @@
+#include "configReader.h"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+using namespace std;
+
+
+// Trim function to remove leading and trailing whitespace
+string trim(const string& str) {
+    size_t first = str.find_first_not_of(' ');
+    if (first == string::npos)
+        return ""; // Return an empty string if the string contains only spaces
+    size_t last = str.find_last_not_of(' ');
+    return str.substr(first, (last - first + 1));
+}
+
+string grabRunHandle(const string& str){
+    size_t lastDotIndex = str.find_last_of('.');
+        return (lastDotIndex != string::npos) ? str.substr(0, lastDotIndex) : str;
+}
+
+// Function to convert string to boolean
+bool stringToBool(const string& str) {
+    if (str == "true") return true;
+    if (str == "false") return false;
+    throw invalid_argument("Invalid boolean value: " + str);
+}
+
+// Template function to handle conversion from string to numeric types with error checking
+template<typename T> T stringToNumber(const string& str) {
+    T num;
+    istringstream iss(str);
+    iss >> num;
+    if (iss.fail() || !iss.eof()) {
+        throw invalid_argument("Invalid numeric value: " + str);
+    }
+    return num;
+}
+
+// Error handling
+void logConfigError(const string& key, const string& value, const string& error) {
+    cerr << "CONFIG ERROR for key '" << key << "' with value '" << value << "': " << error << endl;
+}
+
+
+/**
+ * @brief Reads configuration parameters from a given file and populates a struct with the configuration values.
+ * 
+ * This function opens a configuration file specified by the filename and reads it line by line. Each line
+ * is expected to contain a key-value pair separated by an '=' character. Lines starting with '#' or containing
+ * '#' are ignored as comments. The function supports setting various configuration parameters specified
+ * by the keys in the file. Invalid or unexpected key-value pairs will generate errors to stderr.
+ * 
+ * Supported configuration parameters include:
+ * - batchMode: Whether to run in batch mode (true/false).
+ * - rawTPX3Folder: Folder for raw TPX3 files.
+ * - rawTPX3File: Specific raw TPX3 file name.
+ * - writeRawSignals: Whether to write raw signals (true/false).
+ * - outputFolder: Folder for output files.
+ * - maxBuffersToRead: Maximum number of buffers to read.
+ * - sortSignals: Whether to sort signals (true/false).
+ * - verboseLevel: Level of verbosity in output.
+ * - clusterPixels: Whether to cluster pixels (true/false).
+ * - queryRegion: Region to query (as an integer within uint16_t range).
+ * - writeOutPhotons: Whether to write out photons (true/false).
+ * - epsSpatial: Epsilon spatial value (as an integer within uint8_t range).
+ * - epsTemporal: Epsilon temporal value (as a double).
+ * - minPts: Minimum points value (as an integer within uint8_t range).
+ * 
+ * TODO: refactor this!!!
+ * 
+ * @param filename The path to the configuration file to be read.
+ * @param params Reference to a struct where the configuration parameters will be stored.
+ * @return true if the file was successfully read and parsed; false otherwise.
+ * 
+ * @note The function will print error messages to stderr for any issues encountered while reading the file
+ * or parsing the configuration parameters.
+ */
+bool readConfigFile(const string &filename, configParameters &params) {
+    ifstream configFile(filename);
+    if (!configFile.is_open()) {
+        cerr << "Failed to open configuration file: " << filename << endl;
+        return false;
+    }
+    
+    string line;
+    while (getline(configFile, line)) {
+        if (line.empty() || line[0] == '#' || line.find('#') != string::npos) continue;
+
+        istringstream lineStream(line);
+        string key, value;
+        getline(lineStream, key, '=');
+        getline(lineStream, value);
+        key = trim(key);
+        value = trim(value);
+
+        try {
+            if (key == "rawTPX3Folder") params.rawTPX3Folder = value;
+            else if (key == "rawTPX3File") {
+
+                // If the value is empty, blank spaces, "ALL" then analyze all files in the folder in batch mode. 
+
+                if (value.empty() || value == "ALL" || value == "all") {
+                    params.batchMode = true;
+                    params.runHandle = "";
+                    params.rawTPX3File = "";
+                } else { // Otherwise, process the file in single mode.
+                    params.batchMode = false;
+                    params.rawTPX3File = value;
+                    params.runHandle = grabRunHandle(value);
+                }
+            }
+            else if (key == "writeRawSignals") params.writeRawSignals = stringToBool(value);
+            else if (key == "outputFolder") params.outputFolder = value;
+            else if (key == "sortSignals") params.sortSignals = stringToBool(value);
+            else if (key == "verboseLevel") params.verboseLevel = stringToNumber<int>(value);
+            else if (key == "clusterPixels") params.clusterPixels = stringToBool(value);
+            else if (key == "queryRegion") params.queryRegion = static_cast<uint16_t>(stringToNumber<int>(value));
+            else if (key == "writeOutPhotons") params.writeOutPhotons = stringToBool(value);
+            else if (key == "epsSpatial") params.epsSpatial = static_cast<uint8_t>(stringToNumber<int>(value));
+            else if (key == "epsTemporal") params.epsTemporal = stringToNumber<double>(value);
+            else if (key == "minPts") params.minPts = static_cast<uint8_t>(stringToNumber<int>(value));
+            else if (key == "maxPacketsToRead") params.maxPacketsToRead = stringToNumber<int>(value);
+            else cerr << "Unknown configuration key: " << key << endl;
+        } catch (const exception& e) {
+            logConfigError(key, value, e.what());
+        }
+    }
+
+    configFile.close();
+    return true;
+}
+
+void printParameters(const configParameters &params) {
+    // If the program reaches this point, the configuration file was successfully read
+    cout << "=================== Config parameters ====================" << endl;
+    cout << "batchMode: " << (params.batchMode ? "true" : "false") << endl;
+    cout << "inputTPX3Folder: " << params.rawTPX3Folder << endl;
+    cout << "inputTPX3File: " << params.rawTPX3File << endl;
+    cout << "writeRawSignals: " << (params.writeRawSignals ? "true" : "false") << endl;
+    cout << "outputFolder: " << params.outputFolder << endl;
+    cout << "maxPacketsToRead: " << params.maxPacketsToRead << endl;
+    cout << "sortSignals: " << (params.sortSignals ? "true" : "false") << endl;
+    cout << "verboseLevel: " << params.verboseLevel << endl;
+    cout << "clusterPixels: " << (params.clusterPixels ? "true" : "false") << endl;
+    cout << "writeOutPhotons: " << (params.writeOutPhotons ? "true" : "false") << endl;
+    cout << "epsSpatial: " << static_cast<int>(params.epsSpatial) << endl;
+    cout << "epsTemporal: " << params.epsTemporal << endl;
+    cout << "minPts: " << static_cast<int>(params.minPts) << endl;
+    cout << "=========================================================" << endl << endl;
+}

--- a/backends/unpackers/tpx3-spidr/cpp/src/dataPacketProcessor.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/dataPacketProcessor.cpp
@@ -1,0 +1,825 @@
+// dataPacketProcessor.cpp
+#include <filesystem>
+#include <algorithm>
+
+
+#include "dataPacketProcessor.h"
+#include "diagnostics.h"
+#include "structures.h"
+#include "configReader.h"
+
+using namespace std;
+
+const double nanoSecondsToSeconds = 1E-9;
+
+// Some global variables, constants, and containers
+unsigned long long fileLength;
+unsigned long long NumofPackets;
+
+// TODO: Fix this! Possibly make it into a structure that is inherited 
+double coarseTime;
+unsigned long tmpFine;
+unsigned long trigTimeFine;
+double timeUnit = 25. / 4096; 
+double global_timestamp;
+int trigger_counter;
+unsigned long long int timemaster;
+double TDC_timestamp;
+double spidrTimeInNs;
+int x, y;
+double timeOverThresholdNS;
+double timeOfArrivalNS;
+long dCol;
+long sPix;
+long pix;
+unsigned short timeOverThreshold, timeOfArrival;
+char fineTimeOfArrival;
+int frameNr;
+int coarseTimeOfArrival;
+int mode;
+
+// Needed for global time stamps
+uint32_t timeStampLow_25nsClock = 0;    
+uint16_t timeStampHigh_107sClock = 0;
+uint16_t spidrTime = 0;
+unsigned long Timer_LSB32 = 0;
+unsigned long Timer_MSB16 = 0;
+
+// Some buffer timing info for diagnostics
+chrono::duration<double> bufferUnpackTime;
+chrono::duration<double> bufferSortTime;
+chrono::duration<double> bufferWriteTime;
+chrono::duration<double> bufferClusterTime;
+
+
+/**
+ * @brief Resets global variables to clean state for processing new TPX3 files.
+ * 
+ * This function resets all global timing and processing variables to their default
+ * values. This is essential for batch mode processing to prevent contamination
+ * between files, which could lead to incorrect TDC counts and timing information.
+ */
+void resetGlobalVariables() {
+    // Reset basic file processing variables
+    fileLength = 0;
+    NumofPackets = 0;
+    
+    // Reset timing variables
+    coarseTime = 0.0;
+    tmpFine = 0;
+    trigTimeFine = 0;
+    global_timestamp = 0.0;
+    trigger_counter = 0;
+    timemaster = 0;
+    TDC_timestamp = 0.0;
+    spidrTimeInNs = 0.0;
+    
+    // Reset pixel processing variables  
+    x = 0;
+    y = 0;
+    timeOverThresholdNS = 0.0;
+    timeOfArrivalNS = 0.0;
+    dCol = 0;
+    sPix = 0;
+    pix = 0;
+    timeOverThreshold = 0;
+    timeOfArrival = 0;
+    fineTimeOfArrival = 0;
+    frameNr = 0;
+    coarseTimeOfArrival = 0;
+    mode = 0;
+    
+    // Reset global time stamp variables
+    timeStampLow_25nsClock = 0;
+    timeStampHigh_107sClock = 0;
+    spidrTime = 0;
+    Timer_LSB32 = 0;
+    Timer_MSB16 = 0;
+}
+
+
+/**
+ * @brief Get a list of all files in a directory of a specific type or extention.
+ *
+ * This function takes a configParameters structure as input and returns a vector of strings containing the full paths of all files in the directory specified by the rawTPX3Folder field of the configParameters structure. The function uses the filesystem library to iterate over the directory and obtain the full paths of all files within it. The function then returns a vector of strings containing the full paths of all files in the directory.
+ *
+ * @param configParams A const reference to the configParameters structure that includes control parameters for the operation, such as the directory containing the raw TPX3 files.
+ * @return vector<string> A vector of strings containing the full paths of all files in the directory specified by the rawTPX3Folder field of the configParameters structure.
+ * 
+ */
+vector<string> getFilesInDirectory(configParameters configParams){
+    vector<string> files;
+    // grab all files with a given extension of ".tpx3"
+    for (const auto & entry : filesystem::directory_iterator(configParams.rawTPX3Folder)){
+        if (entry.path().extension() == ".tpx3"){
+            // only grab the file name and not the full path
+            files.push_back(entry.path().filename().string());
+
+            //files.push_back(entry.path().string());
+        }
+    }
+    return files;
+}
+
+
+/**
+ * @brief Sorts an array of signalData structures by the ToaFinal field and updates sorting time diagnostics.
+ *
+ * This function sorts an array of signalData structures in ascending order based on the ToaFinal field, 
+ * The function also measures the duration of the sorting process using high-resolution clocks and updates
+ *  the totalSortingTime field in the tpx3FileDiagnostics structure to facilitate performance diagnostics.
+ * Additionally, it outputs a message indicating the start of the sorting operation if the verboseLevel in 
+ * configParameters is set to 3 or higher.
+ *
+ * @param configParams A const reference to the configParameters structure that includes control 
+ *                     parameters for the operation, such as the verbosity level for logging.
+ * @param signalDataArray A pointer to the first element of an array of signalData structures to be sorted. 
+ *                        The array is modified in place by the sorting operation. The length of this 
+ *                        array is determined by the numberOfDataPackets field in tpx3FileInfo.
+ * @param tpx3FileInfo A reference to a tpx3FileDiagnostics structure that is updated with the 
+ *                     sorting duration. This structure also provides the number of data packets 
+ *                     (elements) in signalDataArray that should be sorted.
+ */
+void sortSignals(const configParameters& configParams, signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo) {
+    auto startSortTime = chrono::high_resolution_clock::now(); // Grab a start time for sorting
+        
+    // Print info depending on verbosity level
+    if (configParams.verboseLevel>=2) {cout <<"Sorting " << tpx3FileInfo.numberOfDataPackets << " raw signal data. " << endl;}
+
+    // Sort the signalDataArray based on ToaFinal
+    sort(signalDataArray, signalDataArray + tpx3FileInfo.numberOfDataPackets,[](const signalData &a, const signalData &b) -> bool {return a.ToaFinal < b.ToaFinal;});
+    
+    // Grab stop time, calculate buffer sort duration, and append to total sorting time.
+    auto stopSortTime = chrono::high_resolution_clock::now();
+    bufferSortTime = stopSortTime - startSortTime;
+    tpx3FileInfo.totalSortingTime = bufferSortTime.count();
+    if (configParams.verboseLevel>=2) {cout <<"Finished sorting "<< tpx3FileInfo.numberOfDataPackets << " raw signals. " << endl;}
+}
+
+
+/**
+ * @brief Clusters signal data based on the a selected algorithm and updates clustering time.
+ *
+ * Invokes a clustering algorithm (e.g., DBSCAN) to group pixels in the signalDataArray into clusters based on their properties.
+ * The function measures the duration of the clustering process and updates the totalClusteringTime in the tpx3FileDiagnostics structure.
+ * A message indicating the start of the clustering operation is printed if the verboseLevel in configParams is 3 or higher.
+ * The actual clustering function (ST_DBSCAN or equivalent) should be defined elsewhere and is assumed to operate on the signalDataArray.
+ *
+ * @param configParams Configuration parameters, including the verbosity level for logging.
+ * @param signalDataArray Array of signalData structures to be clustered. The array size is determined by numberOfDataPackets.
+ * @param numberOfDataPackets The number of data packets (elements) in signalDataArray to be clustered.
+ * @param tpx3FileInfo Diagnostics structure that is updated with the duration of the clustering operation.
+ */
+
+void clusterSignals(const configParameters& configParams, signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo) {
+    if (configParams.verboseLevel >= 2) {cout << "Clustering pixels based on DBSCAN " << endl;}
+
+    auto startClusterTime = chrono::high_resolution_clock::now();
+    
+    // Invoke the clustering algorithm.
+    ST_DBSCAN(configParams, tpx3FileInfo, signalDataArray);
+
+    auto stopClusterTime = chrono::high_resolution_clock::now();
+    bufferClusterTime = stopClusterTime - startClusterTime;
+    tpx3FileInfo.totalClusteringTime = bufferClusterTime.count();
+    if (configParams.verboseLevel >= 2) {cout << "Finished clustering of " << tpx3FileInfo.numberOfDataPackets << " pixels based on DBSCAN " << endl;}
+}
+
+
+/**
+ * @brief Opens a TPX3 file, calculates file size and number of data packets, updates diagnostic information, and returns an ifstream object.
+ *
+ * This function constructs the full path to a TPX3 file using the `configParameters` structure provided in `config`. 
+ * It attempts to open the specified TPX3 file in binary mode. Upon successfully opening the file, it utilizes the filesystem 
+ * library to securely obtain the file's size. It then calculates the number of data packets in the TPX3 file based on 
+ * the file size and updates the `tpx3FileDiagnostics` structure `tpx3FileInfo` with this information. The function outputs 
+ * relevant information to the console, depending on the verbosity level specified in `config`. If the file cannot be opened 
+ * or if there is an error obtaining the file size, the function handles these errors appropriately by either throwing a runtime_error 
+ * exception or closing the file and rethrowing the exception to ensure clean error handling and resource management. 
+ * Finally, it returns the ifstream object associated with the opened file, allowing for further processing.
+ *
+ * @param config       The `configParameters` structure that holds control parameters for the operation, 
+ * including the directory and filename of the TPX3 file, and the verbosity level for logging.
+ * @param tpx3FileInfo A reference to a `tpx3FileDiagnostics` structure that will be updated with the file 
+ * size and number of data packets. This structure should be used later for diagnostics and processing information.
+ * @return ifstream An ifstream object associated with the opened TPX3 file. This object is used for subsequent file reading operations.
+ * @throws runtime_error if the TPX3 file cannot be opened or if there is an error obtaining the file size.
+ */
+ifstream openTPX3File(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo) {
+    // Construct the full path to the TPX3 file
+    string fullTpx3Path = configParams.rawTPX3Folder + "/" + configParams.rawTPX3File;
+    cout << "Opening TPX3 file at path: " << fullTpx3Path << endl;
+    
+    // Attempt to open the TPX3 file
+    ifstream tpx3File(fullTpx3Path, ios::binary);
+    
+    // Check if the file stream is in a good state (i.e., the file has been successfully opened)
+    if (!tpx3File) {
+        // If the file cannot be opened, throw an exception
+        throw runtime_error("Unable to open input TPX3 file at path: " + fullTpx3Path);
+    }
+
+    // Using filesystem to get file size securely and handling large files
+    try {
+        tpx3FileInfo.filesize = filesystem::file_size(fullTpx3Path);
+        tpx3FileInfo.numberOfDataPackets = tpx3FileInfo.filesize / 8;
+        if (configParams.verboseLevel >= 2) {
+            cout << "File size: " << tpx3FileInfo.filesize << " bytes" << endl;
+            cout << "Number of Data Packets: " << tpx3FileInfo.numberOfDataPackets << endl;
+        }
+    } catch (filesystem::filesystem_error& e) {
+        cerr << "Error getting file size: " << e.what() << '\n';
+        // Properly handle the error, such as by closing the file and rethrowing the exception
+        tpx3File.close();
+        throw;
+    }
+    
+    return tpx3File; // Return the ifstream object associated with the opened file
+}
+
+/**
+ * @brief Opens an output file for raw signals based on configuration parameters.
+ *
+ * If the writeRawSignals flag within the configParameters structure is set to true, this function constructs
+ * the full path to the output file using the outputFolder and runHandle specified in config. It then attempts
+ * to open this file for binary output. If the file is successfully opened, it returns an ofstream object
+ * associated with the file. If writeRawSignals is false or the file cannot be opened, it handles the
+ * situation appropriately, either by not attempting to open the file or by throwing an exception.
+ *
+ * @param config         The configParameters structure containing the output file configuration, including
+ *                       the output folder, run handle, and the flag indicating whether to write raw signals.
+ * @return ofstream An ofstream object for the output file. If writeRawSignals is false, this ofstream
+ *                       may not be opened (check with is_open() before using).
+ * @throws runtime_error If the file cannot be opened when writeRawSignals is true.
+ */
+ofstream openRawSignalsOutputFile(const configParameters& configParams) {
+    ofstream rawSignalsFile;
+
+    // Construct the full path to the output file
+    string fullOutputPath = configParams.outputFolder + "/" + configParams.runHandle + ".rawSignals";
+    cout << "Opening output file for raw signals at path: " << fullOutputPath << endl;
+
+    // Attempt to open the output file
+    rawSignalsFile.open(fullOutputPath, ios::out | ios::binary);
+
+    // Check if the file stream is in a good state (i.e., the file has been successfully opened)
+    if (!rawSignalsFile) {
+        // If the file cannot be opened, throw an exception
+        throw runtime_error("Unable to open output file for raw signals at path: " + fullOutputPath);
+    }
+    // Return the ofstream object associated with the opened file
+    // Note: If writing is disabled, this returns an unopened ofstream, which the caller needs to check
+    return rawSignalsFile;
+}
+
+
+/**
+ * @brief Writes raw signal data to a file and updates writing duration.
+ *
+ * Logs the operation if verboseLevel is 3 or higher, writes the raw signal data from signalDataArray to 
+ * the file associated with rawSignalsFile, and updates tpx3FileInfo's totalWritingTime with the duration 
+ * of the write operation. Assumes rawSignalsFile is open and ready for writing.
+ *
+ * @param configParams Configuration parameters, including verboseLevel for logging.
+ * @param rawSignalsFile Open ofstream for writing raw signal data.
+ * @param signalDataArray Array of signalData to be written.
+ * @param tpx3FileInfo Diagnostics structure to be updated with writing time.
+ */
+void writeRawSignals(const configParameters& configParams, ofstream& rawSignalsFile, const signalData* signalDataArray, tpx3FileDiagnostics& tpx3FileInfo) {
+
+    if (configParams.verboseLevel >= 3) {cout << "Writing out raw signal data." << endl;}
+
+    auto startWriteTime = chrono::high_resolution_clock::now(); // Grab a start time for writing
+
+    // Perform the writing operation
+    rawSignalsFile.write(reinterpret_cast<const char*>(signalDataArray), sizeof(signalData) * tpx3FileInfo.numberOfDataPackets);
+
+    // Calculate and update the total writing time
+    auto stopWriteTime = chrono::high_resolution_clock::now();
+    bufferWriteTime = stopWriteTime - startWriteTime;
+    tpx3FileInfo.totalWritingTime = bufferWriteTime.count();
+    if (configParams.verboseLevel >= 3) {cout << "Finished writing out raw signal data." << endl;}
+}
+
+
+/**
+ * @brief Takes a TDC data packet from a tpx3 file, processes it, and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing of 
+ * the TDC trigger. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */
+void processTDCPacket_old(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData) {
+    // Logic for TDC packet
+
+	// Unpack dataPacket
+	coarseTime = (dataPacket >> 12) & 0xFFFFFFFF;                        
+	tmpFine = (dataPacket >> 5) & 0xF; 
+	tmpFine = ((tmpFine - 1) << 9) / 12;
+	trigTimeFine = (dataPacket & 0x0000000000000E00) | (tmpFine & 0x00000000000001FF);
+
+	// Set info in signalData 
+    signalData.bufferNumber = bufferNumber;
+    signalData.signalType = 1;
+	signalData.xPixel = 0;
+	signalData.yPixel = 0;
+	signalData.ToaFinal = coarseTime*25*nanoSecondsToSeconds + trigTimeFine*timeUnit*nanoSecondsToSeconds;
+	signalData.TotFinal = 0;
+}
+
+
+/**
+ * @brief Takes a TDC data packet from a tpx3 file, processes it, and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing of 
+ * the TDC trigger. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */
+void processTDCPacket(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData) {
+    // Extract according to manual specification
+    uint64_t timestamp = (dataPacket >> 9) & 0x7FFFFFFFF;  // Bits 43-9 (35 bits)
+    uint8_t stamp = (dataPacket >> 5) & 0xF;               // Bits 8-5 (4 bits)
+    
+    // Calculate time according to manual
+    double timestampNs = timestamp * 3.125;  // 320MHz -> nanoseconds
+    double stampNs = (stamp != 0) ? stamp * 0.260 : 0.0;  // 260 ps -> nanoseconds
+    
+    double finalTimestampNs = timestampNs + stampNs;
+    
+    // Set info in signalData 
+    signalData.bufferNumber = bufferNumber;
+    signalData.signalType = 1;
+    signalData.xPixel = 0;
+    signalData.yPixel = 0;
+    signalData.ToaFinal = finalTimestampNs * nanoSecondsToSeconds;  // Convert to seconds
+    signalData.TotFinal = 0;
+}
+
+
+/**
+ * @brief Takes a Pixel data packet from a tpx3 file, processes it, and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing and position of 
+ * the Pixel hit. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * TODO: I need to rewrite this for clarity. 
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */ 
+void processPixelPacket(uint16_t bufferNumber, unsigned long long dataPacket, signalData &signalData) {
+    // Unpack dataPacket
+    spidrTime = (unsigned short)(dataPacket & 0xffff);
+    dCol = (dataPacket & 0x0FE0000000000000L) >> 52;                                                                  
+    sPix = (dataPacket & 0x001F800000000000L) >> 45;                                                                    
+    pix = (dataPacket & 0x0000700000000000L) >> 44;
+    x = (int)(dCol + pix / 4);
+    y = (int)(sPix + (pix & 0x3));
+    timeOfArrival = (unsigned short)((dataPacket >> (16 + 14)) & 0x3fff);   
+    timeOverThreshold = (unsigned short)((dataPacket >> (16 + 4)) & 0x3ff);	
+    fineTimeOfArrival = (unsigned char)((dataPacket >> 16) & 0xf);
+    coarseTimeOfArrival = (timeOfArrival << 4) | (~fineTimeOfArrival & 0xf);
+    spidrTimeInNs = spidrTime * 25.0 * 16384.0;
+    //timeOfArrivalNS = timeOfArrival * 25.0;
+    timeOverThresholdNS = timeOverThreshold * 25.0;	
+    global_timestamp = spidrTimeInNs + coarseTimeOfArrival * (25.0 / 16);
+    
+    // Set info in signalData 
+    signalData.bufferNumber = bufferNumber;
+    signalData.signalType = 2;
+	signalData.xPixel = x;
+	signalData.yPixel = y;
+	signalData.ToaFinal = global_timestamp / 1E9;
+	signalData.TotFinal = timeOverThresholdNS;
+}
+
+
+/**
+ * @brief Takes a Global Time Stamp data packet from a tpx3 file, processes it, 
+ * and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing of 
+ * the Global Time Stamp hit. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * TODO: I need to rewrite this for clarity. Also need to figure out logic for time stamps.  
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */ 
+void processGlobalTimePacket(uint16_t bufferNumber, uint64_t dataPacket, signalData &signalData) {
+    // Logic for Global time packet
+    uint8_t timeType = static_cast<uint8_t>((dataPacket >> 56) & 0xFF);                        
+
+    // Time Low packet
+    if (timeType == 0x44) {
+        timeStampLow_25nsClock = static_cast<uint32_t>((dataPacket >> 16) & 0xFFFFFFFF);    // Extract 32-bit timestamp
+        spidrTime = static_cast<uint16_t>(dataPacket & 0xFFFF);                             // Extract 16-bit SPIDR time
+        global_timestamp = timeStampLow_25nsClock*25E-9;
+
+    // Time High packet
+    } else if (timeType == 0x45) { 
+        timeStampHigh_107sClock = static_cast<uint16_t>((dataPacket >> 16) & 0xFFFF);       // Extract 16-bit timestamp
+        spidrTime = static_cast<uint16_t>(dataPacket & 0xFFFF);                             // Extract 16-bit SPIDR time
+        global_timestamp = timeStampHigh_107sClock*107.374182;
+    }
+
+    // Set info in signalData 
+    signalData.bufferNumber = bufferNumber;
+    signalData.signalType = 3;
+    signalData.xPixel = 0;
+    signalData.yPixel = 0;
+    signalData.ToaFinal = global_timestamp;
+    signalData.TotFinal = spidrTime;
+	
+}
+
+/**
+ * @brief Takes a SPIDR control packet from a tpx3 file, processes it, 
+ * and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing of 
+ * the SPIDR control flag. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * TODO: Need to get logic for unpacking from ASI.  
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */ 
+void processSPIDRControlPacket(uint16_t bufferNumber, uint64_t dataPacket, signalData &signalData) {
+
+    // Set info in signalData 
+    signalData.bufferNumber = bufferNumber;
+    signalData.signalType = 4;
+    signalData.xPixel = 0;
+    signalData.yPixel = 0;
+    signalData.ToaFinal = 0;
+    signalData.TotFinal = 0;
+	
+}
+
+/**
+ * @brief Takes a TPX3 control packet from a tpx3 file, processes it, 
+ * and updates the corresponding signal data structure. 
+ *
+ * This function takes the data packet pass through unsigned long long dataPacket and processes the timing of 
+ * the TPX3 control flag. It then update the corresponding signalData structure, which is passed by reference. 
+ * 
+ * TODO: Need to get logic for unpacking from ASI.  
+ * 
+ * @param dataPacket    64 byte data packet that contains raw timing info
+ * @param signalData    HERMES defined structure that contain raw data info from data packets.
+ * @return nothing
+ */ 
+void processTPX3ControlPacket(uint16_t bufferNumber, uint64_t dataPacket, signalData &signalData) {
+
+    // Set info in signalData 
+    signalData.bufferNumber = bufferNumber;
+    signalData.signalType = 5;
+    signalData.xPixel = 0;
+    signalData.yPixel = 0;
+    signalData.ToaFinal = 0;
+    signalData.TotFinal = 0;
+	
+}
+
+
+void processDataPackets(const configParameters& configParams, tpx3FileDiagnostics& tpx3FileInfo, const uint64_t* dataPackets, signalData* signalDataArray) {
+    
+    // Grab a START time for unpacking
+    auto startUnpackTime = chrono::high_resolution_clock::now(); 
+    if(configParams.verboseLevel >=2){cout << "Unpacking " << configParams.maxPacketsToRead << " raw signals from " << configParams.rawTPX3File << endl;}
+
+    // Convert "TPX3" string to uint32_t in little endian format
+    const char tpx3SignatureStr[] = "TPX3";
+    uint32_t tpx3Signature;
+    memcpy(&tpx3Signature, tpx3SignatureStr, sizeof(uint32_t));
+
+    size_t currentPacket = 0;       // Initialize the counter outside the while loop
+    tpx3FileInfo.numberOfBuffers = 1;
+    
+    // Continue to loop through dataPacket array until you hit the numberOfDataPackets 
+    while (currentPacket < configParams.maxPacketsToRead) {
+        
+        // Grab last 32 bits of current packet
+        uint32_t tpx3flag = static_cast<uint32_t>(dataPackets[currentPacket]);
+        
+        // If tpx3flag matches the "TPX3" then you found a chuck header
+        if (tpx3flag == tpx3Signature) {
+
+            // Start processing the chuck header to get size and number of data packets in chuck. 
+            uint16_t chunkSize = static_cast<uint16_t>((dataPackets[currentPacket] >> 48) & 0xFFFF);
+            uint16_t numPacketsInChunk = chunkSize / 8;
+            if(configParams.verboseLevel >= 3){cout << dec << currentPacket << ":-: Found TPX3 chunk header with " << numPacketsInChunk << " packets."<<endl;}
+
+            tpx3FileInfo.numberOfProcessedPackets++; // processed a chunk header packet so increment processed packets
+            currentPacket++;    // move onto the next packet
+
+            // Ensure we do not process more packets than the maxPacketsToRead limit
+            if (tpx3FileInfo.numberOfProcessedPackets + numPacketsInChunk > configParams.maxPacketsToRead) {
+                numPacketsInChunk = configParams.maxPacketsToRead - tpx3FileInfo.numberOfProcessedPackets;
+                if(configParams.verboseLevel >= 3){cout << "MESSAGE: Shortening numPacketsInChunk to " << numPacketsInChunk << endl;}
+            }
+
+            // Iterate through each data packet in the current chunk
+            for (uint16_t chunkPacketIndex = 0; chunkPacketIndex < numPacketsInChunk; ++chunkPacketIndex) {
+
+                // Checking to make sure we are not reading a TPX3 chunk header packet
+                // Grab last 32 bits of current packet
+                uint32_t tpx3flag = static_cast<uint32_t>(dataPackets[currentPacket]);
+                if (tpx3flag == tpx3Signature){ cout << "ERROR: FOUND a TPX3 chunk header before finishing with current buffer...";}
+
+                // Safeguard against going beyond the allocated memory
+                if (currentPacket >= tpx3FileInfo.numberOfDataPackets){ 
+                    if(configParams.verboseLevel >= 3){cout << "Current Packet beyond " <<  tpx3FileInfo.numberOfDataPackets << ". Breaking out of process loop." << endl;}
+                    break;
+                }
+
+                // Extract the packet type from the most significant nibble
+                uint8_t packetType = static_cast<uint8_t>((dataPackets[currentPacket] >> 60) & 0xF);
+
+                switch (packetType) {
+                    case 0xA: // Integrated ToT mode
+                        cout << "Integrated ToT mode packet detected." << endl;
+                        break;
+                    case 0xB: // Time of Arrival mode
+                        processPixelPacket(tpx3FileInfo.numberOfBuffers, dataPackets[currentPacket], signalDataArray[currentPacket]);
+
+                        if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" <<chunkPacketIndex << ": Pixel data packet" << endl;}
+                        
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
+                        tpx3FileInfo.numberOfPixelHits++;
+                        break;
+                    case 0x6: // TDC data packets
+                        processTDCPacket(tpx3FileInfo.numberOfBuffers, dataPackets[currentPacket], signalDataArray[currentPacket]);
+
+                        if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" << chunkPacketIndex << ": TDC data packet" << endl;}
+                        
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
+                        tpx3FileInfo.numberOfTDC1s++;
+                        break;
+                    case 0x4: // Global time data packets
+                        processGlobalTimePacket(tpx3FileInfo.numberOfBuffers, dataPackets[currentPacket], signalDataArray[currentPacket]);
+
+                        if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" << chunkPacketIndex << ": Global time stamp data packet" << endl;}
+                        
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
+                        tpx3FileInfo.numberOfGTS++;
+                        break;
+                        
+                    case 0x5: { // SPIDR control packets, note the added braces to introduce a new block scope
+                        uint8_t subType = static_cast<uint8_t>((dataPackets[currentPacket] >> 56) & 0xF);
+                        switch (subType) {
+                            case 0xF:
+                                if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" << chunkPacketIndex << ": Open shutter packet detected." << endl;}
+                                break;
+                            case 0xA:
+                                if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" << chunkPacketIndex << ": Close shutter packet detected." << endl;}
+                                break;
+                            case 0xC:
+                                if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" << chunkPacketIndex << ": Heartbeat packet detected." << endl;}
+                                break;
+                            default:
+                                if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" << chunkPacketIndex << ": Unknown SPIDR control packet subtype detected." << endl;}
+                                break;
+                        }
+
+                        processSPIDRControlPacket(tpx3FileInfo.numberOfBuffers, dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
+                        break;
+                    }
+                    case 0x7: { // TPX3 control packets, again note the added braces
+                        uint8_t controlType = static_cast<uint8_t>((dataPackets[currentPacket] >> 48) & 0xFF);
+                        if (controlType ==0xA0) {
+                            if(configParams.verboseLevel >= 4){
+                                cout << "End of sequential readout detected with "<< hex << "packetType: 0x" << +packetType << "\t"<< "controlType: 0x" << +controlType << endl;
+                            }
+
+                        } else if (controlType == 0xB0) {
+                            if(configParams.verboseLevel >= 4){
+                                cout << "End of data driven readout detected with "<< hex << "packetType: 0x" << +packetType << "\t"<< "controlType: 0x" << +controlType << endl;
+                            }
+                        } else {
+                            if(configParams.verboseLevel >= 4){
+                            // Print out the hex value of controlType
+                                cout << currentPacket << ":" << chunkPacketIndex << ": Unkown TPX3 control packets detected with "
+                                << "packetType: 0x"<< hex << +packetType << "\t"
+                                << "controlType: 0x" << controlType << endl;
+                            }
+                        }
+                        
+                        processTPX3ControlPacket(tpx3FileInfo.numberOfBuffers, dataPackets[currentPacket], signalDataArray[currentPacket]);
+                        tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
+                        tpx3FileInfo.numberOfTXP3Controls++;
+                        break;
+                    }
+                    default: // Handle unrecognized packet types
+                        if(configParams.verboseLevel >= 3){
+                            cout << dec << currentPacket << ":" << chunkPacketIndex 
+                                      << ": Unrecognized packet type 0x" << hex << +packetType 
+                                      << " (packet: 0x" << hex << dataPackets[currentPacket] << ")" << endl;
+                        }
+                        // Leave signalData uninitialized (defaults to signalType=0)
+                        tpx3FileInfo.numberOfProcessedPackets++; // Still count as processed
+                        break;
+                }
+
+                currentPacket++;
+
+                // Break out of the loop if processedPackets reaches maxPacketsToRead
+                if (tpx3FileInfo.numberOfProcessedPackets >= configParams.maxPacketsToRead) {break;}
+            }
+            
+            // Update number of buffers processed. instead
+            if (tpx3FileInfo.numberOfBuffers == 0){cout << "Buffer Number 0" << endl;}
+            tpx3FileInfo.numberOfBuffers++;
+            
+        } else {
+            cout << "ERROR: Could not find TPX3 Flag, instead found " << hex << +tpx3flag << endl;
+            currentPacket++;
+        }
+    }
+
+    // Grab stop time, calculate buffer unpacking duration, and append to total unpacking time.
+    auto stopUnpackTime = chrono::high_resolution_clock::now(); // Grab a STOP time for unpacking
+    bufferUnpackTime = stopUnpackTime - startUnpackTime;
+    tpx3FileInfo.totalUnpackingTime = tpx3FileInfo.totalUnpackingTime + bufferUnpackTime.count();
+    tpx3FileInfo.numberOfDataPackets = currentPacket;
+    if(configParams.verboseLevel >= 2){cout << "Unpacked "<< currentPacket << " data packets, processed "<< tpx3FileInfo.numberOfProcessedPackets << " data packets" << endl;}
+}
+
+
+/**
+ * @brief  Unpacks a TPX3 file, sorts the signals, clusters the pixels, and writes raw signals to a file.
+ * 
+ * @param configParams    64 byte data packet that contains raw timing info
+ * 
+ * @return tpx3FileDiagnostics  HERMES defined structure that contains various diagnostic info used during the unpacking processes
+ */ 
+tpx3FileDiagnostics unpackAndSortTPX3File(configParameters configParams){
+    
+    ifstream tpx3File;             // initiate a input file-stream for reading in TPX3file
+    ofstream rawSignalsFile;       // initiate a output file-stream for writing raw data
+    tpx3FileDiagnostics tpx3FileInfo;    // initiate container for diagnostics while unpacking.
+
+    // TODO: Combine these two once better error handling is implemented. 
+    // Open the TPX3File
+    try {tpx3File = openTPX3File(configParams,tpx3FileInfo);} 
+    catch (const runtime_error& e) {
+        cerr << "Error: " << e.what() << endl;
+        return {};  // Handle the error as needed, possibly returning an error code or an empty object
+    }  
+    // If writeRawSignals is ``true, attempt to open the output file for raw signals
+    if(configParams.writeRawSignals == true){
+    // If writeRawSignals is true, attempt to open the output file for raw signals
+        try {rawSignalsFile = openRawSignalsOutputFile(configParams);} 
+        catch (const runtime_error& e) {
+            cerr << "Error: " << e.what() << endl;
+            return {}; // Handle the errors needed, possibly returning an error code or an empty object
+        }
+    }
+
+    // Ensure maxPacketsToRead does not exceed the total number of available packets
+    size_t packetsToRead = min(static_cast<size_t>(configParams.maxPacketsToRead), static_cast<size_t>(tpx3FileInfo.numberOfDataPackets));
+    
+    // If maxPacketsToRead is set to zero then read entire tpx3File and set maxPacketsToRead to numberOfDataPackets
+    if(configParams.maxPacketsToRead == 0){
+        packetsToRead = tpx3FileInfo.numberOfDataPackets;
+        configParams.maxPacketsToRead = tpx3FileInfo.numberOfDataPackets;
+    } else {
+        // Update maxPacketsToRead to reflect the actual number of packets we'll process
+        // This ensures processDataPackets doesn't try to read beyond available data
+        configParams.maxPacketsToRead = packetsToRead;
+    }
+
+    // Allocate an array for tpx3DataPackets to store signals up to the maxPacketsToRead from the TPX3 file
+    uint64_t* tpx3DataPackets = new uint64_t[packetsToRead];
+    
+    // Calculate the number of bytes to read based on the number of packets
+    size_t bytesToRead = packetsToRead * sizeof(uint64_t);
+    
+    // Read the calculated number of bytes from the TPX3 file
+    if(configParams.verboseLevel>=2){cout << "Reading tpx file "<<  configParams.runHandle << " into memory" << endl;}
+    tpx3File.read((char*)tpx3DataPackets, bytesToRead);
+    if(configParams.verboseLevel>=2){cout << "Closing tpx3 file" << configParams.runHandle << endl;}
+    tpx3File.close();
+
+    // allocate an array of signalData called signalDataArray that is the same size as bufferSize//8
+    // Initialize to zero to prevent contamination between batch mode files
+    signalData* signalDataArray = new signalData[packetsToRead]();  // Note the () for zero-initialization
+    
+    // Process the data packets and fill the signalDataArray
+    processDataPackets(configParams, tpx3FileInfo,  tpx3DataPackets, signalDataArray);
+
+    // If sortSignals is true then sort!! 
+    if (configParams.sortSignals){sortSignals(configParams, signalDataArray, tpx3FileInfo);}        
+
+    // If writeRawSignals is true then write out binary
+    if (configParams.writeRawSignals){writeRawSignals(configParams, rawSignalsFile, signalDataArray, tpx3FileInfo);}   
+
+    // If clusterPixels is true, then cluster signals
+    if (configParams.clusterPixels){clusterSignals(configParams, signalDataArray, tpx3FileInfo);}
+    
+    delete[] tpx3DataPackets;   // Don't forget to free the allocated memory
+    delete[] signalDataArray;   // Assuming you're done with signalDataArray
+    return tpx3FileInfo;        // Return the tpx3file info. 
+}
+
+/**
+ * @brief Processes TPX3 files based on the configuration parameters.
+ * 
+ * This function processes TPX3 files based on the configuration parameters provided. It can process a single file or all files in a directory,
+ * depending on the batchMode flag in the configParameters structure. The function prints out information based on the verbosity level specified in the configParameters.
+ * 
+ * 
+ * @param  configParams    Configuration parameters for the operation, including the verbosity level for logging.
+ * @param  verboseLevel    Verbosity level for logging (default is 0).
+ * 
+ * @return nothing
+ */
+void processTPX3Files(configParameters configParams){
+
+    tpx3FileDiagnostics tpxFileInfo;
+
+    // Print out config parameters based on verbosity level
+    if(configParams.verboseLevel>=2){printParameters(configParams);}
+
+    // Check for bacthMode
+    if (configParams.batchMode){
+        if (configParams.verboseLevel >= 1){
+            cout << "Batch mode is enabled. Processing all files in the directory." << endl;
+        }
+        // Get a list of all the files in the directory
+        vector<string> tpx3Files = getFilesInDirectory(configParams);
+        // Loop through all the files in the directory
+        for (const auto& tpx3File : tpx3Files){
+
+            // Reset global variables to prevent contamination between files
+            resetGlobalVariables();
+            if (configParams.verboseLevel >= 2) {
+                cout << "Global variables reset for file: " << tpx3File << endl;
+            }
+
+            // Grab start time for unpacking
+            chrono::duration<double> hermesTime;
+            auto hermesStartTime = chrono::high_resolution_clock::now();
+
+            // Set the rawTPX3File to the current file
+            configParams.rawTPX3File = tpx3File;
+
+            // Set the handle to the current file
+            configParams.runHandle = grabRunHandle(tpx3File);
+
+            // Process the single file
+            cout << "Processing file: " << tpx3File << endl;  
+            tpxFileInfo = unpackAndSortTPX3File(configParams);
+
+            // Grab stop time for unpacking and calculate total times
+            auto hermesStopTime = chrono::high_resolution_clock::now();
+            hermesTime = hermesStopTime - hermesStartTime;
+            tpxFileInfo.totalHermesTime = hermesTime.count();
+
+            // Print out diagnostics based on verbosity level
+            if(configParams.verboseLevel>=2){printOutUnpackingDiagnostics(tpxFileInfo);}
+            
+        }
+
+    } else {
+        // Process a single file
+
+        // Grab start time for unpacking
+        chrono::duration<double> hermesTime;
+        auto hermesStartTime = chrono::high_resolution_clock::now();
+
+        // Process the single file
+        tpxFileInfo = unpackAndSortTPX3File(configParams);
+        
+        // Grab stop time for unpacking and calculate total times
+        auto hermesStopTime = chrono::high_resolution_clock::now();
+        hermesTime = hermesStopTime - hermesStartTime;
+        tpxFileInfo.totalHermesTime = hermesTime.count();
+
+        // Print out diagnostics based on verbosity level
+        if(configParams.verboseLevel>=2){printOutUnpackingDiagnostics(tpxFileInfo);}
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+

--- a/backends/unpackers/tpx3-spidr/cpp/src/dataPacketProcessor.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/dataPacketProcessor.cpp
@@ -558,14 +558,20 @@ void processDataPackets(const configParameters& configParams, tpx3FileDiagnostic
                         tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
                         tpx3FileInfo.numberOfPixelHits++;
                         break;
-                    case 0x6: // TDC data packets
+                    case 0x6: { // TDC data packets
                         processTDCPacket(tpx3FileInfo.numberOfBuffers, dataPackets[currentPacket], signalDataArray[currentPacket]);
 
                         if(configParams.verboseLevel >= 4){cout << dec << currentPacket << ":" << chunkPacketIndex << ": TDC data packet" << endl;}
-                        
+
                         tpx3FileInfo.numberOfProcessedPackets++; // Update number of packets processed
-                        tpx3FileInfo.numberOfTDC1s++;
+                        uint8_t edgeCode = static_cast<uint8_t>((dataPackets[currentPacket] >> 56) & 0xF);
+                        if (edgeCode == 0xF || edgeCode == 0xA) {
+                            tpx3FileInfo.numberOfTDC1s++;
+                        } else if (edgeCode == 0xE || edgeCode == 0xB) {
+                            tpx3FileInfo.numberOfTDC2s++;
+                        }
                         break;
+                    }
                     case 0x4: // Global time data packets
                         processGlobalTimePacket(tpx3FileInfo.numberOfBuffers, dataPackets[currentPacket], signalDataArray[currentPacket]);
 

--- a/backends/unpackers/tpx3-spidr/cpp/src/dataPacketProcessor.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/dataPacketProcessor.cpp
@@ -348,8 +348,8 @@ void processTDCPacket(uint16_t bufferNumber, unsigned long long dataPacket, sign
     
     // Calculate time according to manual
     double timestampNs = timestamp * 3.125;  // 320MHz -> nanoseconds
-    double stampNs = (stamp != 0) ? stamp * 0.260 : 0.0;  // 260 ps -> nanoseconds
-    
+    double stampNs = (stamp >= 1 && stamp <= 12) ? (static_cast<double>(stamp) - 1.0) * (25.0 / 96.0) : 0.0;  // 25 ns / 96 -> nanoseconds
+
     double finalTimestampNs = timestampNs + stampNs;
     
     // Set info in signalData 

--- a/backends/unpackers/tpx3-spidr/cpp/src/diagnostics.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/diagnostics.cpp
@@ -1,0 +1,91 @@
+#include <iomanip> // Include for setw and setprecision
+
+// HERMES defined libraries
+#include "diagnostics.h"
+
+using namespace std;
+
+// TODO: Figure out if you still need these otherwise delete them.
+int numberOfHeaders = 0;
+int numberOfBuffers = 0;
+int numberOfTDCPackets = 0;
+int numberOfPixelPackets = 0;
+int numberOfGlobalTSPackets = 0;
+int numberOfPhotons = 0;
+
+/**
+ * @brief converts signal type numbers to more descriptive strings
+ *
+ * This function function takes a HERMES defined structure tpx3FileDianostics
+ * and prints out most of the diagnostic info that might be desired in 
+ *
+ * @param signalType int of signal types (e.g. 1,2,3,..)
+ * @return string description of signal type
+ */
+string signalTypeToString(int signalType) {
+    switch (signalType) {
+        case 1: return "TDC";
+        case 2: return "Pixel";
+        case 3: return "GTS";
+        default: return "Unknown";
+    }
+}
+
+/**
+ * @brief Prints out group ID info for all data in a single TPX3 data buffer.
+ *
+ * This function function loops through the singalData and the corresponding signalGroupID arrays
+ * and prints out a table of signalType, xPixel, yPixel, ToaFinal, TotFinal, and groupID. 
+ * Here groupID is assigned from some sorting algorithm, such as DBSCAN. 
+ *
+ * TODO: Add a output file instead of printing to terminal. 
+ * 
+ * @param buffernNumber         the buffer number from which the singalData was taking from.
+ * @param signalDataArray       the array of raw signal data from a TPX3 file, such as pixelHit, TDCs, or global time stamps.
+ * @param signalGroupID         the corresponding sorted IDs for all the raw signal data.
+ * @param dataPacketsInBuffer   Number of data packets in buffer. 
+ * @return nothing
+ */
+void printGroupIDs(int buffernNumber, signalData* signalDataArray, int16_t* signalGroupID, size_t dataPacketsInBuffer) {
+    // Loop through dataPacketsInBuffer and print out each field. 
+    for (size_t i = 0; i < dataPacketsInBuffer; i++) {
+        cout << left 
+                  << setw(6) << buffernNumber
+                  << setw(10) << signalTypeToString(static_cast<int>(signalDataArray[i].signalType))
+                  << setw(8) << static_cast<int>(signalDataArray[i].xPixel)
+                  << setw(8) << static_cast<int>(signalDataArray[i].yPixel)
+                  << setw(16) << fixed << setprecision(10) << signalDataArray[i].ToaFinal
+                  << setw(10) << fixed << setprecision(3) << signalDataArray[i].TotFinal
+                  << setw(10) << static_cast<int>(signalGroupID[i])
+                  << endl;
+    }
+}
+
+/**
+ * @brief Prints out all diagnostics for unpacking, sorting, and writingout data from a TPX3 file.
+ *
+ * This function function takes a HERMES defined structure tpx3FileDianostics
+ * and prints out most of the diagnostic info that might be desired in 
+ *
+ * @param tpxFileInfo a tpx3FileDianostics structure that contains all the diagnostic containers for
+ * unpacking and processing tpx3Files.
+ * @return nothing
+ */
+void printOutUnpackingDiagnostics(tpx3FileDiagnostics tpxFileInfo){
+    int numberOfUnprocessedPackets = tpxFileInfo.numberOfDataPackets - tpxFileInfo.numberOfBuffers - tpxFileInfo.numberOfTDC1s - tpxFileInfo.numberOfPixelHits - tpxFileInfo.numberOfGTS - tpxFileInfo.numberOfTXP3Controls;
+    cout << endl << "=============== Diagnostics ==============" << endl;
+    cout << "Total HERMES Time: " << tpxFileInfo.totalHermesTime << " seconds" << endl;
+    cout << "Total Unpacking Time: " << tpxFileInfo.totalUnpackingTime << " seconds" << endl;
+    cout << "Total Sorting Time: " << tpxFileInfo.totalSortingTime << " seconds" << endl;
+    cout << "Total Clustering Time: " << tpxFileInfo.totalClusteringTime << " seconds" << endl;
+    cout << "Total Writing Time: " << tpxFileInfo.totalWritingTime << " seconds" << endl;
+    cout << "------------------------------------------" << endl;
+    cout << "Number of data packets: " << tpxFileInfo.numberOfDataPackets << endl;
+    cout << "Number of headers packets: " << tpxFileInfo.numberOfBuffers << endl;
+    cout << "Number of TDC packets: " << tpxFileInfo.numberOfTDC1s << endl;
+    cout << "Number of Pixels packets: " << tpxFileInfo.numberOfPixelHits << endl;
+    cout << "Number of Global Time stamp packets: " << tpxFileInfo.numberOfGTS << endl;
+    cout << "Number of TPX3 control packets: " << tpxFileInfo.numberOfTXP3Controls << endl;
+    cout << "Number of Unknown processed packets: " << numberOfUnprocessedPackets << endl;
+    cout << "==========================================" << endl;
+}

--- a/backends/unpackers/tpx3-spidr/cpp/src/photonRecon.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/photonRecon.cpp
@@ -97,7 +97,7 @@ photonData expandCluster(configParameters configParams, tpx3FileDiagnostics& tpx
     float weightedSumX = signalDataArray[homeIndex].xPixel * signalDataArray[homeIndex].TotFinal;
     float weightedSumY = signalDataArray[homeIndex].yPixel * signalDataArray[homeIndex].TotFinal;
     double weightedSumToA = signalDataArray[homeIndex].ToaFinal * signalDataArray[homeIndex].TotFinal;
-    uint16_t totalToT = signalDataArray[homeIndex].TotFinal;
+    uint32_t totalToT = signalDataArray[homeIndex].TotFinal;
     size_t pixelCount = 1; // Initialize pixel count, starting with the seed point itself
 
 

--- a/backends/unpackers/tpx3-spidr/cpp/src/photonRecon.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/photonRecon.cpp
@@ -1,0 +1,196 @@
+#include "structures.h"
+#include "photonRecon.h"
+
+#include <iostream>
+#include <fstream> 
+
+using namespace std;
+
+// Computes the spatial distance between two signal data points using Euclidean distance formula.
+double spatialDistance(const signalData& p1, const signalData& p2) {
+    return sqrt((p1.xPixel - p2.xPixel) * (p1.xPixel - p2.xPixel) +
+                     (p1.yPixel - p2.yPixel) * (p1.yPixel - p2.yPixel));
+}
+
+// Computes the temporal distance between two signal data points.
+double temporalDistance(const signalData& p1, const signalData& p2) {
+    return abs(p1.ToaFinal - p2.ToaFinal);
+}
+
+// Checks if two signal data points are neighbors based on given spatial and temporal thresholds.
+bool isNeighbor(const signalData& p1, const signalData& p2, double epsSpatial, double epsTemporal) {
+    return spatialDistance(p1, p2) <= epsSpatial && temporalDistance(p1, p2) <= epsTemporal;
+}
+
+/**
+ * @brief Searches for neighboring signal data points within defined spatial
+ * and temporal thresholds.
+ *
+ * This function identifies neighbors of a specified 'homeIndex' in
+ * 'signalDataArray', within a [-queryRegion, +queryRegion] range. It adjusts
+ * the search to stay within array bounds, using 'configParams' for spatial
+ * (epsSpatial) and temporal (epsTemporal) distance thresholds.
+ *
+ * @param configParams Configuration parameters including spatial (epsSpatial)
+ * and temporal (epsTemporal) thresholds.
+ * @param tpx3FileInfo Contains file diagnostics, like total number of data
+ * packets (numberOfDataPackets), to keep search indices valid.
+ * @param signalDataArray Pointer to the array of signal data points, each
+ * includes spatial coordinates, time of arrival, etc.
+ * @param homeIndex Index in 'signalDataArray' for which neighbors are searched.
+ *
+ * @return vector<size_t> Indices of neighboring data points within
+ * specified thresholds.
+ *
+ * Example usage:
+ * auto neighbors = regionQuery(config, fileInfo, signalData, 1000);
+ * Searches for neighbors of data point at index 1000 in 'signalDataArray',
+ * using 'config' defined thresholds.
+ */
+vector<size_t> regionQuery(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray, const size_t homeIndex) {
+    
+    // Calculate start and end indices to search within, ensuring they stay within bounds of the array
+    size_t startIndex = homeIndex > configParams.queryRegion ? homeIndex - configParams.queryRegion : 0;
+    size_t endIndex = homeIndex + configParams.queryRegion < tpx3FileInfo.numberOfDataPackets ? homeIndex + configParams.queryRegion : tpx3FileInfo.numberOfDataPackets - 1;
+    
+    vector<size_t> neighbors;
+    for (size_t i = startIndex; i <= endIndex; i++) {
+        if (isNeighbor(signalDataArray[homeIndex], signalDataArray[i], configParams.epsSpatial, configParams.epsTemporal)) {
+            neighbors.push_back(i);
+        }
+    }
+    return neighbors;
+}
+
+
+/**
+ * @brief Expands a cluster from a seed point by including all density-reachable
+ * points within spatial and temporal thresholds.
+ *
+ * This function evaluates each new point found within the specified spatial and
+ * temporal thresholds not already assigned to a cluster or marked as noise. If
+ * a point has enough neighbors, it is added to the cluster, and its neighbors
+ * are also evaluated, recursively expanding the cluster. The function accumulates
+ * photon data statistics for the cluster and returns a photonData structure
+ * containing the calculated center of mass and total Time over Threshold (ToT)
+ * for the cluster.
+ *
+ * @param configParams Configuration parameters including the spatial
+ * (epsSpatial) and temporal (epsTemporal) thresholds.
+ * @param tpx3FileInfo Contains information about the dataset, such as the
+ * number of data packets.
+ * @param signalDataArray Array of signal data points to be clustered.
+ * @param homeIndex Index of the seed point from which to start expanding the
+ * cluster.
+ * @param neighbors Initial list of neighbors of the seed point that meet the
+ * density criteria.
+ * @param clusterId The identifier for the current cluster being expanded.
+ * @return photonData Structure containing the photon data statistics for the
+ * expanded cluster.
+ */
+photonData expandCluster(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray, size_t homeIndex, vector<size_t>& neighbors, size_t clusterId) {
+   
+    photonData pd;                                      // Create a photonData instance to be filled and returned
+    signalDataArray[homeIndex].groupID = clusterId;     // Mark the seed point as part of the cluster
+
+    // Initialize weighted sums for calculating the center of mass (CoM) of the cluster
+    float weightedSumX = signalDataArray[homeIndex].xPixel * signalDataArray[homeIndex].TotFinal;
+    float weightedSumY = signalDataArray[homeIndex].yPixel * signalDataArray[homeIndex].TotFinal;
+    double weightedSumToA = signalDataArray[homeIndex].ToaFinal * signalDataArray[homeIndex].TotFinal;
+    uint16_t totalToT = signalDataArray[homeIndex].TotFinal;
+    size_t pixelCount = 1; // Initialize pixel count, starting with the seed point itself
+
+
+    // Use a queue to iteratively process each neighbor and its neighbors
+    size_t index = 0;
+    while (index < neighbors.size()) {
+        size_t qIndex = neighbors[index];
+
+        // Skip non-Pixel signals
+        if (signalDataArray[qIndex].signalType != 2) {
+            //TODO Figure out if I need to ++index
+            ++index;    // Move to the next neighbor, even if the current one is skipped   
+            continue;   // Skip the rest of the iteration in this loop
+        }
+
+        // Only process points that haven't been assigned to a cluster or marked as noise
+        if (signalDataArray[qIndex].groupID == 0) { 
+            signalDataArray[qIndex].groupID = clusterId; // Mark as part of the current cluster
+            pixelCount++; // Increment the count of pixels contributing to the photon
+
+            // Find neighbors of this point
+            vector<size_t> qNeighbors = regionQuery(configParams, tpx3FileInfo, signalDataArray, qIndex);
+
+            // If this point has enough neighbors, add them to the list for processing
+            if (qNeighbors.size() >= configParams.minPts) {
+                neighbors.insert(neighbors.end(), qNeighbors.begin(), qNeighbors.end());
+            }
+        }
+
+        // Update weighted sums for CoM calculations
+        weightedSumX += signalDataArray[qIndex].xPixel * signalDataArray[qIndex].TotFinal;
+        weightedSumY += signalDataArray[qIndex].yPixel * signalDataArray[qIndex].TotFinal;
+        weightedSumToA += signalDataArray[qIndex].ToaFinal * signalDataArray[qIndex].TotFinal;
+        totalToT += signalDataArray[qIndex].TotFinal;
+
+        ++index; // Move to the next neighbor
+    }
+
+    // Calculate and store the cluster's center of mass and total ToT
+    pd.photonX = weightedSumX / totalToT;
+    pd.photonY = weightedSumY / totalToT;
+    pd.photonToa = weightedSumToA / totalToT;
+    pd.integratedTot = totalToT;
+    pd.multiplicity = pixelCount;
+
+    return pd;
+}
+
+
+
+/**
+ * @brief Performs the ST_DBSCAN clustering algorithm on a dataset of signal
+ * data points.
+ *
+ * This function segregates Pixel signals (signalType == 2) into clusters based
+ * on spatial and temporal closeness according to configuration parameters,
+ * marks non-Pixel signals as unprocessed, and identifies noise. Clusters are
+ * assigned unique IDs starting from 2, with noise marked as 1, and
+ * unprocessed/non-Pixel signals left as 0.
+ *
+ * @param configParams Configuration parameters for the DBSCAN algorithm,
+ * including spatial and temporal thresholds (epsSpatial, epsTemporal) and the
+ * minimum number of points (minPts) required to form a cluster.
+ * @param tpx3FileInfo File diagnostics information including the total number
+ * of data packets (numberOfDataPackets) to be processed.
+ * @param signalDataArray Array of signalData structs representing the dataset
+ * for clustering.
+ *
+ * @note The function modifies the `groupID` field of each `signalData` struct
+ * in `signalDataArray` to indicate cluster membership, mark as noise, or leave
+ * as unprocessed for non-Pixel signals.
+ */
+void ST_DBSCAN(configParameters configParams, tpx3FileDiagnostics& tpx3FileInfo, signalData* signalDataArray) {
+    uint32_t clusterId = 2; // Start cluster IDs from 2, reserving 1 for noise
+    vector<photonData> photons; // Vector to store photon data for each cluster.
+
+    // Loop through signalDataArray and begin clustering. 
+    for (size_t currentPacketIndex = 0; currentPacketIndex < tpx3FileInfo.numberOfDataPackets; currentPacketIndex++) {
+        
+        // Skip processing for non-Pixel signals or already processed signals
+        // TODO: Figure out if I should be skipping already processed signals. 
+        if (signalDataArray[currentPacketIndex].signalType != 2 || signalDataArray[currentPacketIndex].groupID != 0) {
+            continue;
+        }
+
+        vector<size_t> neighbors = regionQuery(configParams, tpx3FileInfo, signalDataArray, currentPacketIndex);
+
+        if (neighbors.size() < static_cast<size_t>(configParams.minPts)) {
+            signalDataArray[currentPacketIndex].groupID = 1; // Mark as noise
+        } else {
+            clusterId++;
+            photonData clusterPhotonData = expandCluster(configParams, tpx3FileInfo, signalDataArray, currentPacketIndex, neighbors, clusterId);
+            photons.push_back(clusterPhotonData); // Store the photon data for the cluster
+        }
+    }
+}

--- a/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file tpx3SpidrUnpacker.cpp
+ * @brief Main entry point for the TPX3 SPIDR data unpacking application.
+ *
+ * This program can be used in multiple ways:
+ * 1. ./tpx3SpidrUnpacker -i <input_file> [options...]
+ * 2. ./tpx3SpidrUnpacker -c <config_file> [options...]
+ * 3. ./tpx3SpidrUnpacker -I <input_dir> [options...]
+ *
+ * The flag-based interface allows for flexible configuration with the ability
+ * to override config file settings via command-line flags.
+ */
+
+#include <chrono>
+#include <iostream>
+
+// HERMES defined functions 
+#include "dataPacketProcessor.h"
+#include "structures.h"
+#include "diagnostics.h"
+#include "photonRecon.h"
+#include "configReader.h"
+#include "commandLineParser.h"
+
+using namespace std;
+
+int main(int argc, char *argv[]){  
+
+    configParameters configParams;
+    int helpLevel = 0;
+
+    // Check for the number of command-line arguments
+    if (argc < 2) {
+        cerr << "Error: Please provide command-line arguments." << endl;
+        printUsage(argv[0]);
+        return 1;
+    }
+
+    string firstArg = argv[1];
+    
+    // Case 1: Help requested
+    if (firstArg == "-h" || firstArg == "--help") {
+        // Check if next argument is a number for help level
+        if (argc > 2 && argv[2][0] != '-') {
+            helpLevel = parseIntOrDefault(argv[2], 1);
+            if (helpLevel < 1 || helpLevel > 2) {
+                helpLevel = 1;  // Default to level 1 if invalid
+            }
+        } else {
+            helpLevel = 1;  // Default help level
+        }
+        printUsage(argv[0], helpLevel);
+        return 0;
+    }
+    
+    // Case 2: Flag-based parsing (starts with -)
+    else if (firstArg[0] == '-') {
+        if (!parseCommandLineFlags(argc, argv, configParams, helpLevel)) {
+            if (helpLevel > 0) {
+                // Help was requested during parsing
+                printUsage(argv[0], helpLevel);
+            } else {
+                // Error occurred
+                printUsage(argv[0]);
+            }
+            return (helpLevel > 0) ? 0 : 1;
+        }
+        
+        cout << "Using flag-based configuration:" << endl;
+        if (configParams.batchMode) {
+            cout << "Input directory: " << configParams.rawTPX3Folder << endl;
+            cout << "Batch mode: ALL files" << endl;
+        } else {
+            cout << "Input file: " << configParams.rawTPX3Folder << "/" << configParams.rawTPX3File << endl;
+        }
+        cout << "Output folder: " << configParams.outputFolder << endl;
+        cout << "Verbose level: " << configParams.verboseLevel << endl;
+    }
+    else {
+        cerr << "Error: Unrecognized option. Please use flags starting with '-' or '--'." << endl;
+        cerr << "Provided: " << firstArg << endl;
+        cout << "Note: To use a config file, use: -c <config_file>" << endl;
+        printUsage(argv[0]);
+        return 1;
+    }
+
+    processTPX3Files(configParams);
+
+	return 0;
+}

--- a/docs/architecture/analysis.md
+++ b/docs/architecture/analysis.md
@@ -1,25 +1,116 @@
 # Analysis
 
-`src/hermes/analysis/` owns the Python code that runs analysis steps. The Rust
-unpacker, not Python, reads the binary packets in raw TPX3 files.
+`src/hermes/analysis/` contains the Python code that runs analysis steps. The
+unpacker selected by the user, not Python, reads the binary packets in raw TPX3
+files.
 
 Expected responsibilities:
 
-- call the Rust unpacker for raw `.tpx3` files
+- run the selected unpacker for raw `.tpx3` files
 - load pixel-hit, TDC-hit, timestamp, or control-packet Parquet files
 - group pixel hits into photons when photon clustering is requested
 - group photons into events when event clustering is requested  
 - write specific output files, such as photon and event Parquet files, images, or plots
-- update the analysis section of the central record through `hermes.state_service`
+- save analysis settings and results through `hermes.state_service`
 
 Analysis workflows should accept explicitly named inputs, such as raw TPX3 files
-or directories containing TPX3 Parquet files, together with Pydantic
-configuration models. They should return explicitly named paths, such as the TPX3
-Parquet output directory, summary JSON file, image file, or plot file. Any saved
-state updates must be applied through `hermes.state_service`; analysis code
-should not mutate the record directly.
+or directories containing TPX3 Parquet files, together with typed Pydantic
+settings. They should return explicitly named paths, such as the TPX3 Parquet
+output directory, summary JSON file, image file, or plot file. Analysis code
+must save changes through `hermes.state_service`; it should not change the
+HERMES state directly.
 
 Analysis workflows must not require acquisition state to be present. For
 analysis-only use, raw TPX3 files, image files, or directories containing TPX3
-Parquet files should be recorded directly in the analysis section of the
-`HermesRecord`.
+Parquet files should be saved directly in the analysis section of the HERMES
+state.
+
+## C++ and Rust Backends
+
+HERMES should allow more than one backend to perform each analysis step. For
+example, a user may choose a C++ unpacker for one run and a Rust unpacker for
+another run. The same choice should be possible when multiple photon or event
+reconstruction programs are available.
+
+Analysis backends should be grouped by the step they perform. C++ and Rust
+versions of the same backend should live beside each other:
+
+```text
+HERMES/
+├── Cargo.toml
+└── backends/
+    ├── unpackers/
+    │   └── tpx3-spidr/
+    │       ├── cpp/
+    │       └── rust/
+    ├── photon-reconstructors/
+    └── event-reconstructors/
+```
+
+The top-level `Cargo.toml` should include the Rust directories that are part of
+the Cargo workspace. Each C++ directory should contain its own CMake project.
+A directory should be created only when its backend is being implemented.
+
+HERMES should run the backend selected for each step using its executable path.
+The selected backend may come from this repository or may be installed
+somewhere else on the user's computer. HERMES should not require separate
+Python code for C++ and Rust versions of the same step.
+
+Backends that perform the same step must accept the same required input and
+produce the same required output. This allows the user to change programs
+without changing the rest of the analysis workflow.
+
+For example, a user could select:
+
+```yaml
+analysis:
+  unpacker:
+    name: hermes-tpx3-spidr-cpp
+    executable_path: /path/to/hermes-tpx3-spidr-cpp
+  photon_reconstructor:
+    name: hermes-photon-reconstructor-rust
+    executable_path: /path/to/hermes-photon-reconstructor-rust
+  event_reconstructor:
+    name: another-event-program
+    executable_path: /path/to/another-event-program
+```
+
+## Files Created Between Analysis Steps
+
+The TPX3 analysis can run as three separate steps:
+
+```text
+raw TPX3 file
+  -> unpacker
+  -> pixel and timing Parquet files
+  -> photon reconstruction
+  -> photon Parquet files
+  -> event reconstruction
+  -> event Parquet files
+```
+
+The user should be able to choose the program used for each step. The output
+from one step becomes the input to the next step.
+
+HERMES should always keep the original raw TPX3 file and the output from the
+last step requested by the user. Files created between steps do not always need
+to be kept permanently. A single setting should control this behavior:
+
+```yaml
+keep_intermediate_files: false
+```
+
+When this setting is `false`, HERMES may write the files needed by the next step
+to a temporary working directory. HERMES should delete those files only after
+the next step finishes successfully. If a step fails, HERMES should leave the
+temporary files in place so the user can inspect them and investigate the
+failure.
+
+When `keep_intermediate_files` is `true`, HERMES should keep the pixel, timing,
+photon, and event Parquet files produced by the requested steps.
+
+The first working version should use Parquet files between programs. The time
+spent reading and writing each file should be measured. If these file operations
+make the analysis too slow, a later version may pass data directly between
+programs. This performance change should not alter the names, columns, timing
+units, or meaning of the saved Parquet files.

--- a/docs/architecture/environment.md
+++ b/docs/architecture/environment.md
@@ -11,8 +11,9 @@ Important environment fields include:
 - EMPIR installation path or executable path as a `Path`
 - EMPIR version, when available
 - HERMES Python package version
-- `hermes-tpx3-spidr` binary path as a `Path`
-- `hermes-tpx3-spidr` version
+- selected unpacker name, executable path as a `Path`, and version
+- selected photon reconstruction backend name, executable path, and version
+- selected event reconstruction backend name, executable path, and version
 - Python version and platform, when useful for provenance
 - `working_dir`
 - `data_dir`

--- a/docs/architecture/general.md
+++ b/docs/architecture/general.md
@@ -44,14 +44,23 @@ for each major boundary live in separate files:
 ```text
 
 HERMES/
-├── Cargo.toml  # Rust workspace file for SPIDR unpacker and related crates
-├── crates/                 # Rust crates for SPIDR unpacking and related functionality
-│   └── hermes-tpx3-spidr/
-│       ├── Cargo.toml      # crate file for the SPIDR unpacker 
-│       ├── src/            # Rust source code for the SPIDR unpacker
-│       │   ├── lib.rs      # main library file for the SPIDR unpacker
-│       │   └── main.rs     # main executable file for the SPIDR unpacker
-│       └── tests/          # tests for the SPIDR unpacker
+├── Cargo.toml  # Rust workspace file for Rust analysis backends
+├── backends/   # backends selected by HERMES for each analysis step
+│   ├── unpackers/
+│   │   └── tpx3-spidr/
+│   │       ├── cpp/
+│   │       │   ├── CMakeLists.txt
+│   │       │   ├── include/
+│   │       │   ├── src/
+│   │       │   └── tests/
+│   │       └── rust/
+│   │           ├── Cargo.toml
+│   │           ├── src/
+│   │           │   ├── lib.rs
+│   │           │   └── main.rs
+│   │           └── tests/
+│   ├── photon-reconstructors/
+│   └── event-reconstructors/
 │
 ├── src/
 │   └── hermes/
@@ -112,7 +121,9 @@ HERMES/
 ```
 
 This layout is a target shape, not a requirement to create every file
-immediately. Add modules only when the first workflow needs them.
+immediately. Add a backend directory only when its first working version is
+being implemented. Rust backends remain members of the top-level Cargo
+workspace even though they are grouped by analysis step under `backends/`.
 
 ## External References
 

--- a/docs/architecture/open-questions.md
+++ b/docs/architecture/open-questions.md
@@ -1,4 +1,4 @@
 # Open Questions
-- Should the Rust unpacker be invoked only as a CLI at first, or should a Python extension be planned later with PyO3 or maturin?
+- After file reading and writing have been measured, is it fast enough to keep using Parquet files between analysis backends, or is direct data transfer needed later?
 - What would PyMEPix and MCP2Hist acquisition environments look like in the state model, and how would they differ from the SERVAL environment?
 - Which metadata are required for EMPIR analysis provenance?

--- a/docs/architecture/unpacker.md
+++ b/docs/architecture/unpacker.md
@@ -1,30 +1,33 @@
-# TPX3 SPIDR Unpacker
+# TPX3 SPIDR Unpacking
 
-The Rust unpacker should live outside the Python package:
+TPX3 SPIDR unpackers should live outside the Python package. C++ and Rust
+versions should live beside each other:
 
 ```text
-crates/hermes-tpx3-spidr/
+backends/unpackers/tpx3-spidr/
+├── cpp/
+└── rust/
 ```
 
-The Rust crate should read each binary packet in a raw `.tpx3` file, identify the
-packet type, and extract its fields. It should keep this packet-reading code in
-`src/lib.rs` and expose a CLI in `src/main.rs`.
+Each version should read the binary packets in a raw `.tpx3` file, identify the
+packet type, and extract its fields. C++ and Rust versions must accept the same
+required inputs and write the same required outputs.
 
-Python should run the unpacker as a separate command-line program. A wrapper in
-`src/hermes/analysis/hermes_tpx3_spidr.py` can run the binary, validate the
-summary JSON file, and use `hermes.state_service` to update the central Pydantic
-record. The wrapper must not directly mutate the record.
+Python should run the unpacker selected by the user as a separate command-line
+program. Code in `src/hermes/analysis/` should run the selected executable,
+check the summary JSON file, and save the results through
+`hermes.state_service`. It must not change the HERMES state directly.
 
 The CLI should have an explicit interface, for example:
 
 ```text
-hermes-tpx3-spidr input.tpx3 --output tpx3_parquet/ --summary tpx3_parquet/summary.json
+<executable> input.tpx3 --output tpx3_parquet/ --summary tpx3_parquet/summary.json
 ```
 
-The state record should capture the raw TPX3 input file, TPX3 Parquet output
-directory, summary JSON file, unpacker name, unpacker version, command arguments,
-pixel-hit count, TDC-hit count, global-timestamp count, control-packet count,
-timing ranges, warnings, and errors.
+The HERMES state should save the raw TPX3 input file, TPX3 Parquet output
+directory, summary JSON file, unpacker name, unpacker version, command
+arguments, pixel-hit count, TDC-hit count, global-timestamp count,
+control-packet count, timing ranges, warnings, and errors.
 
 ## TPX3 Parquet Output Directory
 
@@ -44,17 +47,12 @@ tpx3_parquet/
     part-00000.parquet
   control_packets/
     part-00000.parquet
-  photon/
-    photon_events/
-      part-00000.parquet
-    photon_pixels/
-      part-00000.parquet
 ```
 
 The Parquet files should preserve the integer timing fields read from the raw
 packets. Pixel hits, TDC hits, and global timestamp packets have different timing
 fields and resolutions, so the unpacker should not replace them with only
-floating-point seconds. It should keep the integer columns and record their units
+floating-point seconds. It should keep the integer columns and save their units
 in the Parquet metadata and summary JSON file.
 
 For example, pixel timing columns may include:
@@ -72,7 +70,7 @@ TDC timing columns may include:
 
 ## Native Timestamp Fields
 
-The unpacker should record the following timestamp fields and units in the
+The unpacker should save the following timestamp fields and units in the
 Parquet metadata and summary JSON file:
 
 | Quantity | Raw field | Native unit | Notes |
@@ -93,7 +91,7 @@ Parquet metadata and summary JSON file:
 | SPIDR control timestamp | packet type `0x5` | `25 ns` ticks | Used for shutter and heartbeat-style control packets. |
 
 The unpacker should also produce a canonical synchronized integer time column
-when enough information is available to place records on one shared time axis.
+when enough information is available to place rows on one shared time axis.
 The preferred exact common unit is:
 
 ```text
@@ -106,21 +104,28 @@ be added as convenience columns, but integer raw fields and integer synchronized
 time should remain the source of truth.
 
 If sorted output is required for timing analysis, the unpacker should sort by
-canonical event time and record the sort order in metadata. For very large files,
+canonical event time and save the sort order in metadata. For very large files,
 the implementation should not require every extracted row to fit in memory. It
 should read and sort chunks, write temporary sorted Parquet files, and merge them
 into the final Parquet files.
 
-## Photon Clustering
+## Photon Reconstruction
 
-The unpacker may also produce photon-cluster output for image-intensifier data.
-Photon clusters are calculated from the pixel-hit rows. They do not replace the
-original `pixel_hits` Parquet files.
+Photon reconstruction is a separate analysis step, not a required part of the
+unpacker. A user-selected photon reconstruction backend should read the
+`pixel_hits` Parquet files and write photon Parquet files. Possible C++ and Rust
+versions should be grouped under:
+
+```text
+backends/photon-reconstructors/<name>/
+├── cpp/
+└── rust/
+```
 
 The purpose of photon clustering is to group adjacent pixel hits that likely came
 from one photon entering the image intensifier and producing a phosphor response
 across multiple TPX3 pixels. A first clustering pass should be configurable and
-should record its full configuration in the summary and state model.
+should save its full settings in the summary and HERMES state.
 
 Important clustering parameters include:
 
@@ -133,7 +138,7 @@ Important clustering parameters include:
 - whether clustering is performed before or after TDC association
 - quality flags for ambiguous, saturated, split, or merged clusters
 
-The `tpx3_parquet/photon/` directory should contain two Parquet file groups:
+The photon output directory should contain two Parquet file groups:
 
 - `photon_events`: one row per reconstructed photon candidate
 - `photon_pixels`: membership rows linking source pixel hits to photon candidates
@@ -150,8 +155,8 @@ The averaging rule should be explicit in the clustering metadata. The first
 implementation may use arithmetic averages, but the schema should allow a
 ToT-weighted average or fitted estimate later. Cluster diagnostics such as pixel
 count, time span, quality flags, and source-pixel membership should not be
-required fields in `photon_events`; they can be recorded in `summary.json`, the
-state model, or optional diagnostic tables.
+required fields in `photon_events`; they can be saved in `summary.json`, the
+HERMES state, or optional diagnostic tables.
 
 `photon_pixels` may include columns such as:
 
@@ -162,6 +167,21 @@ state model, or optional diagnostic tables.
 - `tot_raw`
 - `event_time_ticks`
 
-The state model should record the photon-clustering settings, run status,
+The HERMES state should save the photon-clustering settings, run status,
 pixel-hit input directory, photon-event output directory, photon-pixel output
-directory, algorithm version, photon counts, warnings, and errors.
+directory, program version, photon counts, warnings, and errors.
+
+## Event Reconstruction
+
+Event reconstruction is another separate analysis step. A user-selected event
+reconstruction backend should read photon Parquet files and write event Parquet
+files. Possible C++ and Rust versions should be grouped under:
+
+```text
+backends/event-reconstructors/<name>/
+├── cpp/
+└── rust/
+```
+
+The exact event file columns and timing rules must be added to the architecture
+before the first event reconstruction backend is implemented.

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -34,12 +34,12 @@ The first workflow should be intentionally narrow:
 4. Start acquisition and wait for completion.
 5. Use `hermes.state_service` to save the raw TPX3 file path in the HERMES
    record.
-6. Run `hermes-tpx3-spidr` on the raw TPX3 file.
+6. Run the TPX3 SPIDR unpacker selected by the user on the raw TPX3 file.
 7. Write pixel-hit, TDC-hit, timestamp, and control-packet Parquet files and a
    summary JSON file.
 8. Use `hermes.state_service` to save the TPX3 Parquet output directory, summary
    JSON file, pixel-hit count, TDC-hit count, global-timestamp count,
    control-packet count, warnings, and errors in the same HERMES record.
 
-This workflow is enough to validate the state model, file tracking, logging, and
-Rust/Python boundary.
+This workflow is enough to test the HERMES state, file tracking, logging, and
+the connection between Python and a selected C++ or Rust backend.


### PR DESCRIPTION
This pull request introduces the initial C++ header and build system scaffolding for the TPX3 SPIDR unpacker. It defines the core data structures, configuration and diagnostics interfaces, and the main processing and clustering APIs. Additionally, it documents the TPX3 packet format and build instructions. The most important changes are grouped below:

**Build System and Documentation**

* Added a new `Makefile` to organize and build the C++ unpacker, with support for object and binary directories, clean/install/help targets, and C++17 compilation. (`backends/unpackers/tpx3-spidr/cpp/Makefile`)
* Added a comprehensive `Notes.md` documenting the TPX3 SPIDR raw packet format, decoding rules, and output requirements for future unpacker development. (`backends/unpackers/tpx3-spidr/cpp/Notes.md`)

**Core Data Structures**

* Introduced `structures.h` defining the main configuration (`configParameters`), diagnostics (`tpx3FileDiagnostics`), signal (`signalData`), and photon (`photonData`) data structures used across the unpacker. (`backends/unpackers/tpx3-spidr/cpp/inc/structures.h`)

**Processing and Clustering APIs**

* Added headers for packet processing (`dataPacketProcessor.h`), clustering and photon reconstruction (`photonRecon.h`), histogramming (`histograms.h`), and diagnostics (`diagnostics.h`), each exposing the main function prototypes and relevant includes. [[1]](diffhunk://#diff-a715d93d52dd58487d394b48916b925f9ca119982e9a3818ca3c5eff771ad600R1-R47) [[2]](diffhunk://#diff-59dce962f31bb74d9e1e8b510b1e212902624cd902c4eb6e15c342f5e9e5fe02R1-R25) [[3]](diffhunk://#diff-9c1e675fab61b9e6393fe0f27f12a363ca49d7c25d0282f71a52e095f8007dafR1-R23) [[4]](diffhunk://#diff-577c65d53c8bc6aea590a4a5b08b3f906799650ff82f130e7b2f06e8075c2b6aR1-R27)

**Configuration and Command-Line Parsing**

* Added headers for configuration file reading (`configReader.h`) and command-line flag parsing (`commandLineParser.h`), providing utility and interface functions for initializing and validating unpacker settings. [[1]](diffhunk://#diff-84116c72cc5019eb311f72779deec2e00a23dd1911ab4bf980a111b8bd49af5bR1-R14) [[2]](diffhunk://#diff-619e5814f75f8217bd61b782b0c176cf9bbdb429e33a43f11556b5d6c23f0bc3R1-R80)