### PR TITLE
30 unpacking improvements

### DIFF
--- a/backends/unpackers/tpx3-spidr/cpp/inc/packet_types.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/packet_types.h
@@ -137,8 +137,8 @@ struct UnpackSummary {
     std::uint64_t chunks_read = 0;
     std::uint64_t packets_read = 0;
     std::uint64_t integrated_tot_count = 0;
-    std::uint64_t pixel_hit_count = 0;
-    std::uint64_t tdc_hit_count = 0;
+    std::uint64_t pixel_data_packet_count = 0;
+    std::uint64_t tdc_timestamp_count = 0;
     std::uint64_t tdc1_rising_count = 0;
     std::uint64_t tdc1_falling_count = 0;
     std::uint64_t tdc2_rising_count = 0;
@@ -146,7 +146,7 @@ struct UnpackSummary {
     std::uint64_t unknown_tdc_edge_count = 0;
     std::uint64_t global_time_low_count = 0;
     std::uint64_t global_time_high_count = 0;
-    std::uint64_t global_timestamp_count = 0;
+    std::uint64_t heartbeat_packet_count = 0;
     std::uint64_t spidr_control_count = 0;
     std::uint64_t packet_count_control_count = 0;
     std::uint64_t shutter_open_count = 0;
@@ -163,7 +163,7 @@ struct UnpackSummary {
     std::uint64_t malformed_chunk_count = 0;
     std::uint64_t truncated_chunk_count = 0;
     std::uint64_t invalid_tdc_fine_value_count = 0;
-    std::uint64_t unknown_packet_count = 0;
+    std::uint64_t unrecognized_packet_count = 0;
     std::vector<std::string> warnings;
     std::vector<std::string> errors;
 };

--- a/backends/unpackers/tpx3-spidr/cpp/src/diagnostics.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/diagnostics.cpp
@@ -9,8 +9,8 @@ void printSummary(const UnpackSummary& summary, std::ostream& output) {
            << " chunks=" << summary.chunks_read
            << " packets=" << summary.packets_read << '\n'
            << "integrated_tot=" << summary.integrated_tot_count
-           << " pixel_hits=" << summary.pixel_hit_count << '\n'
-           << "tdc_hits=" << summary.tdc_hit_count
+           << " pixel_hits=" << summary.pixel_data_packet_count << '\n'
+           << "tdc_hits=" << summary.tdc_timestamp_count
            << " tdc1_rising=" << summary.tdc1_rising_count
            << " tdc1_falling=" << summary.tdc1_falling_count
            << " tdc2_rising=" << summary.tdc2_rising_count
@@ -18,7 +18,7 @@ void printSummary(const UnpackSummary& summary, std::ostream& output) {
            << " unknown_tdc_edge=" << summary.unknown_tdc_edge_count << '\n'
            << "global_time_low=" << summary.global_time_low_count
            << " global_time_high=" << summary.global_time_high_count
-           << " global_timestamps=" << summary.global_timestamp_count << '\n'
+           << " global_timestamps=" << summary.heartbeat_packet_count << '\n'
            << "spidr_controls=" << summary.spidr_control_count
            << " packet_count=" << summary.packet_count_control_count
            << " shutter_open=" << summary.shutter_open_count
@@ -34,7 +34,7 @@ void printSummary(const UnpackSummary& summary, std::ostream& output) {
            << " request_time_high=" << summary.request_time_high_count
            << " other_chip_cmd=" << summary.other_chip_command_count
            << " unknown_tpx3=" << summary.unknown_tpx3_control_count << '\n'
-           << "unknown_packets=" << summary.unknown_packet_count << '\n'
+           << "unknown_packets=" << summary.unrecognized_packet_count << '\n'
            << "malformed_chunks=" << summary.malformed_chunk_count
            << " truncated_chunks=" << summary.truncated_chunk_count
            << " invalid_tdc_fine="

--- a/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
@@ -26,12 +26,12 @@ std::string generateSummaryJson(const SummaryJsonContent& content) {
     j["unpacking"] = {
         {"chunks_read", content.unpack_summary.chunks_read},
         {"packets_read", content.unpack_summary.packets_read},
-        {"decoded_pixel_hits", content.unpack_summary.pixel_hit_count},
-        {"decoded_tdc_triggers", content.unpack_summary.tdc_hit_count},
-        {"decoded_global_timestamps", content.unpack_summary.global_timestamp_count},
+        {"decoded_pixel_hits", content.unpack_summary.pixel_data_packet_count},
+        {"decoded_tdc_triggers", content.unpack_summary.tdc_timestamp_count},
+        {"decoded_global_timestamps", content.unpack_summary.heartbeat_packet_count},
         {"decoded_spidr_control_packets", content.unpack_summary.spidr_control_count},
         {"decoded_tpx3_control_packets", content.unpack_summary.tpx3_control_count},
-        {"decoded_unknown_packets", content.unpack_summary.unknown_packet_count},
+        {"decoded_unknown_packets", content.unpack_summary.unrecognized_packet_count},
         {"warnings", content.unpack_summary.warnings},
         {"errors", content.unpack_summary.errors}
     };

--- a/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <stdexcept>
 
-using json = nlohmann::json;
+using json = nlohmann::ordered_json;
 
 namespace hermes_tpx3_spidr {
 
@@ -22,61 +22,87 @@ json categoryJson(const ParquetCategoryFiles& category) {
 
 std::string generateSummaryJson(const SummaryJsonContent& content) {
     json j;
+    const auto total_seconds = content.timing_diagnostics.total_seconds;
+    const auto packets_per_second =
+        total_seconds > 0.0
+            ? static_cast<double>(content.unpack_summary.packets_read) /
+                  total_seconds
+            : 0.0;
+    const auto megabytes_per_second =
+        total_seconds > 0.0
+            ? static_cast<double>(content.unpack_summary.bytes_read) /
+                  total_seconds / 1'000'000.0
+            : 0.0;
 
     j["unpacking"] = {
+        {"bytes_read", content.unpack_summary.bytes_read},
         {"chunks_read", content.unpack_summary.chunks_read},
         {"packets_read", content.unpack_summary.packets_read},
-        {"decoded_pixel_hits", content.unpack_summary.pixel_data_packet_count},
-        {"decoded_tdc_triggers", content.unpack_summary.tdc_timestamp_count},
-        {"decoded_global_timestamps", content.unpack_summary.heartbeat_packet_count},
-        {"decoded_spidr_control_packets", content.unpack_summary.spidr_control_count},
-        {"decoded_tpx3_control_packets", content.unpack_summary.tpx3_control_count},
-        {"decoded_unknown_packets", content.unpack_summary.unrecognized_packet_count},
-        {"warnings", content.unpack_summary.warnings},
-        {"errors", content.unpack_summary.errors}
+        {"pixel_data_packets",
+         content.unpack_summary.pixel_data_packet_count},
+        {"tdc_timestamps", content.unpack_summary.tdc_timestamp_count},
+        {"heartbeat_packets", content.unpack_summary.heartbeat_packet_count},
+        {"spidr_control_packets", content.unpack_summary.spidr_control_count},
+        {"tpx3_control_packets", content.unpack_summary.tpx3_control_count},
+        {"unrecognized_packets",
+         content.unpack_summary.unrecognized_packet_count},
+        {"tdc1_rising", content.unpack_summary.tdc1_rising_count},
+        {"tdc1_falling", content.unpack_summary.tdc1_falling_count},
+        {"tdc2_rising", content.unpack_summary.tdc2_rising_count},
+        {"tdc2_falling", content.unpack_summary.tdc2_falling_count},
+        {"unknown_tdc_edges",
+         content.unpack_summary.unknown_tdc_edge_count},
+        {"errors", content.unpack_summary.errors},
+        {"warnings", content.unpack_summary.warnings}
     };
 
     j["timestamp_processing"] = {
-        {"anchors", {
-            {"total", content.anchor_diagnostics.total_anchors},
-            {"unpaired_low", content.anchor_diagnostics.unpaired_low_count},
-            {"unpaired_high", content.anchor_diagnostics.unpaired_high_count},
-            {"warnings", content.anchor_diagnostics.warnings}
+        {"heartbeat_pairs", {
+            {"number_of_beats", content.anchor_diagnostics.total_anchors}
         }},
-        {"epoch_assignment", {
-            {"pixels_assigned", content.epoch_diagnostics.pixels_assigned},
-            {"tdc_triggers_assigned", content.epoch_diagnostics.tdcs_assigned},
-            {"controls_assigned", content.epoch_diagnostics.controls_assigned},
-            {"ambiguous_timestamps", content.epoch_diagnostics.ambiguous_timestamps},
-            {"unresolved_timestamps", content.epoch_diagnostics.unresolved_timestamps},
-            {"used_fallback", content.epoch_diagnostics.used_fallback},
-            {"warnings", content.epoch_diagnostics.warnings}
+        {"time_adjustments", {
+            {"pixel_packets", content.epoch_diagnostics.pixels_assigned},
+            {"tdc_packets", content.epoch_diagnostics.tdcs_assigned},
+            {"control_packets", content.epoch_diagnostics.controls_assigned},
+            {"failed", content.epoch_diagnostics.unresolved_timestamps}
         }}
     };
 
     j["sorting"] = {
-        {"method", content.sorting_diagnostics.path_used == SortingPath::in_memory ? "in_memory" : "external_merge"},
+        {"strategy",
+         content.sorting_diagnostics.path_used == SortingPath::in_memory
+             ? "in_memory"
+             : "external_merge"},
         {"memory_budget_bytes", content.sorting_diagnostics.memory_budget_bytes},
         {"estimated_memory_bytes", content.sorting_diagnostics.estimated_memory_bytes},
         {"temporary_runs_created", content.sorting_diagnostics.temporary_runs_created}
     };
 
     j["parquet"] = {
-        {"pixel_hits", categoryJson(content.writer_diagnostics.pixel_hits)},
-        {"tdc_triggers", categoryJson(content.writer_diagnostics.tdc_triggers)},
-        {"global_timestamps", categoryJson(content.writer_diagnostics.global_timestamps)},
+        {"pixel_data", categoryJson(content.writer_diagnostics.pixel_hits)},
+        {"tdc_timestamps", categoryJson(content.writer_diagnostics.tdc_triggers)},
+        {"heartbeat_packets",
+         categoryJson(content.writer_diagnostics.global_timestamps)},
         {"control_packets", categoryJson(content.writer_diagnostics.control_packets)},
-        {"unknown_packets", categoryJson(content.writer_diagnostics.unknown_packets)},
+        {"unrecognized_packets",
+         categoryJson(content.writer_diagnostics.unknown_packets)},
         {"errors", content.writer_diagnostics.errors}
     };
 
     j["processing_times_seconds"] = {
+        {"canonical_time_seconds", 2.0345e-12},
         {"unpacking", content.timing_diagnostics.unpacking_seconds},
-        {"epoch_assignment", content.timing_diagnostics.epoch_assignment_seconds},
-        {"conversion", content.timing_diagnostics.conversion_seconds},
+        {"canonical_conversion",
+         content.timing_diagnostics.conversion_seconds},
+        {"time_adjustments",
+         content.timing_diagnostics.epoch_assignment_seconds},
         {"sorting", content.timing_diagnostics.sorting_seconds},
         {"parquet_writing", content.timing_diagnostics.parquet_writing_seconds},
-        {"total", content.timing_diagnostics.total_seconds}
+        {"total", total_seconds},
+        {"throughput", {
+            {"packets_per_second", packets_per_second},
+            {"megabytes_per_second", megabytes_per_second}
+        }}
     };
 
     return j.dump(2);

--- a/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
@@ -82,7 +82,7 @@ void unpackPixelHit(const PacketPosition& position, UnpackResult& result) {
         coarse_time_25ns,
         fine_time_1p5625ns,
     });
-    ++result.summary.pixel_hit_count;
+    ++result.summary.pixel_data_packet_count;
 }
 
 void unpackTdcHit(const PacketPosition& position, UnpackResult& result) {
@@ -150,7 +150,7 @@ void unpackTdcHit(const PacketPosition& position, UnpackResult& result) {
         fine_value_valid,
         time_canonical_ticks,
     });
-    ++result.summary.tdc_hit_count;
+    ++result.summary.tdc_timestamp_count;
 }
 
 void unpackGlobalTime(const PacketPosition& position, UnpackResult& result) {
@@ -181,7 +181,7 @@ void unpackGlobalTime(const PacketPosition& position, UnpackResult& result) {
         position,
         packet_id,
     });
-    ++result.summary.unknown_packet_count;
+    ++result.summary.unrecognized_packet_count;
     result.summary.warnings.push_back(
         "Unknown global-time packet at " + packetLocation(position));
 }
@@ -274,7 +274,7 @@ void unpackUnknown(const PacketPosition& position, UnpackResult& result) {
         position,
         static_cast<std::uint8_t>(position.raw_word >> 56U),
     });
-    ++result.summary.unknown_packet_count;
+    ++result.summary.unrecognized_packet_count;
     result.summary.warnings.push_back(
         "Unknown packet at " + packetLocation(position));
 }
@@ -470,7 +470,7 @@ UnpackResult unpack(std::istream& input) {
                      << 32U) |
                         low.global_time_low_raw,
                 });
-                ++result.summary.global_timestamp_count;
+                ++result.summary.heartbeat_packet_count;
                 pending_global_time_lows[chunk_read.chip_index].reset();
             }
         }

--- a/backends/unpackers/tpx3-spidr/cpp/tests/diagnostics_tests.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/tests/diagnostics_tests.cpp
@@ -11,7 +11,7 @@ int main() {
     summary.bytes_read = 24U;
     summary.chunks_read = 2U;
     summary.packets_read = 3U;
-    summary.pixel_hit_count = 1U;
+    summary.pixel_data_packet_count = 1U;
     summary.tdc1_rising_count = 1U;
     summary.shutter_open_count = 1U;
     summary.unknown_tpx3_control_count = 1U;

--- a/backends/unpackers/tpx3-spidr/cpp/tests/packet_tests.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/tests/packet_tests.cpp
@@ -114,7 +114,7 @@ void testPixels(TestContext& test) {
     test.expectEqual(hit.fine_time_1p5625ns,
                      static_cast<std::int64_t>(coarse << 4U) - 0x0B,
                      "pixel fine-time subtraction");
-    test.expectEqual(result.summary.pixel_hit_count, std::uint64_t{1},
+    test.expectEqual(result.summary.pixel_data_packet_count, std::uint64_t{1},
                      "pixel summary count");
 
     UnpackResult boundaries;
@@ -141,7 +141,7 @@ void testTdc(TestContext& test) {
             1U, 2U, index, result);
     }
 
-    test.expectEqual(result.summary.tdc_hit_count, std::uint64_t{4},
+    test.expectEqual(result.summary.tdc_timestamp_count, std::uint64_t{4},
                      "TDC total count");
     test.expectEqual(result.summary.tdc1_rising_count, std::uint64_t{1},
                      "TDC1 rising count");

--- a/backends/unpackers/tpx3-spidr/cpp/tests/stream_tests.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/tests/stream_tests.cpp
@@ -144,7 +144,7 @@ void testGlobalTimePairing(TestContext& test) {
                      "global low count");
     test.expectEqual(result.summary.global_time_high_count, std::uint64_t{2},
                      "global high count");
-    test.expectEqual(result.summary.global_timestamp_count,
+    test.expectEqual(result.summary.heartbeat_packet_count,
                      std::uint64_t{1}, "paired global count");
     test.expectEqual(result.summary.packets_read, std::uint64_t{3},
                      "global stream packet count");

--- a/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
@@ -121,11 +121,11 @@ void testSharedDirectoriesForTwoInputs(TestContext& test) {
     if (std::filesystem::exists(first_summary)) {
         const auto first_json = readJson(first_summary);
         test.expectEqual(
-            first_json["parquet"]["pixel_hits"]["row_count"]
+            first_json["parquet"]["pixel_data"]["row_count"]
                 .get<std::uint64_t>(),
             std::uint64_t{1}, "summary records pixel row count");
         test.expectEqual(
-            first_json["parquet"]["pixel_hits"]["files"][0]
+            first_json["parquet"]["pixel_data"]["files"][0]
                 .get<std::string>(),
             std::string(
                 "pixelHits/DT_2p0V_000000-chip-0-part-00000.parquet"),
@@ -175,45 +175,131 @@ void testExistingFilesAreNotOverwritten(TestContext& test) {
 
 void testSummaryJsonGeneration(TestContext& test) {
     SummaryJsonContent content;
+    content.unpack_summary.bytes_read = 2'000'000;
     content.unpack_summary.chunks_read = 2;
-    content.unpack_summary.packets_read = 3;
+    content.unpack_summary.packets_read = 4;
     content.unpack_summary.pixel_data_packet_count = 1;
+    content.unpack_summary.tdc_timestamp_count = 6;
+    content.unpack_summary.heartbeat_packet_count = 7;
+    content.unpack_summary.spidr_control_count = 8;
+    content.unpack_summary.tpx3_control_count = 9;
+    content.unpack_summary.unrecognized_packet_count = 10;
+    content.unpack_summary.tdc1_rising_count = 11;
+    content.unpack_summary.tdc1_falling_count = 12;
+    content.unpack_summary.tdc2_rising_count = 13;
+    content.unpack_summary.tdc2_falling_count = 14;
+    content.unpack_summary.unknown_tdc_edge_count = 15;
     content.anchor_diagnostics.total_anchors = 4;
+    content.epoch_diagnostics.pixels_assigned = 3;
     content.epoch_diagnostics.tdcs_assigned = 5;
+    content.epoch_diagnostics.controls_assigned = 6;
+    content.epoch_diagnostics.unresolved_timestamps = 7;
+    content.sorting_diagnostics.path_used = SortingPath::external_merge;
     content.sorting_diagnostics.estimated_memory_bytes = 2048;
     content.writer_diagnostics.pixel_hits.row_count = 1;
     content.writer_diagnostics.pixel_hits.files.push_back(
         "pixelHits/test-chip-0-part-00000.parquet");
-    content.timing_diagnostics.total_seconds = 1.25;
+    content.timing_diagnostics.conversion_seconds = 0.25;
+    content.timing_diagnostics.epoch_assignment_seconds = 0.5;
+    content.timing_diagnostics.total_seconds = 2.0;
 
     const auto parsed = nlohmann::json::parse(generateSummaryJson(content));
 
     test.expectEqual(
-        parsed["unpacking"]["decoded_pixel_hits"].get<std::uint64_t>(),
-        std::uint64_t{1}, "JSON contains decoded pixel count");
+        parsed["unpacking"]["bytes_read"].get<std::uint64_t>(),
+        std::uint64_t{2'000'000}, "JSON contains byte count");
     test.expectEqual(
-        parsed["timestamp_processing"]["anchors"]["total"].get<std::uint64_t>(),
-        std::uint64_t{4}, "JSON contains anchor count");
+        parsed["unpacking"]["pixel_data_packets"].get<std::uint64_t>(),
+        std::uint64_t{1}, "JSON contains pixel data packet count");
     test.expectEqual(
-        parsed["timestamp_processing"]["epoch_assignment"]
-              ["tdc_triggers_assigned"]
+        parsed["unpacking"]["tdc_timestamps"].get<std::uint64_t>(),
+        std::uint64_t{6}, "JSON contains TDC timestamp count");
+    test.expectEqual(
+        parsed["unpacking"]["heartbeat_packets"].get<std::uint64_t>(),
+        std::uint64_t{7}, "JSON contains heartbeat packet count");
+    test.expectEqual(
+        parsed["unpacking"]["spidr_control_packets"].get<std::uint64_t>(),
+        std::uint64_t{8}, "JSON contains SPIDR control packet count");
+    test.expectEqual(
+        parsed["unpacking"]["tpx3_control_packets"].get<std::uint64_t>(),
+        std::uint64_t{9}, "JSON contains TPX3 control packet count");
+    test.expectEqual(
+        parsed["unpacking"]["unrecognized_packets"].get<std::uint64_t>(),
+        std::uint64_t{10}, "JSON contains unrecognized packet count");
+    test.expectEqual(
+        parsed["unpacking"]["tdc1_rising"].get<std::uint64_t>(),
+        std::uint64_t{11}, "JSON contains TDC1 rising count");
+    test.expectEqual(
+        parsed["unpacking"]["tdc1_falling"].get<std::uint64_t>(),
+        std::uint64_t{12}, "JSON contains TDC1 falling count");
+    test.expectEqual(
+        parsed["unpacking"]["tdc2_rising"].get<std::uint64_t>(),
+        std::uint64_t{13}, "JSON contains TDC2 rising count");
+    test.expectEqual(
+        parsed["unpacking"]["tdc2_falling"].get<std::uint64_t>(),
+        std::uint64_t{14}, "JSON contains TDC2 falling count");
+    test.expectEqual(
+        parsed["unpacking"]["unknown_tdc_edges"].get<std::uint64_t>(),
+        std::uint64_t{15}, "JSON contains unknown TDC edge count");
+    test.expectEqual(
+        parsed["timestamp_processing"]["heartbeat_pairs"]["number_of_beats"]
             .get<std::uint64_t>(),
-        std::uint64_t{5}, "JSON contains assigned TDC trigger count");
+        std::uint64_t{4}, "JSON contains heartbeat pair count");
+    test.expectEqual(
+        parsed["timestamp_processing"]["time_adjustments"]["pixel_packets"]
+            .get<std::uint64_t>(),
+        std::uint64_t{3}, "JSON contains adjusted pixel packet count");
+    test.expectEqual(
+        parsed["timestamp_processing"]["time_adjustments"]["tdc_packets"]
+            .get<std::uint64_t>(),
+        std::uint64_t{5}, "JSON contains adjusted TDC packet count");
+    test.expectEqual(
+        parsed["timestamp_processing"]["time_adjustments"]["control_packets"]
+            .get<std::uint64_t>(),
+        std::uint64_t{6}, "JSON contains adjusted control packet count");
+    test.expectEqual(
+        parsed["timestamp_processing"]["time_adjustments"]["failed"]
+            .get<std::uint64_t>(),
+        std::uint64_t{7}, "JSON contains failed adjustment count");
+    test.expectEqual(
+        parsed["sorting"]["strategy"].get<std::string>(),
+        std::string("external_merge"), "JSON contains sorting strategy");
     test.expectEqual(
         parsed["sorting"]["estimated_memory_bytes"].get<std::uint64_t>(),
         std::uint64_t{2048}, "JSON contains sorting memory estimate");
     test.expectEqual(
-        parsed["parquet"]["pixel_hits"]["row_count"].get<std::uint64_t>(),
+        parsed["parquet"]["pixel_data"]["row_count"].get<std::uint64_t>(),
         std::uint64_t{1}, "JSON contains pixel Parquet row count");
     test.expectEqual(
-        parsed["parquet"]["pixel_hits"]["files"][0].get<std::string>(),
+        parsed["parquet"]["pixel_data"]["files"][0].get<std::string>(),
         std::string("pixelHits/test-chip-0-part-00000.parquet"),
         "JSON contains relative pixel Parquet filename");
-    test.expect(parsed["parquet"]["tdc_triggers"]["files"].empty(),
+    test.expect(parsed["parquet"]["tdc_timestamps"]["files"].empty(),
                 "JSON contains empty TDC file list");
     test.expectEqual(
         parsed["processing_times_seconds"]["total"].get<double>(),
-        1.25, "JSON contains total processing time");
+        2.0, "JSON contains total processing time");
+    test.expectEqual(
+        parsed["processing_times_seconds"]["canonical_time_seconds"]
+            .get<double>(),
+        2.0345e-12, "JSON contains canonical time unit");
+    test.expectEqual(
+        parsed["processing_times_seconds"]["canonical_conversion"]
+            .get<double>(),
+        0.25, "JSON contains canonical conversion time");
+    test.expectEqual(
+        parsed["processing_times_seconds"]["time_adjustments"].get<double>(),
+        0.5, "JSON contains time adjustment duration");
+    test.expectEqual(
+        parsed["processing_times_seconds"]["throughput"]
+              ["packets_per_second"]
+            .get<double>(),
+        2.0, "JSON contains packet throughput");
+    test.expectEqual(
+        parsed["processing_times_seconds"]["throughput"]
+              ["megabytes_per_second"]
+            .get<double>(),
+        1.0, "JSON contains megabyte throughput");
 }
 
 void testSummaryJsonStructure(TestContext& test) {
@@ -235,9 +321,9 @@ void testSummaryJsonStructure(TestContext& test) {
                     std::string("JSON omits ") + removed);
     }
 
-    for (const auto* category : {"pixel_hits", "tdc_triggers",
-                                 "global_timestamps", "control_packets",
-                                 "unknown_packets"}) {
+    for (const auto* category : {"pixel_data", "tdc_timestamps",
+                                 "heartbeat_packets", "control_packets",
+                                 "unrecognized_packets"}) {
         const auto& category_json = parsed["parquet"][category];
         test.expectEqual(category_json.size(), std::size_t{2},
                          std::string(category) +
@@ -251,6 +337,20 @@ void testSummaryJsonStructure(TestContext& test) {
         test.expect(!category_json.contains("file_count"),
                     std::string(category) + " omits file_count");
     }
+
+    test.expectEqual(
+        parsed["timestamp_processing"]["heartbeat_pairs"].size(),
+        std::size_t{1}, "heartbeat pairs contain only number_of_beats");
+    test.expectEqual(
+        parsed["timestamp_processing"]["time_adjustments"].size(),
+        std::size_t{4}, "time adjustments contain four packet counts");
+    test.expect(!parsed["sorting"].contains("method"),
+                "sorting omits old method field");
+    test.expect(!parsed["processing_times_seconds"].contains("conversion"),
+                "processing times omit old conversion field");
+    test.expect(
+        !parsed["processing_times_seconds"].contains("epoch_assignment"),
+        "processing times omit old epoch assignment field");
 }
 
 void testWorkflowErrorHandling(TestContext& test) {

--- a/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
@@ -177,7 +177,7 @@ void testSummaryJsonGeneration(TestContext& test) {
     SummaryJsonContent content;
     content.unpack_summary.chunks_read = 2;
     content.unpack_summary.packets_read = 3;
-    content.unpack_summary.pixel_hit_count = 1;
+    content.unpack_summary.pixel_data_packet_count = 1;
     content.anchor_diagnostics.total_anchors = 4;
     content.epoch_diagnostics.tdcs_assigned = 5;
     content.sorting_diagnostics.estimated_memory_bytes = 2048;

--- a/docs/architecture/analysis.md
+++ b/docs/architecture/analysis.md
@@ -138,9 +138,9 @@ The HERMES pipeline is:
 ```text
 raw TPX3 files
   -> HERMES TPX3 SPIDR unpacker
-  -> sorted pixel_hits Parquet files
-  -> sorted tdc_triggers Parquet files
-  -> sorted global_timestamps Parquet files
+  -> sorted pixel_data Parquet files
+  -> sorted tdc_timestamps Parquet files
+  -> sorted heartbeat_packets Parquet files
   -> sorted control_packets Parquet files
   -> future HERMES pixel-to-photon reconstruction
   -> future HERMES photon-to-event reconstruction

--- a/docs/architecture/unpacker.md
+++ b/docs/architecture/unpacker.md
@@ -33,10 +33,11 @@ The unpacker derives all category directories and output filenames from those
 two inputs. Do not add separate command options for category directories, a
 filename prefix, or a summary filename.
 
-The HERMES state should save the raw TPX3 input file, shared analysis directory,
-summary JSON file, unpacker name, unpacker version, command
-arguments, pixel-hit count, TDC-trigger count, global-timestamp count,
-control-packet count, timing ranges, warnings, and errors.
+The HERMES state should save the raw TPX3 input files, shared analysis
+directory, unpacker program, and overall unpacking status and times. Each
+input-specific summary JSON file should save its byte and packet counts,
+Parquet filenames and row counts, timestamp-processing information, sorting
+information, processing times, throughput, warnings, and errors.
 
 ## Shared Analysis Directories
 
@@ -73,11 +74,11 @@ The directory names and the corresponding Parquet data category names are:
 
 | Saved data | Directory | Parquet data category |
 | --- | --- | --- |
-| Pixel hits | `pixelHits/` | `pixel_hits` |
-| TDC triggers | `tdcTriggers/` | `tdc_triggers` |
-| Global timestamps | `globalTimestamps/` | `global_timestamps` |
+| Pixel data | `pixelHits/` | `pixel_data` |
+| TDC timestamps | `tdcTriggers/` | `tdc_timestamps` |
+| Heartbeat packets | `globalTimestamps/` | `heartbeat_packets` |
 | Control packets | `controlPackets/` | `control_packets` |
-| Unknown packets | `unknownPackets/` | `unknown_packets` |
+| Unrecognized packets | `unknownPackets/` | `unrecognized_packets` |
 
 ## Parquet Filenames
 
@@ -88,7 +89,7 @@ index:
 <raw-file-stem>-chip-<chip-index>-part-<five-digit-part-index>.parquet
 ```
 
-For example, the first pixel-hit part for chip 0 from
+For example, the first pixel-data part for chip 0 from
 `DT_2p0V_000000.tpx3` is:
 
 ```text
@@ -107,11 +108,11 @@ cannot overwrite another input's files. Existing files with the same expected
 names must also cause the run to stop; the unpacker must not silently overwrite
 them.
 
-Integrated-ToT packets should be decoded and counted, but the first output
+Integrated-ToT packets should be unpacked and counted, but the first output
 format does not write them. A later acquisition-mode-specific version may add
 an `integratedPixels/` directory.
 
-The C++ decoder should use the native integer timing fields to calculate final
+The C++ unpacker should use the native integer timing fields to calculate final
 timestamps, but it should not copy those raw timing fields into Parquet. Each
 known timestamped dataset should contain only `timestamp_canonical` for time.
 The Parquet metadata and summary JSON file should define the canonical unit.
@@ -120,16 +121,16 @@ Pixel ToT should remain in the pixel table because it is a detector measurement,
 not an arrival-timestamp component. The TDC table should contain only
 `trigger_type` and `timestamp_canonical`. `trigger_type` uses `0` for TDC1
 rising, `1` for TDC1 falling, `2` for TDC2 rising, and `3` for TDC2 falling.
-Invalid-time TDC packets should be counted as decoder errors and omitted from
+Invalid-time TDC packets should be counted as unpacking errors and omitted from
 Parquet.
 
 ## Parquet Schemas
 
 Known-packet tables should contain the final analysis values rather than copies
-of raw packet words or raw timestamp components. Unknown packets retain their
-raw word because no reliable decoded representation exists for them.
+of raw packet words or raw timestamp components. Unrecognized packets retain
+their raw word because no reliable unpacked representation exists for them.
 
-### `pixel_hits`
+### `pixel_data`
 
 | Column | Arrow type | Nullable | Description |
 | --- | --- | --- | --- |
@@ -140,11 +141,11 @@ raw word because no reliable decoded representation exists for them.
 | `tot_raw` | `uint16` | no | Pixel ToT measurement |
 | `timestamp_canonical` | `uint64` | no | Unwrapped final timestamp |
 
-The raw `pixel_address`, ToA, FToA, and SPIDR time are used by the C++ decoder
+The raw `pixel_address`, ToA, FToA, and SPIDR time are used by the C++ unpacker
 but are not copied into Parquet. `local_x` and `local_y` contain the complete
-decoded pixel location.
+unpacked pixel location.
 
-### `tdc_triggers`
+### `tdc_timestamps`
 
 | Column | Arrow type | Nullable | Description |
 | --- | --- | --- | --- |
@@ -153,10 +154,10 @@ decoded pixel location.
 
 The normalized trigger type replaces separate channel and edge columns. Raw
 edge code, trigger counter, reserved bits, fine-time validity, and packet
-provenance remain decoder diagnostics and are not written. A TDC packet with an
+provenance remain unpacker diagnostics and are not written. A TDC packet with an
 invalid fine-time value does not produce a Parquet row.
 
-### `global_timestamps`
+### `heartbeat_packets`
 
 | Column | Arrow type | Nullable | Description |
 | --- | --- | --- | --- |
@@ -164,9 +165,8 @@ invalid fine-time value does not produce a Parquet row.
 | `packet_index` | `uint64` | no | High packet index within that chunk |
 | `timestamp_canonical` | `uint64` | no | Paired and unwrapped final timestamp |
 
-Only complete low/high pairs are written. The low packet position and raw low,
-high, paired, and SPIDR timing values are not copied into Parquet. Unpaired
-packet counts belong in `summary.json`.
+Only complete heartbeat low/high pairs are written. The low packet position and
+raw low, high, paired, and SPIDR timing values are not copied into Parquet.
 
 ### `control_packets`
 
@@ -185,13 +185,13 @@ packet counts belong in `summary.json`.
 | `control_payload_raw` | `uint64` | yes | TPX3 control value data when present |
 | `timestamp_canonical` | `uint64` | yes | Unwrapped final timestamp when present |
 
-### `unknown_packets`
+### `unrecognized_packets`
 
 | Column | Arrow type | Nullable | Description |
 | --- | --- | --- | --- |
 | `chunk_index` | `uint64` | no | Chunk index in the input file |
 | `packet_index` | `uint64` | no | Packet index within the chunk |
-| `raw_word` | `uint64` | no | Original unknown packet word |
+| `raw_word` | `uint64` | no | Original unrecognized packet word |
 | `most_significant_byte` | `uint8` | no | Raw most-significant byte |
 
 Every schema should record its version and the canonical time unit in Parquet
@@ -214,8 +214,8 @@ Parquet columns:
 | TDC coarse time | packet timestamp field | `25 ns` ticks | Used with finer TDC fields to derive edge time. |
 | TDC sub-coarse time | packet timestamp field | `3.125 ns` ticks | Part of the TDC timestamp. |
 | TDC fine time | 4-bit, values `1..12` | `260.416666 ps` steps | Value `0` is an error state per ASI documentation. |
-| Global timestamp low | 32-bit | `25 ns` ticks | Low part of the 48-bit global timer. |
-| Global timestamp high | 16-bit | high bits of same `25 ns` timer | Combined global timer lasts about `81 days`. |
+| Heartbeat timestamp low | 32-bit | `25 ns` ticks | Low part of the 48-bit global timer. |
+| Heartbeat timestamp high | 16-bit | high bits of same `25 ns` timer | Combined global timer lasts about `81 days`. |
 | SPIDR control timestamp | packet type `0x5` | `25 ns` ticks | Used for shutter and heartbeat-style control packets. |
 
 The unpacker should produce a final integer `timestamp_canonical` column when
@@ -231,12 +231,12 @@ and the TDC fine step of `25 ns / 96`. The unpacker should not write derived
 floating-point time columns. Later analysis code may calculate floating-point
 seconds or nanoseconds when needed.
 
-Pixel, TDC, global-timestamp, and timestamped control rows should be calculated
-in canonical time units. Global low and high packets should be paired per chip;
-only paired global timestamps should be written. Timestamp rollovers should be
-tracked independently for each chip and packet category. A paired global row's
-`chunk_index` and `packet_index` should identify the high packet that completed
-the pair; the low packet position should not be written.
+Pixel-data, TDC-timestamp, heartbeat, and timestamped control rows should be
+calculated in canonical time units. Heartbeat low and high packets should be
+paired per chip; only paired heartbeat timestamps should be written. Timestamp
+rollovers should be tracked independently for each chip and packet category. A
+paired heartbeat row's `chunk_index` and `packet_index` should identify the high
+packet that completed the pair; the low packet position should not be written.
 
 Each timestamped dataset should be sorted by `timestamp_canonical`, using source
 stream order internally as a stable tie breaker. For very large files, the
@@ -259,73 +259,77 @@ analysis/logs/DT_2p0V_000000-unpacker-summary.json
 ```
 
 The summary JSON file is the sole saved detailed result for that raw TPX3 file.
-It contains information calculated by the unpacker and does not repeat the
-unpacker program, raw input path, raw input byte count, shared analysis
+It contains information calculated by the unpacker, including the raw byte
+count. It does not repeat the unpacker program, raw input path, shared analysis
 directory, summary filename, or overall HERMES unpacking status.
 
 The summary should have this structure:
 
 ```yaml
 unpacking:
+  bytes_read: 0
   chunks_read: 0
   packets_read: 0
-  decoded_pixel_hits: 0
-  decoded_tdc_triggers: 0
-  decoded_global_timestamps: 0
-  decoded_spidr_control_packets: 0
-  decoded_tpx3_control_packets: 0
-  decoded_unknown_packets: 0
-  warnings: []
+  pixel_data_packets: 0
+  tdc_timestamps: 0
+  heartbeat_packets: 0
+  spidr_control_packets: 0
+  tpx3_control_packets: 0
+  unrecognized_packets: 0
+  tdc1_rising: 0
+  tdc1_falling: 0
+  tdc2_rising: 0
+  tdc2_falling: 0
+  unknown_tdc_edges: 0
   errors: []
+  warnings: []
 
 timestamp_processing:
-  anchors:
-    total: 0
-    unpaired_low: 0
-    unpaired_high: 0
-    warnings: []
-  epoch_assignment:
-    pixels_assigned: 0
-    tdc_triggers_assigned: 0
-    controls_assigned: 0
-    ambiguous_timestamps: 0
-    unresolved_timestamps: 0
-    used_fallback: false
-    warnings: []
+  heartbeat_pairs:
+    number_of_beats: 0
+  time_adjustments:
+    pixel_packets: 0
+    tdc_packets: 0
+    control_packets: 0
+    failed: 0
 
 sorting:
-  method: in_memory
+  strategy: in_memory
   memory_budget_bytes: 0
   estimated_memory_bytes: 0
   temporary_runs_created: 0
 
 parquet:
-  pixel_hits:
+  pixel_data:
     row_count: 1200000
     files:
       - pixelHits/DT_2p0V_000000-chip-0-part-00000.parquet
       - pixelHits/DT_2p0V_000000-chip-0-part-00001.parquet
-  tdc_triggers:
+  tdc_timestamps:
     row_count: 0
     files: []
-  global_timestamps:
+  heartbeat_packets:
     row_count: 0
     files: []
   control_packets:
     row_count: 0
     files: []
-  unknown_packets:
+  unrecognized_packets:
     row_count: 0
     files: []
   errors: []
 
 processing_times_seconds:
+  canonical_time_seconds: 2.0345e-12
   unpacking: 0.0
-  epoch_assignment: 0.0
-  conversion: 0.0
+  canonical_conversion: 0.0
+  time_adjustments: 0.0
   sorting: 0.0
   parquet_writing: 0.0
   total: 0.0
+  throughput:
+    packets_per_second: 0.0
+    megabytes_per_second: 0.0
 ```
 
 All five category entries are required, including categories with no rows. The
@@ -335,10 +339,19 @@ a different input. Paths are relative to the shared analysis directory and
 begin with their category directory, so the directory is not repeated in
 another field. The file count is calculated from `len(files)` and is not saved.
 
-Decoded packet counts and Parquet row counts both remain because they describe
-different processing stages. A decoded packet may be rejected before a
+Unpacked packet counts and Parquet row counts both remain because they describe
+different processing stages. An unpacked packet may be rejected before a
 Parquet row is written. Warnings and errors remain in the section that produced
-them.
+them. `canonical_time_seconds` records the duration of one canonical tick:
+`25 ns / 12288`, or about `2.0345 ps`. Throughput uses the total processing
+time, with megabytes calculated as `1,000,000` bytes.
+
+The TDC edge counts show how the unpacked timestamps divide between TDC1 and
+TDC2 rising and falling edges. `heartbeat_pairs.number_of_beats` reports the
+paired heartbeat timestamps used for time adjustment. The `time_adjustments`
+counts show how many pixel, TDC, and control packets received adjusted times
+and how many adjustments failed. `sorting.strategy` is either `in_memory` or
+`external_merge`.
 
 Write the summary only after every final Parquet file closes successfully.
 
@@ -346,7 +359,7 @@ Write the summary only after every final Parquet file closes successfully.
 
 Photon reconstruction is a separate analysis step, not a required part of the
 unpacker. A user-selected photon reconstruction backend should read the
-`pixel_hits` Parquet files and write photon Parquet files. Possible C++ and Rust
+`pixel_data` Parquet files and write photon Parquet files. Possible C++ and Rust
 versions should be grouped under:
 
 ```text
@@ -355,10 +368,11 @@ backends/photon-reconstructors/<name>/
 └── rust/
 ```
 
-The purpose of photon clustering is to group adjacent pixel hits that likely came
-from one photon entering the image intensifier and producing a phosphor response
-across multiple TPX3 pixels. A first clustering pass should be configurable and
-should save its full settings in the summary and HERMES state.
+The purpose of photon clustering is to group adjacent pixel-data rows that
+likely came from one photon entering the image intensifier and producing a
+phosphor response across multiple TPX3 pixels. A first clustering pass should
+be configurable and should save its full settings in the summary and HERMES
+state.
 
 Important clustering parameters include:
 
@@ -374,7 +388,7 @@ Important clustering parameters include:
 The photon output directory should contain two Parquet file groups:
 
 - `photon_events`: one row per reconstructed photon candidate
-- `photon_pixels`: membership rows linking source pixel hits to photon candidates
+- `photon_pixels`: membership rows linking source pixel data to photon candidates
 
 `photon_events` should be a minimal event table with only the reconstructed
 photon coordinates and signal values:
@@ -401,7 +415,7 @@ HERMES state, or optional diagnostic tables.
 - `timestamp_canonical`
 
 The HERMES state should save the photon-clustering settings, run status,
-pixel-hit input directory, photon-event output directory, photon-pixel output
+pixel-data input directory, photon-event output directory, photon-pixel output
 directory, program version, photon counts, warnings, and errors.
 
 ## Event Reconstruction

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -313,11 +313,11 @@ def _validate_completed_files(
 
     analysis_root = analysis_directory.resolve()
     categories = (
-        ("pixelHits", summary.parquet.pixel_hits, True),  # includes chip ID
-        ("tdcTriggers", summary.parquet.tdc_triggers, False),  # no chip ID
-        ("globalTimestamps", summary.parquet.global_timestamps, False),
+        ("pixelHits", summary.parquet.pixel_data, True),  # includes chip ID
+        ("tdcTriggers", summary.parquet.tdc_timestamps, False),  # no chip ID
+        ("globalTimestamps", summary.parquet.heartbeat_packets, False),
         ("controlPackets", summary.parquet.control_packets, False),
-        ("unknownPackets", summary.parquet.unknown_packets, False),
+        ("unknownPackets", summary.parquet.unrecognized_packets, False),
     )
     listed_files: set[Path] = set()
     filename_pattern_with_chip = re.compile(

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -9,7 +9,7 @@ from pydantic import Field, model_validator
 from hermes.state.models.shared_models import FileReference, StrictBaseModel
 
 AnalysisRunStatus = Literal["planned", "running", "completed", "failed"]
-SortingMethod = Literal["in_memory", "external_merge"]
+SortingStrategy = Literal["in_memory", "external_merge"]
 
 
 class Tpx3SpidrUnpackerProgram(StrictBaseModel):
@@ -57,42 +57,42 @@ class HermesTpx3AnalysisState(StrictBaseModel):
 
 
 class Tpx3SpidrUnpackingSummary(StrictBaseModel):
+    bytes_read: int = Field(ge=0)
     chunks_read: int = Field(ge=0)
     packets_read: int = Field(ge=0)
-    decoded_pixel_hits: int = Field(ge=0)
-    decoded_tdc_triggers: int = Field(ge=0)
-    decoded_global_timestamps: int = Field(ge=0)
-    decoded_spidr_control_packets: int = Field(ge=0)
-    decoded_tpx3_control_packets: int = Field(ge=0)
-    decoded_unknown_packets: int = Field(ge=0)
-    warnings: list[str]
+    pixel_data_packets: int = Field(ge=0)
+    tdc_timestamps: int = Field(ge=0)
+    heartbeat_packets: int = Field(ge=0)
+    spidr_control_packets: int = Field(ge=0)
+    tpx3_control_packets: int = Field(ge=0)
+    unrecognized_packets: int = Field(ge=0)
+    tdc1_rising: int = Field(ge=0)
+    tdc1_falling: int = Field(ge=0)
+    tdc2_rising: int = Field(ge=0)
+    tdc2_falling: int = Field(ge=0)
+    unknown_tdc_edges: int = Field(ge=0)
     errors: list[str]
-
-
-class Tpx3SpidrAnchorSummary(StrictBaseModel):
-    total: int = Field(ge=0)
-    unpaired_low: int = Field(ge=0)
-    unpaired_high: int = Field(ge=0)
     warnings: list[str]
 
 
-class Tpx3SpidrEpochAssignmentSummary(StrictBaseModel):
-    pixels_assigned: int = Field(ge=0)
-    tdc_triggers_assigned: int = Field(ge=0)
-    controls_assigned: int = Field(ge=0)
-    ambiguous_timestamps: int = Field(ge=0)
-    unresolved_timestamps: int = Field(ge=0)
-    used_fallback: bool
-    warnings: list[str]
+class Tpx3SpidrHeartbeatPairsSummary(StrictBaseModel):
+    number_of_beats: int = Field(ge=0)
+
+
+class Tpx3SpidrTimeAdjustmentsSummary(StrictBaseModel):
+    pixel_packets: int = Field(ge=0)
+    tdc_packets: int = Field(ge=0)
+    control_packets: int = Field(ge=0)
+    failed: int = Field(ge=0)
 
 
 class Tpx3SpidrTimestampProcessingSummary(StrictBaseModel):
-    anchors: Tpx3SpidrAnchorSummary
-    epoch_assignment: Tpx3SpidrEpochAssignmentSummary
+    heartbeat_pairs: Tpx3SpidrHeartbeatPairsSummary
+    time_adjustments: Tpx3SpidrTimeAdjustmentsSummary
 
 
 class Tpx3SpidrSortingSummary(StrictBaseModel):
-    method: SortingMethod
+    strategy: SortingStrategy
     memory_budget_bytes: int = Field(ge=0)
     estimated_memory_bytes: int = Field(ge=0)
     temporary_runs_created: int = Field(ge=0)
@@ -112,21 +112,21 @@ class Tpx3SpidrParquetCategorySummary(StrictBaseModel):
 
 
 class Tpx3SpidrParquetSummary(StrictBaseModel):
-    pixel_hits: Tpx3SpidrParquetCategorySummary
-    tdc_triggers: Tpx3SpidrParquetCategorySummary
-    global_timestamps: Tpx3SpidrParquetCategorySummary
+    pixel_data: Tpx3SpidrParquetCategorySummary
+    tdc_timestamps: Tpx3SpidrParquetCategorySummary
+    heartbeat_packets: Tpx3SpidrParquetCategorySummary
     control_packets: Tpx3SpidrParquetCategorySummary
-    unknown_packets: Tpx3SpidrParquetCategorySummary
+    unrecognized_packets: Tpx3SpidrParquetCategorySummary
     errors: list[str]
 
     @model_validator(mode="after")
     def require_category_relative_paths(self) -> Tpx3SpidrParquetSummary:
         expected_directories = {
-            "pixel_hits": "pixelHits",
-            "tdc_triggers": "tdcTriggers",
-            "global_timestamps": "globalTimestamps",
+            "pixel_data": "pixelHits",
+            "tdc_timestamps": "tdcTriggers",
+            "heartbeat_packets": "globalTimestamps",
             "control_packets": "controlPackets",
-            "unknown_packets": "unknownPackets",
+            "unrecognized_packets": "unknownPackets",
         }
         for field_name, expected_directory in expected_directories.items():
             category = getattr(self, field_name)
@@ -144,13 +144,20 @@ class Tpx3SpidrParquetSummary(StrictBaseModel):
         return self
 
 
+class Tpx3SpidrThroughputSummary(StrictBaseModel):
+    packets_per_second: float = Field(ge=0)
+    megabytes_per_second: float = Field(ge=0)
+
+
 class Tpx3SpidrProcessingTimesSummary(StrictBaseModel):
+    canonical_time_seconds: float = Field(gt=0)
     unpacking: float = Field(ge=0)
-    epoch_assignment: float = Field(ge=0)
-    conversion: float = Field(ge=0)
+    canonical_conversion: float = Field(ge=0)
+    time_adjustments: float = Field(ge=0)
     sorting: float = Field(ge=0)
     parquet_writing: float = Field(ge=0)
     total: float = Field(ge=0)
+    throughput: Tpx3SpidrThroughputSummary
 
 
 class Tpx3SpidrSummary(StrictBaseModel):

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -107,58 +107,63 @@ def _summary(raw_stem: str, *, pixel_rows: int = 0) -> Tpx3SpidrSummary:
     return Tpx3SpidrSummary.model_validate(
         {
             "unpacking": {
+                "bytes_read": 0,
                 "chunks_read": 0,
                 "packets_read": pixel_rows,
-                "decoded_pixel_hits": pixel_rows,
-                "decoded_tdc_triggers": 0,
-                "decoded_global_timestamps": 0,
-                "decoded_spidr_control_packets": 0,
-                "decoded_tpx3_control_packets": 0,
-                "decoded_unknown_packets": 0,
-                "warnings": [],
+                "pixel_data_packets": pixel_rows,
+                "tdc_timestamps": 0,
+                "heartbeat_packets": 0,
+                "spidr_control_packets": 0,
+                "tpx3_control_packets": 0,
+                "unrecognized_packets": 0,
+                "tdc1_rising": 0,
+                "tdc1_falling": 0,
+                "tdc2_rising": 0,
+                "tdc2_falling": 0,
+                "unknown_tdc_edges": 0,
                 "errors": [],
+                "warnings": [],
             },
             "timestamp_processing": {
-                "anchors": {
-                    "total": 0,
-                    "unpaired_low": 0,
-                    "unpaired_high": 0,
-                    "warnings": [],
+                "heartbeat_pairs": {
+                    "number_of_beats": 0,
                 },
-                "epoch_assignment": {
-                    "pixels_assigned": pixel_rows,
-                    "tdc_triggers_assigned": 0,
-                    "controls_assigned": 0,
-                    "ambiguous_timestamps": 0,
-                    "unresolved_timestamps": 0,
-                    "used_fallback": False,
-                    "warnings": [],
+                "time_adjustments": {
+                    "pixel_packets": pixel_rows,
+                    "tdc_packets": 0,
+                    "control_packets": 0,
+                    "failed": 0,
                 },
             },
             "sorting": {
-                "method": "in_memory",
+                "strategy": "in_memory",
                 "memory_budget_bytes": 0,
                 "estimated_memory_bytes": 0,
                 "temporary_runs_created": 0,
             },
             "parquet": {
-                "pixel_hits": {
+                "pixel_data": {
                     "row_count": pixel_rows,
                     "files": pixel_files,
                 },
-                "tdc_triggers": {"row_count": 0, "files": []},
-                "global_timestamps": {"row_count": 0, "files": []},
+                "tdc_timestamps": {"row_count": 0, "files": []},
+                "heartbeat_packets": {"row_count": 0, "files": []},
                 "control_packets": {"row_count": 0, "files": []},
-                "unknown_packets": {"row_count": 0, "files": []},
+                "unrecognized_packets": {"row_count": 0, "files": []},
                 "errors": [],
             },
             "processing_times_seconds": {
+                "canonical_time_seconds": 2.0345e-12,
                 "unpacking": 0,
-                "epoch_assignment": 0,
-                "conversion": 0,
+                "canonical_conversion": 0,
+                "time_adjustments": 0,
                 "sorting": 0,
                 "parquet_writing": 0,
                 "total": 0,
+                "throughput": {
+                    "packets_per_second": 0,
+                    "megabytes_per_second": 0,
+                },
             },
         }
     )
@@ -171,7 +176,7 @@ def _save_completed_files(
     pixel_rows: int = 0,
 ) -> None:
     summary = _summary(raw_file.path.stem, pixel_rows=pixel_rows)
-    for relative_path in summary.parquet.pixel_hits.files:
+    for relative_path in summary.parquet.pixel_data.files:
         parquet_path = analysis.analysis_directory / relative_path
         parquet_path.parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(pa.table({"value": [1]}), parquet_path)
@@ -242,64 +247,69 @@ def _write_fake_unpacker(executable: Path) -> None:
         row_count = 2 if mode == "row_mismatch" else 1
         summary = {{
             "unpacking": {{
+                "bytes_read": 16,
                 "chunks_read": 1,
                 "packets_read": 1,
-                "decoded_pixel_hits": 1,
-                "decoded_tdc_triggers": 0,
-                "decoded_global_timestamps": 0,
-                "decoded_spidr_control_packets": 0,
-                "decoded_tpx3_control_packets": 0,
-                "decoded_unknown_packets": 0,
-                "warnings": ["test warning"],
+                "pixel_data_packets": 1,
+                "tdc_timestamps": 0,
+                "heartbeat_packets": 0,
+                "spidr_control_packets": 0,
+                "tpx3_control_packets": 0,
+                "unrecognized_packets": 0,
+                "tdc1_rising": 0,
+                "tdc1_falling": 0,
+                "tdc2_rising": 0,
+                "tdc2_falling": 0,
+                "unknown_tdc_edges": 0,
                 "errors": (
                     ["test unpacking error"]
                     if mode == "unpacking_errors"
                     else []
                 ),
+                "warnings": ["test warning"],
             }},
             "timestamp_processing": {{
-                "anchors": {{
-                    "total": 0,
-                    "unpaired_low": 0,
-                    "unpaired_high": 0,
-                    "warnings": [],
+                "heartbeat_pairs": {{
+                    "number_of_beats": 0,
                 }},
-                "epoch_assignment": {{
-                    "pixels_assigned": 1,
-                    "tdc_triggers_assigned": 0,
-                    "controls_assigned": 0,
-                    "ambiguous_timestamps": 0,
-                    "unresolved_timestamps": 0,
-                    "used_fallback": False,
-                    "warnings": [],
+                "time_adjustments": {{
+                    "pixel_packets": 1,
+                    "tdc_packets": 0,
+                    "control_packets": 0,
+                    "failed": 0,
                 }},
             }},
             "sorting": {{
-                "method": "in_memory",
+                "strategy": "in_memory",
                 "memory_budget_bytes": 1000,
                 "estimated_memory_bytes": 100,
                 "temporary_runs_created": 0,
             }},
             "parquet": {{
-                "pixel_hits": {{
+                "pixel_data": {{
                     "row_count": row_count,
                     "files": [str(relative_parquet)],
                 }},
-                "tdc_triggers": {{"row_count": 0, "files": []}},
-                "global_timestamps": {{"row_count": 0, "files": []}},
+                "tdc_timestamps": {{"row_count": 0, "files": []}},
+                "heartbeat_packets": {{"row_count": 0, "files": []}},
                 "control_packets": {{"row_count": 0, "files": []}},
-                "unknown_packets": {{"row_count": 0, "files": []}},
+                "unrecognized_packets": {{"row_count": 0, "files": []}},
                 "errors": (
                     ["test Parquet error"] if mode == "summary_errors" else []
                 ),
             }},
             "processing_times_seconds": {{
+                "canonical_time_seconds": 2.0345e-12,
                 "unpacking": 0.1,
-                "epoch_assignment": 0.1,
-                "conversion": 0.1,
+                "canonical_conversion": 0.1,
+                "time_adjustments": 0.1,
                 "sorting": 0.1,
                 "parquet_writing": 0.1,
                 "total": 0.5,
+                "throughput": {{
+                    "packets_per_second": 2.0,
+                    "megabytes_per_second": 0.000032,
+                }},
             }},
         }}
         summary_path.write_text(json.dumps(summary), encoding="utf-8")
@@ -546,9 +556,9 @@ def test_run_executes_fake_unpacker_logs_details_and_round_trips_yaml(
     assert completed["extra"]["exit_code"] == 0
     assert len(completed["extra"]["stdout_excerpt"]) == 4_000
     assert len(completed["extra"]["stderr_excerpt"]) == 4_000
-    assert completed["extra"]["summary"]["unpacking"]["decoded_pixel_hits"] == 1
-    assert completed["extra"]["summary"]["sorting"]["method"] == "in_memory"
-    assert completed["extra"]["summary"]["parquet"]["pixel_hits"][
+    assert completed["extra"]["summary"]["unpacking"]["pixel_data_packets"] == 1
+    assert completed["extra"]["summary"]["sorting"]["strategy"] == "in_memory"
+    assert completed["extra"]["summary"]["parquet"]["pixel_data"][
         "row_count"
     ] == 1
 

--- a/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
@@ -100,11 +100,11 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
         listed_paths = {
             relative_path
             for category in (
-                summary.parquet.pixel_hits,
-                summary.parquet.tdc_triggers,
-                summary.parquet.global_timestamps,
+                summary.parquet.pixel_data,
+                summary.parquet.tdc_timestamps,
+                summary.parquet.heartbeat_packets,
                 summary.parquet.control_packets,
-                summary.parquet.unknown_packets,
+                summary.parquet.unrecognized_packets,
             )
             for relative_path in category.files
         }
@@ -123,7 +123,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     assert all(not summary.unpacking.errors for summary in summaries)
     assert all(not summary.parquet.errors for summary in summaries)
     assert sum(
-        summary.parquet.pixel_hits.row_count for summary in summaries
+        summary.parquet.pixel_data.row_count for summary in summaries
     ) > 0
 
     saved_analysis = completed_state.analysis.model_dump(mode="json")

--- a/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
+++ b/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
@@ -42,60 +42,65 @@ def _analysis_state(tmp_path: Path, *raw_names: str) -> HermesTpx3AnalysisState:
 def _summary_data() -> dict[str, object]:
     return {
         "unpacking": {
+            "bytes_read": 24,
             "chunks_read": 2,
             "packets_read": 3,
-            "decoded_pixel_hits": 1,
-            "decoded_tdc_triggers": 0,
-            "decoded_global_timestamps": 0,
-            "decoded_spidr_control_packets": 0,
-            "decoded_tpx3_control_packets": 0,
-            "decoded_unknown_packets": 0,
-            "warnings": [],
+            "pixel_data_packets": 1,
+            "tdc_timestamps": 0,
+            "heartbeat_packets": 0,
+            "spidr_control_packets": 0,
+            "tpx3_control_packets": 0,
+            "unrecognized_packets": 0,
+            "tdc1_rising": 0,
+            "tdc1_falling": 0,
+            "tdc2_rising": 0,
+            "tdc2_falling": 0,
+            "unknown_tdc_edges": 0,
             "errors": [],
+            "warnings": [],
         },
         "timestamp_processing": {
-            "anchors": {
-                "total": 0,
-                "unpaired_low": 0,
-                "unpaired_high": 0,
-                "warnings": [],
+            "heartbeat_pairs": {
+                "number_of_beats": 0,
             },
-            "epoch_assignment": {
-                "pixels_assigned": 1,
-                "tdc_triggers_assigned": 0,
-                "controls_assigned": 0,
-                "ambiguous_timestamps": 0,
-                "unresolved_timestamps": 0,
-                "used_fallback": True,
-                "warnings": [],
+            "time_adjustments": {
+                "pixel_packets": 1,
+                "tdc_packets": 0,
+                "control_packets": 0,
+                "failed": 0,
             },
         },
         "sorting": {
-            "method": "in_memory",
+            "strategy": "in_memory",
             "memory_budget_bytes": 1_000_000,
             "estimated_memory_bytes": 128,
             "temporary_runs_created": 0,
         },
         "parquet": {
-            "pixel_hits": {
+            "pixel_data": {
                 "row_count": 1,
                 "files": [
                     "pixelHits/raw-chip-0-part-00000.parquet",
                 ],
             },
-            "tdc_triggers": {"row_count": 0, "files": []},
-            "global_timestamps": {"row_count": 0, "files": []},
+            "tdc_timestamps": {"row_count": 0, "files": []},
+            "heartbeat_packets": {"row_count": 0, "files": []},
             "control_packets": {"row_count": 0, "files": []},
-            "unknown_packets": {"row_count": 0, "files": []},
+            "unrecognized_packets": {"row_count": 0, "files": []},
             "errors": [],
         },
         "processing_times_seconds": {
+            "canonical_time_seconds": 2.0345e-12,
             "unpacking": 0.1,
-            "epoch_assignment": 0.2,
-            "conversion": 0.3,
+            "canonical_conversion": 0.3,
+            "time_adjustments": 0.2,
             "sorting": 0.4,
             "parquet_writing": 0.5,
             "total": 1.5,
+            "throughput": {
+                "packets_per_second": 2.0,
+                "megabytes_per_second": 3.0,
+            },
         },
     }
 
@@ -165,20 +170,25 @@ def test_empty_reconstruction_model_rejects_undefined_fields() -> None:
 def test_summary_validates_every_section() -> None:
     summary = Tpx3SpidrSummary.model_validate(_summary_data())
 
-    assert summary.unpacking.decoded_pixel_hits == 1
-    assert summary.timestamp_processing.epoch_assignment.used_fallback is True
-    assert summary.sorting.method == "in_memory"
-    assert summary.parquet.pixel_hits.row_count == 1
-    assert summary.parquet.pixel_hits.files == [
+    assert summary.unpacking.pixel_data_packets == 1
+    assert summary.timestamp_processing.time_adjustments.pixel_packets == 1
+    assert summary.sorting.strategy == "in_memory"
+    assert summary.parquet.pixel_data.row_count == 1
+    assert summary.parquet.pixel_data.files == [
         Path("pixelHits/raw-chip-0-part-00000.parquet")
     ]
+    assert summary.processing_times_seconds.canonical_time_seconds == 2.0345e-12
+    assert (
+        summary.processing_times_seconds.throughput.packets_per_second
+        == 2.0
+    )
     assert summary.processing_times_seconds.total == 1.5
 
 
 @pytest.mark.parametrize(
     ("section", "field"),
     [
-        ("unpacking", "decoded_pixel_hits"),
+        ("unpacking", "pixel_data_packets"),
         ("sorting", "estimated_memory_bytes"),
         ("processing_times_seconds", "total"),
     ],
@@ -216,11 +226,11 @@ def test_summary_rejects_invalid_pixel_parquet_paths(file_path: str) -> None:
     summary_data = _summary_data()
     parquet = summary_data["parquet"]
     assert isinstance(parquet, dict)
-    pixel_hits = parquet["pixel_hits"]
-    assert isinstance(pixel_hits, dict)
-    pixel_hits["files"] = [file_path]
+    pixel_data = parquet["pixel_data"]
+    assert isinstance(pixel_data, dict)
+    pixel_data["files"] = [file_path]
 
-    with pytest.raises(ValidationError, match="pixel_hits Parquet paths"):
+    with pytest.raises(ValidationError, match="pixel_data Parquet paths"):
         Tpx3SpidrSummary.model_validate(summary_data)
 
 
@@ -238,10 +248,10 @@ def test_summary_requires_parquet_files_to_match_saved_rows(
     summary_data = _summary_data()
     parquet = summary_data["parquet"]
     assert isinstance(parquet, dict)
-    pixel_hits = parquet["pixel_hits"]
-    assert isinstance(pixel_hits, dict)
-    pixel_hits["row_count"] = row_count
-    pixel_hits["files"] = files
+    pixel_data = parquet["pixel_data"]
+    assert isinstance(pixel_data, dict)
+    pixel_data["row_count"] = row_count
+    pixel_data["files"] = files
 
     with pytest.raises(ValidationError, match="category"):
         Tpx3SpidrSummary.model_validate(summary_data)


### PR DESCRIPTION
This pull request refactors and clarifies the naming and structure of packet statistics, diagnostics output, and JSON summary generation in the TPX3-SPIDR unpacker backend. The changes improve the consistency and clarity of variable names, the structure of JSON output, and ensure all code and tests use the updated terminology.

**Refactoring and renaming for clarity:**

* Renamed several fields in `UnpackSummary` and throughout the codebase for clarity and specificity: e.g., `pixel_hit_count` → `pixel_data_packet_count`, `tdc_hit_count` → `tdc_timestamp_count`, `global_timestamp_count` → `heartbeat_packet_count`, and `unknown_packet_count` → `unrecognized_packet_count`. [[1]](diffhunk://#diff-030e876aa152b610f3d507435a1551c5e33652020ca8470a8c0cf1076e6c9a98L140-R149) [[2]](diffhunk://#diff-030e876aa152b610f3d507435a1551c5e33652020ca8470a8c0cf1076e6c9a98L166-R166) [[3]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbL85-R85) [[4]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbL153-R153) [[5]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbL184-R184) [[6]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbL277-R277) [[7]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbL473-R473) [[8]](diffhunk://#diff-6048d641dd393c721023b1284703680d92464cbd7155840fb35f9543ef07f2ecL12-R21) [[9]](diffhunk://#diff-6048d641dd393c721023b1284703680d92464cbd7155840fb35f9543ef07f2ecL37-R37)

* Updated all related test cases and diagnostics output to use the new field names, ensuring consistency across the codebase. [[1]](diffhunk://#diff-b5b46f0cfe48066d38f81f77f050b81c4066b38e4861cf02f8dcb0a96f3bb2b6L14-R14) [[2]](diffhunk://#diff-d39cd46c394c4f0ae852b3607119b4b4d0db3f1b4cbea8e2efe237542e4e9e57L117-R117) [[3]](diffhunk://#diff-d39cd46c394c4f0ae852b3607119b4b4d0db3f1b4cbea8e2efe237542e4e9e57L144-R144) [[4]](diffhunk://#diff-3f49eb46f3a15c18c6e9aa30a5172fc37f2930df55b6e9c78b3ecfed6168bc76L147-R147) [[5]](diffhunk://#diff-b457fa99482537753d82acb7990ea3bd2cbdaccdbf4a326b209989dbd98b80bbL124-R128)

**Improvements to JSON summary output:**

* Switched to using `nlohmann::ordered_json` for deterministic JSON field ordering.
* Reorganized and renamed keys in the JSON summary output to match the new field names and provide greater clarity (e.g., `pixel_data_packets`, `tdc_timestamps`, `heartbeat_packets`, `unrecognized_packets`).
* Added throughput metrics (`packets_per_second`, `megabytes_per_second`) and clarified time-related fields in the processing times section of the JSON output.

**Test and workflow updates:**

* Updated test assertions and expected JSON output to match the new field names and JSON structure. [[1]](diffhunk://#diff-b5b46f0cfe48066d38f81f77f050b81c4066b38e4861cf02f8dcb0a96f3bb2b6L14-R14) [[2]](diffhunk://#diff-d39cd46c394c4f0ae852b3607119b4b4d0db3f1b4cbea8e2efe237542e4e9e57L117-R117) [[3]](diffhunk://#diff-d39cd46c394c4f0ae852b3607119b4b4d0db3f1b4cbea8e2efe237542e4e9e57L144-R144) [[4]](diffhunk://#diff-3f49eb46f3a15c18c6e9aa30a5172fc37f2930df55b6e9c78b3ecfed6168bc76L147-R147) [[5]](diffhunk://#diff-b457fa99482537753d82acb7990ea3bd2cbdaccdbf4a326b209989dbd98b80bbL124-R128)

These changes collectively improve the maintainability and clarity of the codebase and output formats.