### PR TITLE
36 record integration

### DIFF
--- a/backends/unpackers/tpx3-spidr/cpp/inc/parquet_writer.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/parquet_writer.h
@@ -14,6 +14,7 @@ struct ParquetWriterConfig {
     std::string raw_file_stem;
     std::uint64_t rows_per_part = 1000000;
     std::uint8_t chip_index = 0;
+    bool overwrite = false;
 };
 
 struct ParquetCategoryFiles {

--- a/backends/unpackers/tpx3-spidr/cpp/inc/summary_json.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/summary_json.h
@@ -30,7 +30,8 @@ struct SummaryJsonContent {
 std::string generateSummaryJson(const SummaryJsonContent& content);
 
 void writeSummaryJsonFile(const std::string& output_path,
-                          const SummaryJsonContent& content);
+                          const SummaryJsonContent& content,
+                          bool overwrite = false);
 
 }  // namespace hermes_tpx3_spidr
 

--- a/backends/unpackers/tpx3-spidr/cpp/inc/unpacker.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/unpacker.h
@@ -30,7 +30,8 @@ struct WorkflowResult {
 
 WorkflowResult runTwoPassWorkflow(std::istream& input,
                                   const std::string& source_file_path,
-                                  const std::string& analysis_directory);
+                                  const std::string& analysis_directory,
+                                  bool overwrite = false);
 
 }  // namespace hermes_tpx3_spidr
 

--- a/backends/unpackers/tpx3-spidr/cpp/src/parquet_writer.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/parquet_writer.cpp
@@ -345,7 +345,7 @@ void writeRowsToParquet(
         const std::string relative_path = category.directory + "/" + filename;
         const std::string full_path = config.analysis_directory + "/" + relative_path;
 
-        if (std::filesystem::exists(full_path)) {
+        if (!config.overwrite && std::filesystem::exists(full_path)) {
             errors.push_back("Refusing to overwrite existing Parquet file " +
                              full_path);
             return;

--- a/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
@@ -109,8 +109,9 @@ std::string generateSummaryJson(const SummaryJsonContent& content) {
 }
 
 void writeSummaryJsonFile(const std::string& output_path,
-                          const SummaryJsonContent& content) {
-    if (std::filesystem::exists(output_path)) {
+                          const SummaryJsonContent& content,
+                          const bool overwrite) {
+    if (!overwrite && std::filesystem::exists(output_path)) {
         throw std::runtime_error(
             "Refusing to overwrite existing summary JSON file");
     }

--- a/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
@@ -1,6 +1,8 @@
 #include <fstream>
 #include <iostream>
 #include <cstring>
+#include <string>
+#include <vector>
 
 #include "diagnostics.h"
 #include "unpacker.h"
@@ -13,8 +15,9 @@ void printHelp(const char* program_name) {
     std::cout << "  <input.tpx3>        Input TPX3 raw data file\n";
     std::cout << "  [analysis_directory]  Shared directory for analysis files\n\n";
     std::cout << "Options:\n";
-    std::cout << "  -h, --help     Show this help message\n";
-    std::cout << "  -v, --version  Show version information\n\n";
+    std::cout << "  -h, --help       Show this help message\n";
+    std::cout << "  -v, --version    Show version information\n";
+    std::cout << "      --overwrite  Overwrite existing summary and Parquet files\n\n";
     std::cout << "Output Modes:\n";
     std::cout << "  Without analysis_directory:\n";
     std::cout << "    Prints summary statistics to stdout\n\n";
@@ -40,37 +43,44 @@ void printVersion() {
 }  // namespace
 
 int main(const int argc, char* argv[]) {
-    // Handle help and version flags
-    if (argc == 2) {
-        if (std::strcmp(argv[1], "-h") == 0 || std::strcmp(argv[1], "--help") == 0) {
+    // Separate options from positional arguments.
+    bool overwrite = false;
+    std::vector<std::string> positionals;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
             printHelp(argv[0]);
             return 0;
         }
-        if (std::strcmp(argv[1], "-v") == 0 || std::strcmp(argv[1], "--version") == 0) {
+        if (std::strcmp(argv[i], "-v") == 0 || std::strcmp(argv[i], "--version") == 0) {
             printVersion();
             return 0;
         }
+        if (std::strcmp(argv[i], "--overwrite") == 0) {
+            overwrite = true;
+            continue;
+        }
+        positionals.emplace_back(argv[i]);
     }
 
-    if (argc < 2 || argc > 3) {
+    if (positionals.empty() || positionals.size() > 2) {
         std::cerr << "Error: Invalid number of arguments\n\n";
         std::cerr << "Usage: " << argv[0] << " [OPTIONS] <input.tpx3> [analysis_directory]\n";
         std::cerr << "Try '" << argv[0] << " --help' for more information.\n";
         return 2;
     }
 
-    const std::string input_path = argv[1];
+    const std::string input_path = positionals[0];
     std::ifstream input(input_path, std::ios::binary);
     if (!input) {
-        std::cerr << "Unable to open TPX3 input file: " << argv[1] << '\n';
+        std::cerr << "Unable to open TPX3 input file: " << input_path << '\n';
         return 2;
     }
 
-    if (argc == 3) {
+    if (positionals.size() == 2) {
         // Two-pass workflow with output
-        const std::string output_dir = argv[2];
+        const std::string output_dir = positionals[1];
         const auto result = hermes_tpx3_spidr::runTwoPassWorkflow(
-            input, input_path, output_dir);
+            input, input_path, output_dir, overwrite);
 
         if (!result.success) {
             std::cerr << "Workflow failed with errors:\n";

--- a/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
@@ -486,7 +486,8 @@ UnpackResult unpack(std::istream& input) {
 
 WorkflowResult runTwoPassWorkflow(std::istream& input,
                                   const std::string& source_file_path,
-                                  const std::string& analysis_directory) {
+                                  const std::string& analysis_directory,
+                                  const bool overwrite) {
     using Clock = std::chrono::high_resolution_clock;
     using Duration = std::chrono::duration<double>;
 
@@ -508,16 +509,18 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
     const auto summary_path = std::filesystem::path(analysis_directory) /
                               summary_json_file;
 
-    try {
-        findExistingOutputFiles(analysis_directory, raw_file_stem,
-                                summary_path, workflow_result.errors);
-    } catch (const std::exception& error) {
-        workflow_result.errors.push_back(
-            "Failed to check existing analysis files: " +
-            std::string(error.what()));
-    }
-    if (!workflow_result.errors.empty()) {
-        return workflow_result;
+    if (!overwrite) {
+        try {
+            findExistingOutputFiles(analysis_directory, raw_file_stem,
+                                    summary_path, workflow_result.errors);
+        } catch (const std::exception& error) {
+            workflow_result.errors.push_back(
+                "Failed to check existing analysis files: " +
+                std::string(error.what()));
+        }
+        if (!workflow_result.errors.empty()) {
+            return workflow_result;
+        }
     }
 
     // Pass 1: Unpack and decode all packets
@@ -614,6 +617,7 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
     writer_config.analysis_directory = analysis_directory;
     writer_config.raw_file_stem = raw_file_stem;
     writer_config.chip_index = 0;  // Single chip for now
+    writer_config.overwrite = overwrite;
 
     writePixelHitsParquet(output_rows.pixels, writer_config, writer_diag);
     writeTdcTriggersParquet(output_rows.tdcs, writer_config, writer_diag);
@@ -633,7 +637,8 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
 
     if (writer_diag.errors.empty()) {
         try {
-            writeSummaryJsonFile(summary_path.string(), workflow_result.summary);
+            writeSummaryJsonFile(summary_path.string(), workflow_result.summary,
+                                 overwrite);
         } catch (const std::exception& error) {
             workflow_result.errors.push_back(
                 "Failed to write summary JSON file " + summary_path.string() +

--- a/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
@@ -509,18 +509,41 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
     const auto summary_path = std::filesystem::path(analysis_directory) /
                               summary_json_file;
 
-    if (!overwrite) {
-        try {
-            findExistingOutputFiles(analysis_directory, raw_file_stem,
-                                    summary_path, workflow_result.errors);
-        } catch (const std::exception& error) {
-            workflow_result.errors.push_back(
-                "Failed to check existing analysis files: " +
-                std::string(error.what()));
+    try {
+        if (overwrite) {
+            std::filesystem::remove(summary_path);
+            const std::string parquet_prefix_with_chip = raw_file_stem + "-chip-";
+            const std::string parquet_prefix_without_chip = raw_file_stem + "-part-";
+            for (const char* directory_name : parquet_directories) {
+                const auto directory =
+                    std::filesystem::path(analysis_directory) / directory_name;
+                if (!std::filesystem::exists(directory)) {
+                    continue;
+                }
+
+                for (const auto& entry : std::filesystem::directory_iterator(directory)) {
+                    if (!entry.is_regular_file() || entry.path().extension() != ".parquet") {
+                        continue;
+                    }
+                    const auto filename = entry.path().filename().string();
+                    if (filename.rfind(parquet_prefix_with_chip, 0) == 0 ||
+                        filename.rfind(parquet_prefix_without_chip, 0) == 0) {
+                        std::filesystem::remove(entry.path());
+                    }
+                }
+            }
+        } else {
+            findExistingOutputFiles(analysis_directory, raw_file_stem, summary_path,
+                                    workflow_result.errors);
         }
-        if (!workflow_result.errors.empty()) {
-            return workflow_result;
-        }
+    } catch (const std::exception& error) {
+        workflow_result.errors.push_back(
+            std::string(overwrite ? "Failed to remove existing analysis files: "
+                                  : "Failed to check existing analysis files: ") +
+            error.what());
+    }
+    if (!workflow_result.errors.empty()) {
+        return workflow_result;
     }
 
     // Pass 1: Unpack and decode all packets

--- a/docs/architecture/state-model.md
+++ b/docs/architecture/state-model.md
@@ -107,6 +107,35 @@ Pydantic supplies `acquisition: null`, `resource_limit_percent: 90`, planned
 unpacking results, and `None` for the optional unpacker version and optional raw
 TPX3 file information.
 
+### Raw TPX3 file input
+
+`HermesTpx3AnalysisState.tpx3_files` accepts an explicit list:
+
+```yaml
+tpx3_files:
+  - path: data/raw/run_001.tpx3
+  - path: data/raw/run_002.tpx3
+```
+
+User-authored YAML may instead name a text file:
+
+```yaml
+tpx3_files:
+  file_list: data/raw/raw_tpx3_files.txt
+```
+
+The text file contains one raw TPX3 file path per line. Empty lines and lines
+whose first non-whitespace character is `#` are ignored. The `file_list` path
+follows the existing YAML path behavior and is interpreted from the process
+working directory. Relative raw TPX3 paths inside the text file are resolved
+from the text file's directory.
+
+Pydantic expands the text file into the existing `list[FileReference]` before
+the rest of `HermesTpx3AnalysisState` is validated. Missing, unreadable, and
+empty text files fail validation. Duplicate raw TPX3 filename stems remain
+rejected. Saving the HERMES record always writes the expanded explicit
+`tpx3_files` list and does not save `file_list`.
+
 ### Current required/default review
 
 - `HermesRecord.measurement_info` and `HermesRecord.environment` are required.

--- a/docs/architecture/state-model.md
+++ b/docs/architecture/state-model.md
@@ -43,6 +43,94 @@ practical for user-authored run inputs. JSON may still be supported as an
 optional export format for tools that need strict machine-readable records, but
 the Pydantic `HermesRecord` schema remains the authoritative field definition.
 
+## Loading a Partial HermesRecord from YAML
+
+`HermesRecord` is the top-level Pydantic model for a user-authored HERMES YAML
+file. `load_hermes_record_from_yaml()` safely parses the file and validates the
+result directly with `HermesRecord.model_validate()`.
+
+The YAML may omit a field only when its Pydantic model declares a default or a
+`default_factory`. Pydantic applies these defaults recursively in supplied
+nested models. A field without a declared default remains required; the YAML
+loader must not guess a value for it.
+
+All HERMES state models reject unknown fields. When an `analysis` or
+`acquisition` section is supplied, users should include its `mode`. The mode
+selects the program-specific Pydantic model. In particular, `analysis.mode` is
+required for Pydantic to choose between HERMES and EMPIR analysis.
+
+Loading only validates and returns a `HermesRecord`. It must not start
+acquisition, analysis, or any other workflow. Later changes to the loaded record
+must go through `StateManager`.
+
+Saving a loaded record writes the complete Pydantic model, including values
+that came from defaults. The user-authored input YAML and the final saved HERMES
+record should be separate files.
+
+The smallest current YAML record supplies the required measurement fields and
+the required top-level environment. The empty environment receives its nested
+defaults:
+
+```yaml
+measurement_info:
+  measurement_id: example-run
+  run_number: 1
+
+environment: {}
+```
+
+This loads with a default `RuntimeEnvironment` and with both `acquisition` and
+`analysis` set to `None`.
+
+A partial HERMES analysis record supplies only required analysis information
+and values that intentionally differ from defaults:
+
+```yaml
+measurement_info:
+  measurement_id: example-tpx3-unpacking
+  run_number: 1
+
+environment:
+  working_dir: data/examples/analysis/unpacker
+
+analysis:
+  mode: hermes
+  unpacker_program:
+    name: tpx3-spidr-cpp
+    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+  analysis_directory: data/examples/analysis/unpacker/analysis
+  tpx3_files:
+    - path: tests/data/Example_1kHz_5frames.tpx3
+```
+
+Pydantic supplies `acquisition: null`, `resource_limit_percent: 90`, planned
+unpacking results, and `None` for the optional unpacker version and optional raw
+TPX3 file information.
+
+### Current required/default review
+
+- `HermesRecord.measurement_info` and `HermesRecord.environment` are required.
+- `MeasurementInfo.measurement_id` and `MeasurementInfo.run_number` are
+  required. Its other fields have defaults.
+- Every `RuntimeEnvironment` field has a default. Its `working_dir` defaults to
+  the current directory and is marked required and resolved.
+- `HermesTpx3AnalysisState.unpacker_program`, `analysis_directory`, and
+  `tpx3_files` are required. `tpx3_files` must contain at least one entry.
+- `HermesTpx3AnalysisState.resource_limit_percent`, `photon_reconstruction`,
+  and `results` have defaults. Nested unpacking results default to `planned`.
+- `Tpx3SpidrUnpackerProgram.name` and `executable_path` are required; `version`
+  defaults to `None`.
+- `FileReference.path` is required; its file information fields default to
+  `None`.
+
+There is one current difference between the intended mode rule and the source
+models. `analysis` is a discriminated union, so a supplied analysis section
+fails validation without `mode`. `acquisition` currently names only
+`ServalAcquisitionState`, whose `mode` field defaults to `serval`; Pydantic
+therefore currently accepts an acquisition section without `mode`. Supporting
+multiple acquisition programs will require making acquisition mode selection
+explicit. No model change is part of this documentation stage.
+
 ## Expected model groups ###
 Expected model groups and their responsibilities include:
 - MeasurementInfo: metadata about the measurement, including measurement ID, run number, beamline, proposal ID, image intensifier serial number, scintillator serial number, sample name, operator name, log notes, and any other relevant metadata fields that are important for provenance and record-keeping.

--- a/docs/architecture/state-service.md
+++ b/docs/architecture/state-service.md
@@ -99,6 +99,14 @@ The `src/hermes/state_service/` module is organized into several key components:
     - parses YAML safely, validates loaded data through the Pydantic
       `HermesRecord` model, and writes predictable YAML without relying on
       advanced YAML features such as anchors.
+    - accepts partial user-authored YAML: fields with declared Pydantic defaults
+      may be omitted, while fields without defaults remain required.
+    - rejects unknown fields through the strict HERMES state models.
+    - only loads or saves a record; it does not start acquisition, analysis, or
+      any other workflow.
+    - writes the complete validated record when saving, including values supplied
+      by Pydantic defaults. A workflow should save this final record separately
+      from the user-authored input YAML.
     - may support JSON import/export as a secondary machine-readable format, but
       YAML is the primary persisted run-record format.
     - functions include:

--- a/examples/analysis/unpacker_multiple_files/README.md
+++ b/examples/analysis/unpacker_multiple_files/README.md
@@ -1,19 +1,23 @@
 # HERMES TPX3 Unpacker: Multiple Files Example
 
-This example demonstrates unpacking multiple raw TPX3 files using the HERMES
-unpacker with resource-aware parallel execution.
+This example loads a partial user-authored YAML file as a `HermesRecord` and
+runs the state-managed HERMES C++ unpacker over several raw TPX3 files with
+resource-aware parallel execution.
 
 ## Input Files
 
-The example unpacks all TPX3 files found in `data/list_tests/`:
+The example is self-contained. Before unpacking, `run_unpacker_mf.py` copies the
+checked-in `tests/data/Example_1kHz_5frames.tpx3` file five times into
+`data/multiFileExample/`:
 
 - `Example_1kHz_5frames_0000.tpx3`
 - `Example_1kHz_5frames_0001.tpx3`
 - `Example_1kHz_5frames_0002.tpx3`
 - `Example_1kHz_5frames_0003.tpx3`
+- `Example_1kHz_5frames_0004.tpx3`
 
-Each file is 348,128 bytes and contains identical data. The unique filename
-stems ensure that output files do not collide.
+Each copy contains identical data. The unique filename stems ensure that output
+files do not collide. This means a fresh clone needs no extra data setup.
 
 ## Building the Unpacker
 
@@ -27,19 +31,17 @@ This creates the executable at `build/backends/tpx3-spidr/hermes-tpx3-spidr`.
 
 ## Running the Example
 
-### Fresh Run
-
-To unpack all four files with a clean output directory:
+Run the checked-in `unpacker_mf_config.yaml`:
 
 ```bash
-rm -rf data/examples/analysis/unpacker_multiple_files/analysis
 pixi run python examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
 ```
 
 This will:
-1. Find and sort all TPX3 files in `data/list_tests/`
-2. Create a HERMES analysis state with `resource_limit_percent=90`
-3. Run the unpacker for each file using the public `run_hermes_analysis()` runner
+1. Create `data/multiFileExample/` and write the five raw TPX3 copies
+2. Load and validate `unpacker_mf_config.yaml` as a `HermesRecord`
+3. Run the unpacker for each file using the public `run_hermes_analysis()`
+   runner with `resource_limit_percent=90`
 4. Write Parquet files under shared directories:
    - `pixelHits/`
    - `tdcTriggers/`
@@ -47,30 +49,61 @@ This will:
    - `controlPackets/`
    - `unknownPackets/`
 5. Write one summary JSON file per input under `analysis/logs/`
-6. Save the final HERMES state to `hermes-record.yaml`
+6. Save the completed HERMES state to `hermes-record_final.yaml`
+
+To use another YAML file, supply its path as the first argument:
+
+```bash
+pixi run python examples/analysis/unpacker_multiple_files/run_unpacker_mf.py \
+  /path/to/unpacker_config.yaml
+```
 
 ### Repeat Run
 
-To verify that existing output is skipped:
+Running the example again validates every summary and listed Parquet file and
+skips all five inputs without launching any unpacker process:
 
 ```bash
 pixi run python examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
 ```
 
-The example validates every summary and listed Parquet file and skips all four
-inputs without launching any unpacker process.
+### Overwriting Existing Output
+
+By default, files that have already been unpacked are skipped. To re-unpack
+every file and overwrite the previously written summary and Parquet files in
+place, pass `--overwrite`:
+
+```bash
+pixi run python examples/analysis/unpacker_multiple_files/run_unpacker_mf.py \
+  --overwrite
+```
+
+## YAML fields
+
+The checked-in `unpacker_mf_config.yaml` lists the five raw TPX3 files directly
+under `analysis.tpx3_files`. The YAML must contain:
+
+- `measurement_info.measurement_id`
+- `measurement_info.run_number`
+- `environment`
+- `analysis.mode: hermes`
+- `analysis.unpacker_program.name`
+- `analysis.unpacker_program.executable_path`
+- `analysis.analysis_directory`
+- at least one entry in `analysis.tpx3_files`
 
 ## Output Structure
 
 ```text
 data/examples/analysis/unpacker_multiple_files/
-├── hermes-record.yaml
+├── hermes-record_final.yaml
 └── analysis/
     ├── pixelHits/
     │   ├── Example_1kHz_5frames_0000-chip-0-part-00000.parquet
     │   ├── Example_1kHz_5frames_0001-chip-0-part-00000.parquet
     │   ├── Example_1kHz_5frames_0002-chip-0-part-00000.parquet
-    │   └── Example_1kHz_5frames_0003-chip-0-part-00000.parquet
+    │   ├── Example_1kHz_5frames_0003-chip-0-part-00000.parquet
+    │   └── Example_1kHz_5frames_0004-chip-0-part-00000.parquet
     ├── tdcTriggers/
     │   └── ...
     ├── globalTimestamps/
@@ -83,14 +116,15 @@ data/examples/analysis/unpacker_multiple_files/
         ├── Example_1kHz_5frames_0000-unpacker-summary.json
         ├── Example_1kHz_5frames_0001-unpacker-summary.json
         ├── Example_1kHz_5frames_0002-unpacker-summary.json
-        └── Example_1kHz_5frames_0003-unpacker-summary.json
+        ├── Example_1kHz_5frames_0003-unpacker-summary.json
+        └── Example_1kHz_5frames_0004-unpacker-summary.json
 ```
 
 Each Parquet filename begins with its raw TPX3 filename stem. Each summary JSON
-file is the sole detailed result for its raw TPX3 file. The HERMES state file
-records the overall unpacking status, start time, finish time, and resource
-limit percentage, but does not duplicate per-file packet counts or Parquet row
-counts.
+file is the sole detailed result for its raw TPX3 file. The `hermes-record_final.yaml`
+file records the complete validated `HermesRecord`, including the overall
+unpacking status, start time, finish time, and resource limit percentage, but
+does not duplicate per-file packet counts or Parquet row counts.
 
 ## Resource Limit
 
@@ -98,6 +132,5 @@ The example sets `resource_limit_percent=90` to demonstrate the default resource
 dial. This limits the scheduled unpacker worker count to 90% of the system's
 physical CPU cores and available memory.
 
-The resource limit is saved in the HERMES YAML file and used for every run. To
-change the limit, modify the value in `run_unpacker_mf.py` or edit the saved
-`hermes-record.yaml` file before the next run.
+The resource limit is read from `unpacker_mf_config.yaml` and used for every
+run. To change the limit, edit the value in the YAML file before the next run.

--- a/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
+++ b/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import argparse
 import shutil
-import sys
 from pathlib import Path
 from typing import cast
 
@@ -23,10 +23,22 @@ DEFAULT_INPUT_YAML_PATH = Path(__file__).with_name("unpacker_mf_config.yaml")
 
 
 def prepare_example_input_files() -> None:
+    """Prepare example input files by copying the source TPX3 file multiple times.
+    
+    Creates NUMBER_OF_COPIES copies of the source TPX3 file in the example
+    input directory with sequential naming.
+    
+    Raises:
+        FileNotFoundError: If the source TPX3 file does not exist.
+    """
+    # Verify that the source file exists before attempting to copy
     if not SOURCE_TPX3_FILE.is_file():
         raise FileNotFoundError(f"Source TPX3 file not found: {SOURCE_TPX3_FILE}")
 
+    # Create the example input directory if it doesn't exist
     EXAMPLE_INPUT_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    
+    # Create multiple copies of the source file with sequential indices
     for index in range(NUMBER_OF_COPIES):
         destination = (
             EXAMPLE_INPUT_DIRECTORY / f"Example_1kHz_5frames_{index:04d}.tpx3"
@@ -34,26 +46,44 @@ def prepare_example_input_files() -> None:
         shutil.copyfile(SOURCE_TPX3_FILE, destination)
 
 
-def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
+def main(
+    input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH,
+    *,
+    overwrite: bool = False,
+) -> None:
+    
+    # Step 1: Prepare example input files by copying the source TPX3 file multiple times
     prepare_example_input_files()
 
+    # Step 2: Load the initial HERMES record from the configuration YAML file
     initial_record = load_hermes_record_from_yaml(input_yaml_path)
+    
+    # Step 3: Extract the working directory path where outputs will be stored
     working_directory = cast(
         Path,
         initial_record.environment.working_dir.resolved_path,
     )
     final_record_path = working_directory / "hermes-record_final.yaml"
 
+    # Step 4: Initialize the state manager with the initial record
+    # This manages the state throughout the analysis workflow
     state_manager = StateManager(
         initial_record,
         config=StateServiceConfig(allow_trusted_workflow_bypass=True),
     )
 
-    unpacked_raw_files = run_hermes_analysis(state_manager)
+    # Step 5: Run the HERMES analysis on all TPX3 files
+    # Returns a list of files that were actually unpacked (not skipped)
+    unpacked_raw_files = run_hermes_analysis(state_manager, overwrite=overwrite)
+    
+    # Step 6: Get the final state after analysis completes
     final_record = state_manager.get_state()
     hermes_analysis = cast(HermesTpx3AnalysisState, final_record.analysis)
+    
+    # Step 7: Save the final HERMES record to a YAML file for future reference
     save_hermes_record_to_yaml(final_record, final_record_path)
 
+    # Step 8: Display analysis summary and results
     print(f"Raw TPX3 files: {len(hermes_analysis.tpx3_files)}")
     for raw_tpx3_file in hermes_analysis.tpx3_files:
         print(f"  - {raw_tpx3_file.path}")
@@ -67,9 +97,18 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 2:
-        raise SystemExit(f"Usage: {Path(sys.argv[0]).name} [YAML_PATH]")
-    input_yaml_path = (
-        Path(sys.argv[1]) if len(sys.argv) == 2 else DEFAULT_INPUT_YAML_PATH
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "yaml_path",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_INPUT_YAML_PATH,
+        help="HERMES record YAML config (defaults to unpacker_mf_config.yaml)",
     )
-    main(input_yaml_path)
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="re-unpack every file, overwriting previously unpacked outputs",
+    )
+    args = parser.parse_args()
+    main(args.yaml_path, overwrite=args.overwrite)

--- a/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
+++ b/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 from typing import cast
@@ -13,10 +14,29 @@ from hermes.state_service.state_io import (
 )
 from hermes.state_service.state_manager import StateManager
 
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+SOURCE_TPX3_FILE = REPOSITORY_ROOT / "tests/data/Example_1kHz_5frames.tpx3"
+EXAMPLE_INPUT_DIRECTORY = REPOSITORY_ROOT / "data/multiFileExample"
+NUMBER_OF_COPIES = 5
+
 DEFAULT_INPUT_YAML_PATH = Path(__file__).with_name("unpacker_mf_config.yaml")
 
 
+def prepare_example_input_files() -> None:
+    if not SOURCE_TPX3_FILE.is_file():
+        raise FileNotFoundError(f"Source TPX3 file not found: {SOURCE_TPX3_FILE}")
+
+    EXAMPLE_INPUT_DIRECTORY.mkdir(parents=True, exist_ok=True)
+    for index in range(NUMBER_OF_COPIES):
+        destination = (
+            EXAMPLE_INPUT_DIRECTORY / f"Example_1kHz_5frames_{index:04d}.tpx3"
+        )
+        shutil.copyfile(SOURCE_TPX3_FILE, destination)
+
+
 def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
+    prepare_example_input_files()
+
     initial_record = load_hermes_record_from_yaml(input_yaml_path)
     working_directory = cast(
         Path,

--- a/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
+++ b/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
@@ -1,81 +1,55 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from typing import cast
 
 from hermes.analysis.hermes.run import run_hermes_analysis
-from hermes.state.models.analysis.hermes_tpx3_spidr import (
-    HermesTpx3AnalysisState,
-    Tpx3SpidrUnpackerProgram,
-)
-from hermes.state.models.environment import RuntimeEnvironment
-from hermes.state.models.measurement import MeasurementInfo
-from hermes.state.models.shared_models import FileReference
-from hermes.state.state import HermesRecord
+from hermes.state.models.analysis.hermes_tpx3_spidr import HermesTpx3AnalysisState
 from hermes.state_service.shared_types import StateServiceConfig
-from hermes.state_service.state_io import save_hermes_record_to_yaml
+from hermes.state_service.state_io import (
+    load_hermes_record_from_yaml,
+    save_hermes_record_to_yaml,
+)
 from hermes.state_service.state_manager import StateManager
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
-RAW_TPX3_DIRECTORY = REPOSITORY_ROOT / "data/list_tests"
-UNPACKER_EXECUTABLE = (
-    REPOSITORY_ROOT / "build/backends/tpx3-spidr/hermes-tpx3-spidr"
-)
-EXAMPLE_DIRECTORY = (
-    REPOSITORY_ROOT / "data/examples/analysis/unpacker_multiple_files"
-)
-ANALYSIS_DIRECTORY = EXAMPLE_DIRECTORY / "analysis"
-HERMES_STATE_FILE = EXAMPLE_DIRECTORY / "hermes-record.yaml"
+DEFAULT_INPUT_YAML_PATH = Path(__file__).with_name("unpacker_mf_config.yaml")
 
 
-def main() -> None:
-    raw_tpx3_files = sorted(RAW_TPX3_DIRECTORY.glob("*.tpx3"))
-
-    if not raw_tpx3_files:
-        raise FileNotFoundError(
-            f"No TPX3 files found in directory: {RAW_TPX3_DIRECTORY}"
-        )
-
-    if not UNPACKER_EXECUTABLE.is_file():
-        raise FileNotFoundError(
-            "C++ unpacker not found. Run `pixi run build-cpp-unpacker` first: "
-            f"{UNPACKER_EXECUTABLE}"
-        )
-
-    print(f"Found {len(raw_tpx3_files)} TPX3 files:")
-    for tpx3_file in raw_tpx3_files:
-        print(f"  - {tpx3_file.name}")
-
-    analysis = HermesTpx3AnalysisState(
-        unpacker_program=Tpx3SpidrUnpackerProgram(
-            name="tpx3-spidr-cpp",
-            executable_path=UNPACKER_EXECUTABLE,
-            version="0.1.0",
-        ),
-        analysis_directory=ANALYSIS_DIRECTORY,
-        tpx3_files=[FileReference(path=f) for f in raw_tpx3_files],
-        resource_limit_percent=90,
+def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
+    initial_record = load_hermes_record_from_yaml(input_yaml_path)
+    working_directory = cast(
+        Path,
+        initial_record.environment.working_dir.resolved_path,
     )
+    final_record_path = working_directory / "hermes-record_final.yaml"
+
     state_manager = StateManager(
-        HermesRecord(
-            measurement_info=MeasurementInfo(
-                measurement_id="example-tpx3-unpacking-multiple-files",
-                run_number=1,
-            ),
-            environment=RuntimeEnvironment(working_dir=EXAMPLE_DIRECTORY),
-            acquisition=None,
-            analysis=analysis,
-        ),
+        initial_record,
         config=StateServiceConfig(allow_trusted_workflow_bypass=True),
     )
 
-    unpacked_files = run_hermes_analysis(state_manager)
-    save_hermes_record_to_yaml(state_manager.get_state(), HERMES_STATE_FILE)
+    unpacked_raw_files = run_hermes_analysis(state_manager)
+    final_record = state_manager.get_state()
+    hermes_analysis = cast(HermesTpx3AnalysisState, final_record.analysis)
+    save_hermes_record_to_yaml(final_record, final_record_path)
 
-    print(f"\nUnpacked: {len(unpacked_files)} files")
-    print(f"Skipped: {len(raw_tpx3_files) - len(unpacked_files)} files")
-    print(f"Analysis directory: {ANALYSIS_DIRECTORY}")
-    print(f"HERMES state file: {HERMES_STATE_FILE}")
+    print(f"Raw TPX3 files: {len(hermes_analysis.tpx3_files)}")
+    for raw_tpx3_file in hermes_analysis.tpx3_files:
+        print(f"  - {raw_tpx3_file.path}")
+    print(f"Unpacked this run: {len(unpacked_raw_files)}")
+    print(
+        "Skipped existing valid outputs: "
+        f"{len(hermes_analysis.tpx3_files) - len(unpacked_raw_files)}"
+    )
+    print(f"Analysis directory: {hermes_analysis.analysis_directory}")
+    print(f"HERMES state file: {final_record_path}")
 
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) > 2:
+        raise SystemExit(f"Usage: {Path(sys.argv[0]).name} [YAML_PATH]")
+    input_yaml_path = (
+        Path(sys.argv[1]) if len(sys.argv) == 2 else DEFAULT_INPUT_YAML_PATH
+    )
+    main(input_yaml_path)

--- a/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
+++ b/examples/analysis/unpacker_multiple_files/run_unpacker_mf.py
@@ -51,9 +51,8 @@ def main(
     *,
     overwrite: bool = False,
 ) -> None:
-    
-    # Step 1: Prepare example input files by copying the source TPX3 file multiple times
-    prepare_example_input_files()
+    if input_yaml_path == DEFAULT_INPUT_YAML_PATH:
+        prepare_example_input_files()
 
     # Step 2: Load the initial HERMES record from the configuration YAML file
     initial_record = load_hermes_record_from_yaml(input_yaml_path)

--- a/examples/analysis/unpacker_multiple_files/unpacker_mf_config.yaml
+++ b/examples/analysis/unpacker_multiple_files/unpacker_mf_config.yaml
@@ -13,7 +13,8 @@ analysis:
   analysis_directory: data/examples/analysis/unpacker_multiple_files/analysis
   resource_limit_percent: 90
   tpx3_files:
-    - path: data/list_tests/Example_1kHz_5frames_0000.tpx3
-    - path: data/list_tests/Example_1kHz_5frames_0001.tpx3
-    - path: data/list_tests/Example_1kHz_5frames_0002.tpx3
-    - path: data/list_tests/Example_1kHz_5frames_0003.tpx3
+    - path: data/multiFileExample/Example_1kHz_5frames_0000.tpx3
+    - path: data/multiFileExample/Example_1kHz_5frames_0001.tpx3
+    - path: data/multiFileExample/Example_1kHz_5frames_0002.tpx3
+    - path: data/multiFileExample/Example_1kHz_5frames_0003.tpx3
+    - path: data/multiFileExample/Example_1kHz_5frames_0004.tpx3

--- a/examples/analysis/unpacker_multiple_files/unpacker_mf_config.yaml
+++ b/examples/analysis/unpacker_multiple_files/unpacker_mf_config.yaml
@@ -1,0 +1,19 @@
+measurement_info:
+  measurement_id: example-tpx3-unpacking-multiple-files
+  run_number: 1
+
+environment:
+  working_dir: data/examples/analysis/unpacker_multiple_files
+
+analysis:
+  mode: hermes
+  unpacker_program:
+    name: tpx3-spidr-cpp
+    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+  analysis_directory: data/examples/analysis/unpacker_multiple_files/analysis
+  resource_limit_percent: 90
+  tpx3_files:
+    - path: data/list_tests/Example_1kHz_5frames_0000.tpx3
+    - path: data/list_tests/Example_1kHz_5frames_0001.tpx3
+    - path: data/list_tests/Example_1kHz_5frames_0002.tpx3
+    - path: data/list_tests/Example_1kHz_5frames_0003.tpx3

--- a/examples/analysis/unpacker_single_file/README.md
+++ b/examples/analysis/unpacker_single_file/README.md
@@ -46,6 +46,43 @@ include:
 - optional unpacker version
 - optional raw TPX3 file information
 
+## Multiple raw TPX3 files
+
+List the files directly:
+
+```yaml
+tpx3_files:
+  - path: data/raw/run_001.tpx3
+  - path: data/raw/run_002.tpx3
+  - path: data/raw/run_003.tpx3
+```
+
+Or name a text file:
+
+```yaml
+tpx3_files:
+  file_list: data/raw/raw_tpx3_files.txt
+```
+
+The text file contains one path per line:
+
+```text
+# Relative to this text file's directory.
+run_001.tpx3
+run_002.tpx3
+run_003.tpx3
+```
+
+Blank lines and lines beginning with `#` are ignored. A relative path inside
+the text file is resolved from the text file's directory. The text file must
+exist and contain at least one raw TPX3 file path. Raw TPX3 filename stems must
+remain unique.
+
+The final `hermes-record_final.yaml` always contains the expanded
+`tpx3_files` list so it records the exact raw TPX3 files used. The command
+prints every configured raw TPX3 path and reports how many were unpacked or
+skipped.
+
 Unknown fields, missing required fields, invalid values, malformed YAML, and a
 missing analysis mode stop the example before analysis starts. A valid
 non-HERMES analysis record is rejected by the HERMES runner with an ERROR-level

--- a/examples/analysis/unpacker_single_file/README.md
+++ b/examples/analysis/unpacker_single_file/README.md
@@ -1,7 +1,8 @@
 # TPX3 SPIDR unpacker example
 
-This example runs the state-managed HERMES C++ unpacker on
-`tests/data/Example_1kHz_5frames.tpx3`.
+This example loads a partial user-authored YAML file as a `HermesRecord`, runs
+the state-managed HERMES C++ unpacker, and saves the completed record separately
+from the input YAML.
 
 Build the C++ executable:
 
@@ -9,18 +10,55 @@ Build the C++ executable:
 pixi run build-cpp-unpacker
 ```
 
-Run the example:
+Run the checked-in `unpacker_config.yaml`:
 
 ```bash
-pixi run python examples/analysis/unpacker/run_unpacker.py
+pixi run python examples/analysis/unpacker_single_file/run_unpacker.py
 ```
 
-The example writes persistent development output outside the tracked source
-tree:
+To use another YAML file, supply its path as the only argument:
+
+```bash
+pixi run python examples/analysis/unpacker_single_file/run_unpacker.py \
+  /path/to/unpacker_config.yaml
+```
+
+## YAML fields
+
+The YAML must contain:
+
+- `measurement_info.measurement_id`
+- `measurement_info.run_number`
+- `environment`
+- `analysis.mode: hermes`
+- `analysis.unpacker_program.name`
+- `analysis.unpacker_program.executable_path`
+- `analysis.analysis_directory`
+- at least one entry in `analysis.tpx3_files`
+
+The checked-in YAML omits values that already have Pydantic defaults. These
+include:
+
+- `acquisition: null`
+- `analysis.resource_limit_percent: 90`
+- unpacking status `planned`
+- optional photon reconstruction
+- optional unpacker version
+- optional raw TPX3 file information
+
+Unknown fields, missing required fields, invalid values, malformed YAML, and a
+missing analysis mode stop the example before analysis starts. A valid
+non-HERMES analysis record is rejected by the HERMES runner with an ERROR-level
+Loguru event.
+
+## Output
+
+The default YAML writes persistent development output outside the tracked
+source tree:
 
 ```text
 data/examples/analysis/unpacker/
-├── hermes-record.yaml
+├── hermes-record_final.yaml
 └── analysis/
     ├── pixelHits/
     ├── tdcTriggers/
@@ -31,5 +69,9 @@ data/examples/analysis/unpacker/
         └── Example_1kHz_5frames-unpacker-summary.json
 ```
 
+The input YAML remains unchanged. The final `hermes-record_final.yaml` contains
+the complete validated `HermesRecord`, including Pydantic defaults and the
+completed unpacking result.
+
 Running the example again validates the existing summary and Parquet files,
-skips unpacking, and refreshes the final HERMES YAML file.
+skips the valid raw TPX3 file, and refreshes the final HERMES YAML file.

--- a/examples/analysis/unpacker_single_file/run_unpacker.py
+++ b/examples/analysis/unpacker_single_file/run_unpacker.py
@@ -34,13 +34,14 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
     hermes_analysis = cast(HermesTpx3AnalysisState, final_record.analysis)
     save_hermes_record_to_yaml(final_record, final_record_path)
 
-    if unpacked_raw_files:
-        print(f"Unpacked: {hermes_analysis.tpx3_files[0].path}")
-    else:
-        print(
-            "Skipped existing valid output for: "
-            f"{hermes_analysis.tpx3_files[0].path}"
-        )
+    print(f"Raw TPX3 files: {len(hermes_analysis.tpx3_files)}")
+    for raw_tpx3_file in hermes_analysis.tpx3_files:
+        print(f"  - {raw_tpx3_file.path}")
+    print(f"Unpacked this run: {len(unpacked_raw_files)}")
+    print(
+        "Skipped existing valid outputs: "
+        f"{len(hermes_analysis.tpx3_files) - len(unpacked_raw_files)}"
+    )
     print(f"Analysis directory: {hermes_analysis.analysis_directory}")
     print(f"HERMES state file: {final_record_path}")
 

--- a/examples/analysis/unpacker_single_file/run_unpacker.py
+++ b/examples/analysis/unpacker_single_file/run_unpacker.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import cast
 
 from hermes.analysis.hermes.run import run_hermes_analysis
 from hermes.state.models.analysis.hermes_tpx3_spidr import HermesTpx3AnalysisState
@@ -17,24 +18,7 @@ DEFAULT_CONFIG_PATH = Path(__file__).with_name("unpacker_config.yaml")
 
 def main(config_path: Path = DEFAULT_CONFIG_PATH) -> None:
     record = load_hermes_record_from_yaml(config_path)
-    analysis = record.analysis
-    if not isinstance(analysis, HermesTpx3AnalysisState):
-        raise ValueError("the YAML file must contain a HERMES analysis section")
-
-    for raw_file in analysis.tpx3_files:
-        if not raw_file.path.is_file():
-            raise FileNotFoundError(f"TPX3 input file not found: {raw_file.path}")
-
-    executable_path = analysis.unpacker_program.executable_path
-    if not executable_path.is_file():
-        raise FileNotFoundError(
-            "C++ unpacker not found. Run `pixi run build-cpp-unpacker` first: "
-            f"{executable_path}"
-        )
-
-    working_dir = record.environment.working_dir.resolved_path
-    if working_dir is None:
-        raise ValueError("the HERMES working directory must be resolved")
+    working_dir = cast(Path, record.environment.working_dir.resolved_path)
     state_path = working_dir / "hermes-record.yaml"
     if config_path.resolve() == state_path.resolve():
         raise ValueError(
@@ -47,7 +31,9 @@ def main(config_path: Path = DEFAULT_CONFIG_PATH) -> None:
     )
 
     unpacked_files = run_hermes_analysis(state_manager)
-    save_hermes_record_to_yaml(state_manager.get_state(), state_path)
+    final_record = state_manager.get_state()
+    analysis = cast(HermesTpx3AnalysisState, final_record.analysis)
+    save_hermes_record_to_yaml(final_record, state_path)
 
     if unpacked_files:
         print(f"Unpacked: {analysis.tpx3_files[0].path}")

--- a/examples/analysis/unpacker_single_file/run_unpacker.py
+++ b/examples/analysis/unpacker_single_file/run_unpacker.py
@@ -1,73 +1,63 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from hermes.analysis.hermes.run import run_hermes_analysis
-from hermes.state.models.analysis.hermes_tpx3_spidr import (
-    HermesTpx3AnalysisState,
-    Tpx3SpidrUnpackerProgram,
-)
-from hermes.state.models.environment import RuntimeEnvironment
-from hermes.state.models.measurement import MeasurementInfo
-from hermes.state.models.shared_models import FileReference
-from hermes.state.state import HermesRecord
+from hermes.state.models.analysis.hermes_tpx3_spidr import HermesTpx3AnalysisState
 from hermes.state_service.shared_types import StateServiceConfig
-from hermes.state_service.state_io import save_hermes_record_to_yaml
+from hermes.state_service.state_io import (
+    load_hermes_record_from_yaml,
+    save_hermes_record_to_yaml,
+)
 from hermes.state_service.state_manager import StateManager
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
-RAW_TPX3_FILE = REPOSITORY_ROOT / "tests/data/Example_1kHz_5frames.tpx3"
-UNPACKER_EXECUTABLE = (
-    REPOSITORY_ROOT / "build/backends/tpx3-spidr/hermes-tpx3-spidr"
-)
-EXAMPLE_DIRECTORY = (
-    REPOSITORY_ROOT / "data/examples/analysis/unpacker"
-)
-ANALYSIS_DIRECTORY = EXAMPLE_DIRECTORY / "analysis"
-HERMES_STATE_FILE = EXAMPLE_DIRECTORY / "hermes-record.yaml"
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("unpacker_config.yaml")
 
 
-def main() -> None:
-    if not RAW_TPX3_FILE.is_file():
-        raise FileNotFoundError(f"TPX3 example file not found: {RAW_TPX3_FILE}")
-    if not UNPACKER_EXECUTABLE.is_file():
+def main(config_path: Path = DEFAULT_CONFIG_PATH) -> None:
+    record = load_hermes_record_from_yaml(config_path)
+    analysis = record.analysis
+    if not isinstance(analysis, HermesTpx3AnalysisState):
+        raise ValueError("the YAML file must contain a HERMES analysis section")
+
+    for raw_file in analysis.tpx3_files:
+        if not raw_file.path.is_file():
+            raise FileNotFoundError(f"TPX3 input file not found: {raw_file.path}")
+
+    executable_path = analysis.unpacker_program.executable_path
+    if not executable_path.is_file():
         raise FileNotFoundError(
             "C++ unpacker not found. Run `pixi run build-cpp-unpacker` first: "
-            f"{UNPACKER_EXECUTABLE}"
+            f"{executable_path}"
         )
 
-    analysis = HermesTpx3AnalysisState(
-        unpacker_program=Tpx3SpidrUnpackerProgram(
-            name="tpx3-spidr-cpp",
-            executable_path=UNPACKER_EXECUTABLE,
-            version="0.1.0",
-        ),
-        analysis_directory=ANALYSIS_DIRECTORY,
-        tpx3_files=[FileReference(path=RAW_TPX3_FILE)],
-    )
+    working_dir = record.environment.working_dir.resolved_path
+    if working_dir is None:
+        raise ValueError("the HERMES working directory must be resolved")
+    state_path = working_dir / "hermes-record.yaml"
+    if config_path.resolve() == state_path.resolve():
+        raise ValueError(
+            "the input YAML and final HERMES record must be separate files"
+        )
+
     state_manager = StateManager(
-        HermesRecord(
-            measurement_info=MeasurementInfo(
-                measurement_id="example-tpx3-unpacking",
-                run_number=1,
-            ),
-            environment=RuntimeEnvironment(working_dir=EXAMPLE_DIRECTORY),
-            acquisition=None,
-            analysis=analysis,
-        ),
+        record,
         config=StateServiceConfig(allow_trusted_workflow_bypass=True),
     )
 
     unpacked_files = run_hermes_analysis(state_manager)
-    save_hermes_record_to_yaml(state_manager.get_state(), HERMES_STATE_FILE)
+    save_hermes_record_to_yaml(state_manager.get_state(), state_path)
 
     if unpacked_files:
-        print(f"Unpacked: {RAW_TPX3_FILE}")
+        print(f"Unpacked: {analysis.tpx3_files[0].path}")
     else:
-        print(f"Skipped existing valid output for: {RAW_TPX3_FILE}")
-    print(f"Analysis directory: {ANALYSIS_DIRECTORY}")
-    print(f"HERMES state file: {HERMES_STATE_FILE}")
+        print(f"Skipped existing valid output for: {analysis.tpx3_files[0].path}")
+    print(f"Analysis directory: {analysis.analysis_directory}")
+    print(f"HERMES state file: {state_path}")
 
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) > 2:
+        raise SystemExit(f"Usage: {Path(sys.argv[0]).name} [YAML_PATH]")
+    main(Path(sys.argv[1]) if len(sys.argv) == 2 else DEFAULT_CONFIG_PATH)

--- a/examples/analysis/unpacker_single_file/run_unpacker.py
+++ b/examples/analysis/unpacker_single_file/run_unpacker.py
@@ -13,37 +13,42 @@ from hermes.state_service.state_io import (
 )
 from hermes.state_service.state_manager import StateManager
 
-DEFAULT_CONFIG_PATH = Path(__file__).with_name("unpacker_config.yaml")
+DEFAULT_INPUT_YAML_PATH = Path(__file__).with_name("unpacker_config.yaml")
 
 
-def main(config_path: Path = DEFAULT_CONFIG_PATH) -> None:
-    record = load_hermes_record_from_yaml(config_path)
-    working_dir = cast(Path, record.environment.working_dir.resolved_path)
-    state_path = working_dir / "hermes-record.yaml"
-    if config_path.resolve() == state_path.resolve():
-        raise ValueError(
-            "the input YAML and final HERMES record must be separate files"
-        )
+def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
+    initial_record = load_hermes_record_from_yaml(input_yaml_path)
+    working_directory = cast(
+        Path,
+        initial_record.environment.working_dir.resolved_path,
+    )
+    final_record_path = working_directory / "hermes-record_final.yaml"
 
     state_manager = StateManager(
-        record,
+        initial_record,
         config=StateServiceConfig(allow_trusted_workflow_bypass=True),
     )
 
-    unpacked_files = run_hermes_analysis(state_manager)
+    unpacked_raw_files = run_hermes_analysis(state_manager)
     final_record = state_manager.get_state()
-    analysis = cast(HermesTpx3AnalysisState, final_record.analysis)
-    save_hermes_record_to_yaml(final_record, state_path)
+    hermes_analysis = cast(HermesTpx3AnalysisState, final_record.analysis)
+    save_hermes_record_to_yaml(final_record, final_record_path)
 
-    if unpacked_files:
-        print(f"Unpacked: {analysis.tpx3_files[0].path}")
+    if unpacked_raw_files:
+        print(f"Unpacked: {hermes_analysis.tpx3_files[0].path}")
     else:
-        print(f"Skipped existing valid output for: {analysis.tpx3_files[0].path}")
-    print(f"Analysis directory: {analysis.analysis_directory}")
-    print(f"HERMES state file: {state_path}")
+        print(
+            "Skipped existing valid output for: "
+            f"{hermes_analysis.tpx3_files[0].path}"
+        )
+    print(f"Analysis directory: {hermes_analysis.analysis_directory}")
+    print(f"HERMES state file: {final_record_path}")
 
 
 if __name__ == "__main__":
     if len(sys.argv) > 2:
         raise SystemExit(f"Usage: {Path(sys.argv[0]).name} [YAML_PATH]")
-    main(Path(sys.argv[1]) if len(sys.argv) == 2 else DEFAULT_CONFIG_PATH)
+    input_yaml_path = (
+        Path(sys.argv[1]) if len(sys.argv) == 2 else DEFAULT_INPUT_YAML_PATH
+    )
+    main(input_yaml_path)

--- a/examples/analysis/unpacker_single_file/unpacker_config.yaml
+++ b/examples/analysis/unpacker_single_file/unpacker_config.yaml
@@ -1,0 +1,15 @@
+measurement_info:
+  measurement_id: example-tpx3-unpacking
+  run_number: 1
+
+environment:
+  working_dir: data/examples/analysis/unpacker
+
+analysis:
+  mode: hermes
+  unpacker_program:
+    name: tpx3-spidr-cpp
+    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+  analysis_directory: data/examples/analysis/unpacker/analysis
+  tpx3_files:
+    - path: tests/data/Example_1kHz_5frames.tpx3

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -145,7 +145,17 @@ def run_hermes_analysis(state_manager: StateManager) -> list[FileReference]:
     state = state_manager.get_state()
     analysis = state.analysis
     if not isinstance(analysis, HermesTpx3AnalysisState):
-        raise HermesAnalysisError("the saved analysis mode is not HERMES")
+        error = "the saved analysis mode is not HERMES"
+        _ANALYSIS_LOGGER.error(
+            "Cannot run HERMES analysis: {error}",
+            event_type="analysis.hermes.invalid_mode",
+            error=error,
+            measurement_id=state.measurement_info.measurement_id,
+            run_number=state.measurement_info.run_number,
+            expected_analysis_mode="hermes",
+            actual_analysis_mode=getattr(analysis, "mode", None),
+        )
+        raise HermesAnalysisError(error)
 
     try:
         unpacking_plan = plan_unpacking(analysis)

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -112,6 +112,8 @@ def _run_parallel_unpacking(
     analysis: HermesTpx3AnalysisState,
     files_to_run: list[FileReference],
     worker_count: int,
+    *,
+    overwrite: bool = False,
 ) -> list[FileReference]:
     """Run unpacker processes concurrently and return successfully unpacked files."""
     first_error: Exception | None = None
@@ -119,7 +121,9 @@ def _run_parallel_unpacking(
 
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
         future_to_index = {
-            executor.submit(execute_unpacker, analysis, raw_file): i
+            executor.submit(
+                execute_unpacker, analysis, raw_file, overwrite=overwrite
+            ): i
             for i, raw_file in enumerate(files_to_run)
         }
 
@@ -141,7 +145,11 @@ def _run_parallel_unpacking(
     return [files_to_run[i] for i in sorted(completed_files)]
 
 
-def run_hermes_analysis(state_manager: StateManager) -> list[FileReference]:
+def run_hermes_analysis(
+    state_manager: StateManager,
+    *,
+    overwrite: bool = False,
+) -> list[FileReference]:
     state = state_manager.get_state()
     analysis = state.analysis
     if not isinstance(analysis, HermesTpx3AnalysisState):
@@ -158,7 +166,7 @@ def run_hermes_analysis(state_manager: StateManager) -> list[FileReference]:
         raise HermesAnalysisError(error)
 
     try:
-        unpacking_plan = plan_unpacking(analysis)
+        unpacking_plan = plan_unpacking(analysis, overwrite=overwrite)
         files_to_run = [
             raw_file
             for raw_file, action in unpacking_plan
@@ -186,6 +194,7 @@ def run_hermes_analysis(state_manager: StateManager) -> list[FileReference]:
                 analysis,
                 files_to_run,
                 worker_count,
+                overwrite=overwrite,
             )
         else:
             unpacked_files = []

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -65,16 +65,25 @@ def derive_summary_path(
 def derive_unpacker_command(
     analysis: HermesTpx3AnalysisState,
     raw_file: FileReference,
+    *,
+    overwrite: bool = False,
 ) -> list[str]:
-    return [
-        str(analysis.unpacker_program.executable_path),
-        str(raw_file.path),
-        str(analysis.analysis_directory),
-    ]
+    command = [str(analysis.unpacker_program.executable_path)]
+    if overwrite:
+        command.append("--overwrite")
+    command.extend([str(raw_file.path), str(analysis.analysis_directory)])
+    return command
 
 
-def plan_unpacking(analysis: HermesTpx3AnalysisState) -> UnpackingPlan:
+def plan_unpacking(
+    analysis: HermesTpx3AnalysisState,
+    *,
+    overwrite: bool = False,
+) -> UnpackingPlan:
     _validate_program_and_inputs(analysis)
+
+    if overwrite:
+        return [(raw_file, "run") for raw_file in analysis.tpx3_files]
 
     plan: UnpackingPlan = []
     for raw_file in analysis.tpx3_files:
@@ -107,8 +116,10 @@ def plan_unpacking(analysis: HermesTpx3AnalysisState) -> UnpackingPlan:
 def execute_unpacker(
     analysis: HermesTpx3AnalysisState,
     raw_file: FileReference,
+    *,
+    overwrite: bool = False,
 ) -> Tpx3SpidrSummary:
-    command = derive_unpacker_command(analysis, raw_file)
+    command = derive_unpacker_command(analysis, raw_file, overwrite=overwrite)
     summary_path = derive_summary_path(analysis, raw_file)
     started = perf_counter()
     _ANALYSIS_LOGGER.info(

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -115,6 +115,49 @@ class HermesTpx3AnalysisState(StrictBaseModel):
         default_factory=HermesTpx3AnalysisResults
     )
 
+    @field_validator("tpx3_files", mode="before")
+    @classmethod
+    def expand_tpx3_file_list(cls, value: object) -> object:
+        if not isinstance(value, dict) or "file_list" not in value:
+            return value
+
+        if set(value) != {"file_list"}:
+            raise ValueError(
+                "the tpx3_files file-list form must contain only file_list"
+            )
+
+        file_list_value = value["file_list"]
+        if not isinstance(file_list_value, str | Path):
+            raise ValueError("tpx3_files.file_list must be a file path")
+
+        file_list_path = Path(file_list_value).expanduser().resolve(strict=False)
+        try:
+            lines = file_list_path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            raise ValueError(
+                f"cannot read raw TPX3 file list: {file_list_path}"
+            ) from exc
+
+        raw_tpx3_files: list[dict[str, Path]] = []
+        for line in lines:
+            entry = line.strip()
+            if not entry or entry.startswith("#"):
+                continue
+
+            raw_tpx3_path = Path(entry).expanduser()
+            if not raw_tpx3_path.is_absolute():
+                raw_tpx3_path = file_list_path.parent / raw_tpx3_path
+            raw_tpx3_files.append(
+                {"path": raw_tpx3_path.resolve(strict=False)}
+            )
+
+        if not raw_tpx3_files:
+            raise ValueError(
+                f"raw TPX3 file list contains no file paths: {file_list_path}"
+            )
+
+        return raw_tpx3_files
+
     @model_validator(mode="after")
     def validate_analysis_paths_and_inputs(self) -> HermesTpx3AnalysisState:
         stems = [raw_file.path.stem for raw_file in self.tpx3_files]

--- a/tests/unit/examples/analysis/test_unpacker_single_file.py
+++ b/tests/unit/examples/analysis/test_unpacker_single_file.py
@@ -145,5 +145,8 @@ analysis:
     assert isinstance(saved_final_record.analysis, HermesTpx3AnalysisState)
     assert saved_final_record.analysis.resource_limit_percent == 90
     assert str(raw_tpx3_file) in console_output
+    assert "Raw TPX3 files: 1" in console_output
+    assert "Unpacked this run: 1" in console_output
+    assert "Skipped existing valid outputs: 0" in console_output
     assert str(analysis_directory) in console_output
     assert str(final_record_path) in console_output

--- a/tests/unit/examples/analysis/test_unpacker_single_file.py
+++ b/tests/unit/examples/analysis/test_unpacker_single_file.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from hermes.state.models.analysis.hermes_tpx3_spidr import (
+    HermesTpx3AnalysisState,
+)
+from hermes.state.models.shared_models import FileReference
+from hermes.state_service.shared_types import StateIOError
+from hermes.state_service.state_io import load_hermes_record_from_yaml
+from hermes.state_service.state_manager import StateManager
+
+
+@pytest.fixture
+def run_unpacker_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    repository_root = Path(__file__).resolve().parents[4]
+    monkeypatch.syspath_prepend(str(repository_root))
+    return importlib.import_module(
+        "examples.analysis.unpacker_single_file.run_unpacker"
+    )
+
+
+def test_checked_in_partial_yaml_loads_with_expected_defaults(
+    run_unpacker_module: ModuleType,
+) -> None:
+    record = load_hermes_record_from_yaml(
+        run_unpacker_module.DEFAULT_CONFIG_PATH
+    )
+
+    assert record.measurement_info.measurement_id == "example-tpx3-unpacking"
+    assert record.environment.working_dir.path == Path(
+        "data/examples/analysis/unpacker"
+    )
+    assert record.acquisition is None
+    assert isinstance(record.analysis, HermesTpx3AnalysisState)
+    assert record.analysis.unpacker_program.executable_path == Path(
+        "build/backends/tpx3-spidr/hermes-tpx3-spidr"
+    )
+    assert record.analysis.analysis_directory == Path(
+        "data/examples/analysis/unpacker/analysis"
+    )
+    assert record.analysis.tpx3_files[0].path == Path(
+        "tests/data/Example_1kHz_5frames.tpx3"
+    )
+    assert record.analysis.resource_limit_percent == 90
+    assert record.analysis.unpacker_program.version is None
+    assert record.analysis.photon_reconstruction is None
+    assert record.analysis.results.unpacking.status == "planned"
+    assert record.analysis.results.reconstruction is None
+
+    raw_file = record.analysis.tpx3_files[0]
+    assert raw_file.media_type is None
+    assert raw_file.sha256 is None
+    assert raw_file.size_bytes is None
+    assert raw_file.created_at is None
+    assert raw_file.description is None
+
+
+def test_invalid_yaml_stops_before_analysis(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    run_unpacker_module: ModuleType,
+) -> None:
+    config_path = tmp_path / "invalid.yaml"
+    config_path.write_text("measurement_info: [", encoding="utf-8")
+
+    def fail_if_called(state_manager: StateManager) -> list[FileReference]:
+        raise AssertionError("analysis must not run for invalid YAML")
+
+    monkeypatch.setattr(
+        run_unpacker_module,
+        "run_hermes_analysis",
+        fail_if_called,
+    )
+
+    with pytest.raises(StateIOError, match="parse"):
+        run_unpacker_module.main(config_path)
+
+
+def test_main_preserves_input_and_saves_final_record_separately(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    run_unpacker_module: ModuleType,
+) -> None:
+    working_dir = tmp_path / "run"
+    analysis_directory = working_dir / "analysis"
+    raw_file = tmp_path / "input.tpx3"
+    executable = tmp_path / "hermes-tpx3-spidr"
+    config_path = tmp_path / "input.yaml"
+    raw_file.write_bytes(b"example")
+    executable.write_text("", encoding="utf-8")
+    config_path.write_text(
+        f"""
+measurement_info:
+  measurement_id: yaml-example
+  run_number: 1
+environment:
+  working_dir: {working_dir}
+analysis:
+  mode: hermes
+  unpacker_program:
+    name: tpx3-spidr-cpp
+    executable_path: {executable}
+  analysis_directory: {analysis_directory}
+  tpx3_files:
+    - path: {raw_file}
+""",
+        encoding="utf-8",
+    )
+    original_input = config_path.read_bytes()
+
+    def run_without_subprocess(
+        state_manager: StateManager,
+    ) -> list[FileReference]:
+        state = state_manager.get_state()
+        assert isinstance(state.analysis, HermesTpx3AnalysisState)
+        return state.analysis.tpx3_files
+
+    monkeypatch.setattr(
+        run_unpacker_module,
+        "run_hermes_analysis",
+        run_without_subprocess,
+    )
+
+    run_unpacker_module.main(config_path)
+
+    state_path = working_dir / "hermes-record.yaml"
+    saved_record = load_hermes_record_from_yaml(state_path)
+    output = capsys.readouterr().out
+
+    assert config_path.read_bytes() == original_input
+    assert state_path != config_path
+    assert saved_record.measurement_info.measurement_id == "yaml-example"
+    assert isinstance(saved_record.analysis, HermesTpx3AnalysisState)
+    assert saved_record.analysis.resource_limit_percent == 90
+    assert str(raw_file) in output
+    assert str(analysis_directory) in output
+    assert str(state_path) in output

--- a/tests/unit/examples/analysis/test_unpacker_single_file.py
+++ b/tests/unit/examples/analysis/test_unpacker_single_file.py
@@ -27,37 +27,40 @@ def run_unpacker_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 def test_checked_in_partial_yaml_loads_with_expected_defaults(
     run_unpacker_module: ModuleType,
 ) -> None:
-    record = load_hermes_record_from_yaml(
-        run_unpacker_module.DEFAULT_CONFIG_PATH
+    initial_record = load_hermes_record_from_yaml(
+        run_unpacker_module.DEFAULT_INPUT_YAML_PATH
     )
 
-    assert record.measurement_info.measurement_id == "example-tpx3-unpacking"
-    assert record.environment.working_dir.path == Path(
+    assert (
+        initial_record.measurement_info.measurement_id
+        == "example-tpx3-unpacking"
+    )
+    assert initial_record.environment.working_dir.path == Path(
         "data/examples/analysis/unpacker"
     )
-    assert record.acquisition is None
-    assert isinstance(record.analysis, HermesTpx3AnalysisState)
-    assert record.analysis.unpacker_program.executable_path == Path(
+    assert initial_record.acquisition is None
+    assert isinstance(initial_record.analysis, HermesTpx3AnalysisState)
+    assert initial_record.analysis.unpacker_program.executable_path == Path(
         "build/backends/tpx3-spidr/hermes-tpx3-spidr"
     )
-    assert record.analysis.analysis_directory == Path(
+    assert initial_record.analysis.analysis_directory == Path(
         "data/examples/analysis/unpacker/analysis"
     )
-    assert record.analysis.tpx3_files[0].path == Path(
+    assert initial_record.analysis.tpx3_files[0].path == Path(
         "tests/data/Example_1kHz_5frames.tpx3"
     )
-    assert record.analysis.resource_limit_percent == 90
-    assert record.analysis.unpacker_program.version is None
-    assert record.analysis.photon_reconstruction is None
-    assert record.analysis.results.unpacking.status == "planned"
-    assert record.analysis.results.reconstruction is None
+    assert initial_record.analysis.resource_limit_percent == 90
+    assert initial_record.analysis.unpacker_program.version is None
+    assert initial_record.analysis.photon_reconstruction is None
+    assert initial_record.analysis.results.unpacking.status == "planned"
+    assert initial_record.analysis.results.reconstruction is None
 
-    raw_file = record.analysis.tpx3_files[0]
-    assert raw_file.media_type is None
-    assert raw_file.sha256 is None
-    assert raw_file.size_bytes is None
-    assert raw_file.created_at is None
-    assert raw_file.description is None
+    raw_tpx3_file = initial_record.analysis.tpx3_files[0]
+    assert raw_tpx3_file.media_type is None
+    assert raw_tpx3_file.sha256 is None
+    assert raw_tpx3_file.size_bytes is None
+    assert raw_tpx3_file.created_at is None
+    assert raw_tpx3_file.description is None
 
 
 def test_invalid_yaml_stops_before_analysis(
@@ -65,8 +68,8 @@ def test_invalid_yaml_stops_before_analysis(
     monkeypatch: pytest.MonkeyPatch,
     run_unpacker_module: ModuleType,
 ) -> None:
-    config_path = tmp_path / "invalid.yaml"
-    config_path.write_text("measurement_info: [", encoding="utf-8")
+    invalid_yaml_path = tmp_path / "invalid.yaml"
+    invalid_yaml_path.write_text("measurement_info: [", encoding="utf-8")
 
     def fail_if_called(state_manager: StateManager) -> list[FileReference]:
         raise AssertionError("analysis must not run for invalid YAML")
@@ -78,7 +81,7 @@ def test_invalid_yaml_stops_before_analysis(
     )
 
     with pytest.raises(StateIOError, match="parse"):
-        run_unpacker_module.main(config_path)
+        run_unpacker_module.main(invalid_yaml_path)
 
 
 def test_main_preserves_input_and_saves_final_record_separately(
@@ -87,39 +90,39 @@ def test_main_preserves_input_and_saves_final_record_separately(
     capsys: pytest.CaptureFixture[str],
     run_unpacker_module: ModuleType,
 ) -> None:
-    working_dir = tmp_path / "run"
-    analysis_directory = working_dir / "analysis"
-    raw_file = tmp_path / "input.tpx3"
-    executable = tmp_path / "hermes-tpx3-spidr"
-    config_path = tmp_path / "input.yaml"
-    raw_file.write_bytes(b"example")
-    executable.write_text("", encoding="utf-8")
-    config_path.write_text(
+    working_directory = tmp_path / "run"
+    analysis_directory = working_directory / "analysis"
+    raw_tpx3_file = tmp_path / "input.tpx3"
+    unpacker_executable = tmp_path / "hermes-tpx3-spidr"
+    input_yaml_path = tmp_path / "input.yaml"
+    raw_tpx3_file.write_bytes(b"example")
+    unpacker_executable.write_text("", encoding="utf-8")
+    input_yaml_path.write_text(
         f"""
 measurement_info:
   measurement_id: yaml-example
   run_number: 1
 environment:
-  working_dir: {working_dir}
+  working_dir: {working_directory}
 analysis:
   mode: hermes
   unpacker_program:
     name: tpx3-spidr-cpp
-    executable_path: {executable}
+    executable_path: {unpacker_executable}
   analysis_directory: {analysis_directory}
   tpx3_files:
-    - path: {raw_file}
+    - path: {raw_tpx3_file}
 """,
         encoding="utf-8",
     )
-    original_input = config_path.read_bytes()
+    original_input_yaml = input_yaml_path.read_bytes()
 
     def run_without_subprocess(
         state_manager: StateManager,
     ) -> list[FileReference]:
-        state = state_manager.get_state()
-        assert isinstance(state.analysis, HermesTpx3AnalysisState)
-        return state.analysis.tpx3_files
+        current_record = state_manager.get_state()
+        assert isinstance(current_record.analysis, HermesTpx3AnalysisState)
+        return current_record.analysis.tpx3_files
 
     monkeypatch.setattr(
         run_unpacker_module,
@@ -127,17 +130,20 @@ analysis:
         run_without_subprocess,
     )
 
-    run_unpacker_module.main(config_path)
+    run_unpacker_module.main(input_yaml_path)
 
-    state_path = working_dir / "hermes-record.yaml"
-    saved_record = load_hermes_record_from_yaml(state_path)
-    output = capsys.readouterr().out
+    final_record_path = working_directory / "hermes-record_final.yaml"
+    saved_final_record = load_hermes_record_from_yaml(final_record_path)
+    console_output = capsys.readouterr().out
 
-    assert config_path.read_bytes() == original_input
-    assert state_path != config_path
-    assert saved_record.measurement_info.measurement_id == "yaml-example"
-    assert isinstance(saved_record.analysis, HermesTpx3AnalysisState)
-    assert saved_record.analysis.resource_limit_percent == 90
-    assert str(raw_file) in output
-    assert str(analysis_directory) in output
-    assert str(state_path) in output
+    assert input_yaml_path.read_bytes() == original_input_yaml
+    assert final_record_path != input_yaml_path
+    assert (
+        saved_final_record.measurement_info.measurement_id
+        == "yaml-example"
+    )
+    assert isinstance(saved_final_record.analysis, HermesTpx3AnalysisState)
+    assert saved_final_record.analysis.resource_limit_percent == 90
+    assert str(raw_tpx3_file) in console_output
+    assert str(analysis_directory) in console_output
+    assert str(final_record_path) in console_output

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -436,7 +436,7 @@ def test_run_marks_analysis_only_state_running_through_state_manager(
     )
     monkeypatch.setattr(
         "hermes.analysis.hermes.run.execute_unpacker",
-        lambda analysis, raw_file: _summary(raw_file.path.stem),
+        lambda analysis, raw_file, **kwargs: _summary(raw_file.path.stem),
     )
 
     files_to_run = run_hermes_analysis(manager)

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -476,9 +476,29 @@ def test_run_with_only_completed_files_does_not_mark_running(
 def test_run_rejects_non_hermes_analysis(tmp_path: Path) -> None:
     empir = EmpirAnalysisState.model_construct(mode="empir")
     manager = StateManager(_record(tmp_path, empir), state_logger=CapturingStateLogger())
+    records: list[dict[str, Any]] = []
+    sink_id = logger.add(
+        lambda message: records.append(message.record),
+        filter=lambda record: record["extra"].get("domain") == "analysis",
+    )
 
-    with pytest.raises(HermesAnalysisError, match="not HERMES"):
-        run_hermes_analysis(manager)
+    try:
+        with pytest.raises(HermesAnalysisError, match="not HERMES"):
+            run_hermes_analysis(manager)
+    finally:
+        logger.remove(sink_id)
+
+    invalid_mode = next(
+        record
+        for record in records
+        if record["extra"].get("event_type") == "analysis.hermes.invalid_mode"
+    )
+    assert invalid_mode["level"].name == "ERROR"
+    assert "Cannot run HERMES analysis" in invalid_mode["message"]
+    assert invalid_mode["extra"]["measurement_id"] == "stage-3"
+    assert invalid_mode["extra"]["run_number"] == 1
+    assert invalid_mode["extra"]["expected_analysis_mode"] == "hermes"
+    assert invalid_mode["extra"]["actual_analysis_mode"] == "empir"
 
 
 def test_disabled_bypass_leaves_pending_change_before_process_execution(

--- a/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
+++ b/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
@@ -243,6 +243,92 @@ def test_hermes_analysis_state_rejects_duplicate_raw_filename_stems(
         )
 
 
+def test_hermes_analysis_state_expands_raw_tpx3_file_list(
+    tmp_path: Path,
+) -> None:
+    file_list_path = tmp_path / "lists/raw_tpx3_files.txt"
+    file_list_path.parent.mkdir(parents=True)
+    absolute_raw_tpx3_path = tmp_path / "absolute/second.tpx3"
+    file_list_path.write_text(
+        f"""
+# One raw TPX3 file path per line.
+../raw/first.tpx3
+
+{absolute_raw_tpx3_path}
+""",
+        encoding="utf-8",
+    )
+
+    analysis = HermesTpx3AnalysisState.model_validate(
+        {
+            "unpacker_program": {
+                "name": "tpx3-spidr-cpp",
+                "executable_path": tmp_path / "hermes-tpx3-spidr",
+            },
+            "analysis_directory": tmp_path / "analysis",
+            "tpx3_files": {"file_list": file_list_path},
+        }
+    )
+
+    assert [raw_file.path for raw_file in analysis.tpx3_files] == [
+        (file_list_path.parent / "../raw/first.tpx3").resolve(),
+        absolute_raw_tpx3_path.resolve(),
+    ]
+    assert isinstance(analysis.tpx3_files[0], FileReference)
+
+
+@pytest.mark.parametrize(
+    ("file_contents", "error"),
+    [
+        (None, "cannot read raw TPX3 file list"),
+        ("", "contains no file paths"),
+        ("\n# no paths\n\n", "contains no file paths"),
+    ],
+)
+def test_hermes_analysis_state_rejects_invalid_raw_tpx3_file_list(
+    tmp_path: Path,
+    file_contents: str | None,
+    error: str,
+) -> None:
+    file_list_path = tmp_path / "raw_tpx3_files.txt"
+    if file_contents is not None:
+        file_list_path.write_text(file_contents, encoding="utf-8")
+
+    with pytest.raises(ValidationError, match=error):
+        HermesTpx3AnalysisState.model_validate(
+            {
+                "unpacker_program": {
+                    "name": "tpx3-spidr-cpp",
+                    "executable_path": tmp_path / "hermes-tpx3-spidr",
+                },
+                "analysis_directory": tmp_path / "analysis",
+                "tpx3_files": {"file_list": file_list_path},
+            }
+        )
+
+
+def test_hermes_analysis_state_checks_duplicate_stems_from_file_list(
+    tmp_path: Path,
+) -> None:
+    file_list_path = tmp_path / "duplicate-stems.txt"
+    file_list_path.write_text(
+        "first/raw.tpx3\nsecond/raw.tpx3\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError, match="filename stems must be unique"):
+        HermesTpx3AnalysisState.model_validate(
+            {
+                "unpacker_program": {
+                    "name": "tpx3-spidr-cpp",
+                    "executable_path": tmp_path / "hermes-tpx3-spidr",
+                },
+                "analysis_directory": tmp_path / "analysis",
+                "tpx3_files": {"file_list": file_list_path},
+            }
+        )
+
+
 def test_reconstruction_result_defaults_and_rejects_undefined_fields() -> None:
     result = HermesTpx3ReconstructionResult()
 

--- a/tests/unit/hermes/state_service/test_state_io.py
+++ b/tests/unit/hermes/state_service/test_state_io.py
@@ -187,6 +187,54 @@ def test_save_partial_loaded_record_writes_defaults_and_round_trips(
     assert reloaded == loaded
 
 
+def test_load_file_list_and_save_expanded_raw_tpx3_files(
+    tmp_path: Path,
+) -> None:
+    file_list_path = tmp_path / "inputs/raw_tpx3_files.txt"
+    file_list_path.parent.mkdir()
+    file_list_path.write_text(
+        "first.tpx3\n# ignored comment\n\nsecond.tpx3\n",
+        encoding="utf-8",
+    )
+    input_yaml_path = tmp_path / "file-list-record.yaml"
+    final_record_path = tmp_path / "final-record.yaml"
+    input_yaml_path.write_text(
+        f"""
+measurement_info:
+  measurement_id: file-list-run
+  run_number: 1
+environment: {{}}
+analysis:
+  mode: hermes
+  unpacker_program:
+    name: tpx3-spidr-cpp
+    executable_path: hermes-tpx3-spidr
+  analysis_directory: analysis
+  tpx3_files:
+    file_list: {file_list_path}
+""",
+        encoding="utf-8",
+    )
+
+    loaded = load_hermes_record_from_yaml(input_yaml_path)
+    save_hermes_record_to_yaml(loaded, final_record_path)
+    saved_yaml = yaml.safe_load(final_record_path.read_text(encoding="utf-8"))
+    reloaded = load_hermes_record_from_yaml(final_record_path)
+
+    assert isinstance(loaded.analysis, HermesTpx3AnalysisState)
+    assert [raw_file.path for raw_file in loaded.analysis.tpx3_files] == [
+        (file_list_path.parent / "first.tpx3").resolve(),
+        (file_list_path.parent / "second.tpx3").resolve(),
+    ]
+    saved_raw_tpx3_files = saved_yaml["analysis"]["tpx3_files"]
+    assert isinstance(saved_raw_tpx3_files, list)
+    assert [Path(raw_file["path"]) for raw_file in saved_raw_tpx3_files] == [
+        (file_list_path.parent / "first.tpx3").resolve(),
+        (file_list_path.parent / "second.tpx3").resolve(),
+    ]
+    assert reloaded == loaded
+
+
 def test_load_hermes_record_from_yaml_rejects_invalid_yaml(tmp_path: Path) -> None:
     record_path = tmp_path / "bad.yaml"
     record_path.write_text("measurement_info: [", encoding="utf-8")

--- a/tests/unit/hermes/state_service/test_state_io.py
+++ b/tests/unit/hermes/state_service/test_state_io.py
@@ -11,6 +11,9 @@ from hermes.state.models.acquisition.serval import (
     ServalAcquisitionResult,
     ServalAcquisitionState,
 )
+from hermes.state.models.analysis.hermes_tpx3_spidr import (
+    HermesTpx3AnalysisState,
+)
 from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
 from hermes.state.models.shared_models import FileReference
@@ -24,6 +27,21 @@ from hermes.state_service.state_io import (
 
 HASH = "a" * 64
 NOW = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
+PARTIAL_HERMES_ANALYSIS_YAML = """
+measurement_info:
+  measurement_id: example-tpx3-unpacking
+  run_number: 1
+environment:
+  working_dir: data/examples/analysis/unpacker
+analysis:
+  mode: hermes
+  unpacker_program:
+    name: tpx3-spidr-cpp
+    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+  analysis_directory: data/examples/analysis/unpacker/analysis
+  tpx3_files:
+    - path: tests/data/Example_1kHz_5frames.tpx3
+"""
 
 
 def _example_record(tmp_path: Path) -> HermesRecord:
@@ -95,6 +113,80 @@ def test_save_hermes_record_yaml_is_readable_and_uses_pythonic_names(
     assert "*id" not in content
 
 
+def test_load_partial_yaml_applies_record_and_environment_defaults(
+    tmp_path: Path,
+) -> None:
+    record_path = tmp_path / "minimal-record.yaml"
+    record_path.write_text(
+        """
+measurement_info:
+  measurement_id: example-run
+  run_number: 1
+environment: {}
+""",
+        encoding="utf-8",
+    )
+
+    loaded = load_hermes_record_from_yaml(record_path)
+
+    assert isinstance(loaded, HermesRecord)
+    assert loaded.acquisition is None
+    assert loaded.analysis is None
+    assert loaded.environment.working_dir.path == Path.cwd()
+    assert loaded.environment.working_dir.required is True
+    assert loaded.environment.working_dir.resolved_path == Path.cwd().resolve()
+    assert loaded.environment.data_dir.path is None
+    assert loaded.environment.data_dir.required is False
+    assert loaded.environment.data_dir.resolved_path is None
+    assert loaded.environment.allow_overlapping_output_dirs is False
+
+
+def test_load_partial_hermes_analysis_yaml_applies_nested_defaults(
+    tmp_path: Path,
+) -> None:
+    record_path = tmp_path / "partial-analysis.yaml"
+    record_path.write_text(PARTIAL_HERMES_ANALYSIS_YAML, encoding="utf-8")
+
+    loaded = load_hermes_record_from_yaml(record_path)
+
+    assert loaded.acquisition is None
+    assert isinstance(loaded.analysis, HermesTpx3AnalysisState)
+    assert loaded.analysis.resource_limit_percent == 90
+    assert loaded.analysis.unpacker_program.version is None
+    assert loaded.analysis.photon_reconstruction is None
+    assert loaded.analysis.results.unpacking.status == "planned"
+    assert loaded.analysis.results.unpacking.started_at is None
+    assert loaded.analysis.results.unpacking.finished_at is None
+    assert loaded.analysis.results.reconstruction is None
+
+    raw_file = loaded.analysis.tpx3_files[0]
+    assert raw_file.media_type is None
+    assert raw_file.sha256 is None
+    assert raw_file.size_bytes is None
+    assert raw_file.created_at is None
+    assert raw_file.description is None
+
+
+def test_save_partial_loaded_record_writes_defaults_and_round_trips(
+    tmp_path: Path,
+) -> None:
+    input_path = tmp_path / "partial-analysis.yaml"
+    saved_path = tmp_path / "final-record.yaml"
+    input_path.write_text(PARTIAL_HERMES_ANALYSIS_YAML, encoding="utf-8")
+
+    loaded = load_hermes_record_from_yaml(input_path)
+    save_hermes_record_to_yaml(loaded, saved_path)
+    saved_yaml = yaml.safe_load(saved_path.read_text(encoding="utf-8"))
+    reloaded = load_hermes_record_from_yaml(saved_path)
+
+    assert saved_yaml["acquisition"] is None
+    assert saved_yaml["analysis"]["resource_limit_percent"] == 90
+    assert saved_yaml["analysis"]["unpacker_program"]["version"] is None
+    assert saved_yaml["analysis"]["results"]["unpacking"]["status"] == "planned"
+    assert saved_yaml["analysis"]["tpx3_files"][0]["sha256"] is None
+    assert reloaded == loaded
+
+
 def test_load_hermes_record_from_yaml_rejects_invalid_yaml(tmp_path: Path) -> None:
     record_path = tmp_path / "bad.yaml"
     record_path.write_text("measurement_info: [", encoding="utf-8")
@@ -133,6 +225,88 @@ environment:
         load_hermes_record_from_yaml(record_path)
 
     assert isinstance(exc_info.value.__cause__, ValidationError)
+
+
+def test_load_hermes_record_from_yaml_requires_environment(tmp_path: Path) -> None:
+    record_path = tmp_path / "missing-environment.yaml"
+    record_path.write_text(
+        """
+measurement_info:
+  measurement_id: LC-20260505
+  run_number: 1
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(StateIOError, match="validate") as exc_info:
+        load_hermes_record_from_yaml(record_path)
+
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert cause.errors()[0]["loc"] == ("environment",)
+    assert cause.errors()[0]["type"] == "missing"
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected_location", "expected_type"),
+    [
+        ("unexpected_field", "true", ("unexpected_field",), "extra_forbidden"),
+        (
+            "run_number",
+            "-1",
+            ("measurement_info", "run_number"),
+            "greater_than_equal",
+        ),
+    ],
+)
+def test_load_hermes_record_from_yaml_rejects_unknown_or_invalid_fields(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    expected_location: tuple[str, ...],
+    expected_type: str,
+) -> None:
+    record_path = tmp_path / f"{field}.yaml"
+    if field == "unexpected_field":
+        yaml_content = f"""
+measurement_info:
+  measurement_id: LC-20260505
+  run_number: 1
+environment: {{}}
+{field}: {value}
+"""
+    else:
+        yaml_content = f"""
+measurement_info:
+  measurement_id: LC-20260505
+  {field}: {value}
+environment: {{}}
+"""
+    record_path.write_text(yaml_content, encoding="utf-8")
+
+    with pytest.raises(StateIOError, match="validate") as exc_info:
+        load_hermes_record_from_yaml(record_path)
+
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert cause.errors()[0]["loc"] == expected_location
+    assert cause.errors()[0]["type"] == expected_type
+
+
+def test_load_hermes_record_from_yaml_requires_analysis_mode(tmp_path: Path) -> None:
+    record_path = tmp_path / "missing-analysis-mode.yaml"
+    record_path.write_text(
+        PARTIAL_HERMES_ANALYSIS_YAML.replace("  mode: hermes\n", ""),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(StateIOError, match="validate") as exc_info:
+        load_hermes_record_from_yaml(record_path)
+
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, ValidationError)
+    assert cause.errors()[0]["loc"] == ("analysis",)
+    assert cause.errors()[0]["type"] == "union_tag_not_found"
 
 
 def test_load_hermes_record_from_yaml_wraps_read_errors(tmp_path: Path) -> None:


### PR DESCRIPTION
This pull request introduces an `--overwrite` option to the TPX3 unpacker command-line tool, allowing users to overwrite existing summary JSON and Parquet output files when desired. The change is implemented end-to-end, from command-line parsing through to file writing logic, and is reflected in both the code and related documentation. Additionally, the documentation for the HERMES YAML state model and example usage is improved, with expanded explanations of partial YAML loading, required fields, and the example workflow.

The most important changes are:

**Overwrite Option for TPX3 Unpacker**
- Added an `--overwrite` command-line flag to the unpacker tool (`tpx3SpidrUnpacker.cpp`), updated help/version output, and refactored argument parsing to support options and positional arguments. The flag is passed through to all file-writing operations. [[1]](diffhunk://#diff-56c2fe93e26e264a9618760b819878a73d31e8876fd9d9240aae6749f9558380L17-R20) [[2]](diffhunk://#diff-56c2fe93e26e264a9618760b819878a73d31e8876fd9d9240aae6749f9558380L43-R83)
- Updated the workflow and file-writing logic to respect the `overwrite` flag, preventing accidental overwrites unless explicitly requested. This affects writing Parquet files (`parquet_writer.cpp`), summary JSON files (`summary_json.cpp`), and the overall workflow (`unpacker.cpp`). [[1]](diffhunk://#diff-c3a69361307b0f1b3a42d29a4de3eecefdb12977fdb08535068ba9c76bd9c719L348-R348) [[2]](diffhunk://#diff-239200d7f5fb2e08897af488eb304cf7af7fa77b0177826224cbb8198aec3116L112-R114) [[3]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbL489-R490) [[4]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbR512) [[5]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbR524) [[6]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbR620) [[7]](diffhunk://#diff-b06b991ca2064f61896a5a76777135d5a4982ae1889b71e23bc2b84b0a5812cbL636-R641)
- Added the `overwrite` field to relevant config structs and function signatures, ensuring the flag is consistently available throughout the codebase. [[1]](diffhunk://#diff-5fa1f2ff72c2fd564276ec188cbcbacc3595f6093004ed0009fbe2b3e277918fR17) [[2]](diffhunk://#diff-2b5ac2ee37e7ab94c1fc4259d6ff8810ae39d0de2f3e1209f79ad8c87cb26294L33-R34) [[3]](diffhunk://#diff-176bc5631cd96ce44ebde42ea01e539684fc89c422937e67f3a417b21d6127cdL33-R34)

**Documentation Improvements**
- Expanded the architecture documentation to clarify how partial user-authored YAML is loaded, how defaults are applied, and which fields are required or optional. This includes details on handling file lists and the validation process. [[1]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbR46-R162) [[2]](diffhunk://#diff-05c612271d33fb540eea5b3180b204021d2815acaa47da0b0221520eea25df06R102-R109)
- Updated the multiple-files unpacker example README to describe the new overwrite behavior, clarify input/output expectations, and provide a more comprehensive explanation of the workflow and YAML requirements. [[1]](diffhunk://#diff-0b119ec59b2caae22114d05876a690582203fbc8cb92a5e14604571c6d90f7a1L3-R20) [[2]](diffhunk://#diff-0b119ec59b2caae22114d05876a690582203fbc8cb92a5e14604571c6d90f7a1L30-R106) [[3]](diffhunk://#diff-0b119ec59b2caae22114d05876a690582203fbc8cb92a5e14604571c6d90f7a1L86-R136)

These changes make the unpacker tool safer and more flexible for repeated workflows and improve the clarity and usability of the HERMES YAML interface and documentation.