### PR TITLE
42 code clean up

### DIFF
--- a/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
@@ -1,8 +1,6 @@
 #include <fstream>
 #include <iostream>
-#include <cstring>
 #include <string>
-#include <vector>
 
 #include "diagnostics.h"
 #include "unpacker.h"
@@ -10,19 +8,19 @@
 namespace {
 void printHelp(const char* program_name) {
     std::cout << "HERMES TPX3 SPIDR Unpacker v0.1.0\n\n";
-    std::cout << "Usage: " << program_name << " [OPTIONS] <input.tpx3> [analysis_directory]\n\n";
-    std::cout << "Arguments:\n";
-    std::cout << "  <input.tpx3>        Input TPX3 raw data file\n";
-    std::cout << "  [analysis_directory]  Shared directory for analysis files\n\n";
+    std::cout << "Usage: " << program_name
+              << " --input <input.tpx3> [--output <analysis_directory>] [--overwrite]\n\n";
     std::cout << "Options:\n";
-    std::cout << "  -h, --help       Show this help message\n";
-    std::cout << "  -v, --version    Show version information\n";
-    std::cout << "      --overwrite  Overwrite existing summary and Parquet files\n\n";
+    std::cout << "  --input <input.tpx3>          Input TPX3 raw data file (required)\n";
+    std::cout << "  --output <analysis_directory> Shared analysis directory (optional)\n";
+    std::cout << "  --overwrite                   Overwrite existing summary and Parquet files\n";
+    std::cout << "  -h, --help                    Show this help message\n";
+    std::cout << "  -v, --version                 Show version information\n\n";
     std::cout << "Output Modes:\n";
-    std::cout << "  Without analysis_directory:\n";
-    std::cout << "    Prints summary statistics to stdout\n\n";
-    std::cout << "  With analysis_directory:\n";
-    std::cout << "    Creates Parquet files for each dataset type:\n";
+    std::cout << "  Without --output:\n";
+    std::cout << "    Prints summary statistics only; writes no files.\n\n";
+    std::cout << "  With --output:\n";
+    std::cout << "    Creates Parquet files under the analysis directory:\n";
     std::cout << "      - pixelHits/          Sorted pixel hit events\n";
     std::cout << "      - tdcTriggers/        Sorted TDC trigger events\n";
     std::cout << "      - globalTimestamps/   Global timestamp anchors\n";
@@ -31,9 +29,9 @@ void printHelp(const char* program_name) {
     std::cout << "      - logs/               Input-specific summary JSON\n\n";
     std::cout << "Examples:\n";
     std::cout << "  # Print summary only\n";
-    std::cout << "  " << program_name << " data.tpx3\n\n";
+    std::cout << "  " << program_name << " --input data.tpx3\n\n";
     std::cout << "  # Write Parquet files\n";
-    std::cout << "  " << program_name << " data.tpx3 output/\n\n";
+    std::cout << "  " << program_name << " --input data.tpx3 --output analysis/\n\n";
 }
 
 void printVersion() {
@@ -43,71 +41,89 @@ void printVersion() {
 }  // namespace
 
 int main(const int argc, char* argv[]) {
-    // Separate options from positional arguments.
     bool overwrite = false;
-    std::vector<std::string> positionals;
+    std::string input_path;
+    std::string output_dir;
+    bool have_input = false;
+    bool have_output = false;
+
     for (int i = 1; i < argc; ++i) {
-        if (std::strcmp(argv[i], "-h") == 0 || std::strcmp(argv[i], "--help") == 0) {
+        const std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
             printHelp(argv[0]);
             return 0;
         }
-        if (std::strcmp(argv[i], "-v") == 0 || std::strcmp(argv[i], "--version") == 0) {
+        if (arg == "-v" || arg == "--version") {
             printVersion();
             return 0;
         }
-        if (std::strcmp(argv[i], "--overwrite") == 0) {
+        if (arg == "--overwrite") {
             overwrite = true;
             continue;
         }
-        positionals.emplace_back(argv[i]);
-    }
-
-    if (positionals.empty() || positionals.size() > 2) {
-        std::cerr << "Error: Invalid number of arguments\n\n";
-        std::cerr << "Usage: " << argv[0] << " [OPTIONS] <input.tpx3> [analysis_directory]\n";
+        if (arg == "--input") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --input requires a file path\n";
+                return 2;
+            }
+            input_path = argv[++i];
+            have_input = true;
+            continue;
+        }
+        if (arg == "--output") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --output requires a directory path\n";
+                return 2;
+            }
+            output_dir = argv[++i];
+            have_output = true;
+            continue;
+        }
+        std::cerr << "Error: unrecognized argument: " << arg << "\n\n";
         std::cerr << "Try '" << argv[0] << " --help' for more information.\n";
         return 2;
     }
 
-    const std::string input_path = positionals[0];
+    if (!have_input) {
+        std::cerr << "Error: --input <input.tpx3> is required\n";
+        return 2;
+    }
+
     std::ifstream input(input_path, std::ios::binary);
     if (!input) {
         std::cerr << "Unable to open TPX3 input file: " << input_path << '\n';
         return 2;
     }
 
-    if (positionals.size() == 2) {
-        // Two-pass workflow with output
-        const std::string output_dir = positionals[1];
-        const auto result = hermes_tpx3_spidr::runTwoPassWorkflow(
-            input, input_path, output_dir, overwrite);
-
-        if (!result.success) {
-            std::cerr << "Workflow failed with errors:\n";
-            for (const auto& error : result.errors) {
-                std::cerr << "  " << error << '\n';
-            }
-            return 1;
-        }
-
-        std::cout << "Successfully wrote output to: " << output_dir << '\n';
-        std::cout << "\nTiming:\n";
-        std::cout << "  Unpacking:         " << result.summary.timing_diagnostics.unpacking_seconds << " s\n";
-        std::cout << "  Epoch assignment:  " << result.summary.timing_diagnostics.epoch_assignment_seconds << " s\n";
-        std::cout << "  Sorting:           " << result.summary.timing_diagnostics.sorting_seconds << " s\n";
-        std::cout << "  Conversion:        " << result.summary.timing_diagnostics.conversion_seconds << " s\n";
-        std::cout << "  Parquet writing:   " << result.summary.timing_diagnostics.parquet_writing_seconds << " s\n";
-        std::cout << "  Total:             " << result.summary.timing_diagnostics.total_seconds << " s\n";
-        std::cout << "\nSummary:\n";
-        hermes_tpx3_spidr::printSummary(result.summary.unpack_summary, std::cout);
-
-        return 0;
-    } else {
-        // Legacy mode: just unpack and print summary
+    if (!have_output) {
+        // Without --output, unpack and print a summary without writing files.
         const auto result = hermes_tpx3_spidr::unpack(input);
         hermes_tpx3_spidr::printSummary(result.summary, std::cout);
         hermes_tpx3_spidr::printMessages(result.summary, std::cerr);
-
         return result.summary.errors.empty() ? 0 : 1;
     }
+
+    const auto result = hermes_tpx3_spidr::runTwoPassWorkflow(
+        input, input_path, output_dir, overwrite);
+
+    if (!result.success) {
+        std::cerr << "Workflow failed with errors:\n";
+        for (const auto& error : result.errors) {
+            std::cerr << "  " << error << '\n';
+        }
+        return 1;
+    }
+
+    std::cout << "Successfully wrote output to: " << output_dir << '\n';
+    std::cout << "\nTiming:\n";
+    std::cout << "  Unpacking:         " << result.summary.timing_diagnostics.unpacking_seconds << " s\n";
+    std::cout << "  Epoch assignment:  " << result.summary.timing_diagnostics.epoch_assignment_seconds << " s\n";
+    std::cout << "  Sorting:           " << result.summary.timing_diagnostics.sorting_seconds << " s\n";
+    std::cout << "  Conversion:        " << result.summary.timing_diagnostics.conversion_seconds << " s\n";
+    std::cout << "  Parquet writing:   " << result.summary.timing_diagnostics.parquet_writing_seconds << " s\n";
+    std::cout << "  Total:             " << result.summary.timing_diagnostics.total_seconds << " s\n";
+    std::cout << "\nSummary:\n";
+    hermes_tpx3_spidr::printSummary(result.summary.unpack_summary, std::cout);
+
+    return 0;
 }

--- a/docs/architecture/analysis.md
+++ b/docs/architecture/analysis.md
@@ -103,33 +103,38 @@ analysis may select a C++ or Rust HERMES implementation for a defined HERMES
 step, but every step remains part of `mode="hermes"`. An EMPIR analysis uses the
 EMPIR binaries and remains `mode="empir"`.
 
-## Program-Agnostic Entry Point
+## Analysis Entry Point
 
-`src/hermes/analysis/run.py` should provide one small entry point. It reads the
-selected Pydantic model from `StateManager` and calls exactly one mode-specific
-pipeline:
+`Workflow.run_analysis` is the entry point for analysis. It calls
+`run_hermes_analysis(state_manager)` directly. There is no separate
+`src/hermes/analysis/run.py` dispatcher, because HERMES is the only analysis
+mode with a runner today.
+
+`run_hermes_analysis` reads the selected Pydantic model from `StateManager` and
+guards on its type before doing any work:
 
 ```python
-def run_analysis(state_manager: StateManager) -> HermesRecord:
+def run_hermes_analysis(state_manager: StateManager) -> HermesRecord:
     analysis = state_manager.get_state().analysis
 
-    if isinstance(analysis, HermesTpx3AnalysisState):
-        run_hermes_analysis(state_manager)
-    elif isinstance(analysis, EmpirAnalysisState):
-        run_empir_analysis(state_manager)
-    else:
-        raise AnalysisError("analysis configuration is missing")
+    if isinstance(analysis, EmpirAnalysisState):
+        message = "EMPIR analysis is not implemented yet"
+        logger.error(message)
+        raise HermesAnalysisError(message)
+    if not isinstance(analysis, HermesTpx3AnalysisState):
+        message = "no valid HERMES analysis is configured"
+        logger.error(message)
+        raise HermesAnalysisError(message)
+
+    ...
 
     return state_manager.get_state()
 ```
 
-The entry point should not accept a second mode argument. This prevents a
-function argument or CLI option from disagreeing with `analysis.mode` in the
-HERMES state file.
-
-The entry point only selects the pipeline. Each mode-specific `run.py` owns the
-order of its commands, checks its files, logs its progress, and applies its
-results through `StateManager`.
+The entry point does not accept a mode argument. This prevents a function
+argument or CLI option from disagreeing with `analysis.mode` in the HERMES state
+file. When an EMPIR runner exists, its guard can dispatch to it instead of
+raising.
 
 ## HERMES Analysis
 

--- a/docs/architecture/state-model.md
+++ b/docs/architecture/state-model.md
@@ -19,6 +19,21 @@ The model should contain metadata, configuration, provenance, and summary
 results. It should not contain raw packet bytes, full pixel-hit or TDC-hit
 tables, image stacks, generated plots, detector data files, or build products.
 
+## Optionality follows selection
+Whether a field is optional or required depends on what the user has selected:
+
+- At the top level, `HermesRecord.acquisition` and `HermesRecord.analysis` are
+  optional. A run may be analysis-only, acquisition-only, or both.
+- The shared `RuntimeEnvironment` stays minimal. It holds install-level
+  provenance (such as `hermes_version`, `python_version`, `platform`), not
+  mode-specific tool paths. A binary path belongs on the mode model that needs
+  it (for example `Tpx3SpidrUnpackerProgram.executable_path`), not on the
+  environment.
+- Once a mode model is created (such as `HermesTpx3AnalysisState` or
+  `ServalAcquisitionState`), the fields that mode needs to run are required on
+  that model. Fields filled in progressively during a run — applied
+  configuration, detector snapshots, and results — stay optional.
+
 ## How model is used to keep a record of acquisition and analysis
 The initial `HermesRecord` is recorded by the state logger. Every later durable
 state change is also logged with the changed state path, previous value, new
@@ -286,8 +301,6 @@ RuntimeEnvironment
   log_dir: Path
   preview_dir: Path
   config_dir: Path | None
-  empir_path: Path | None
-  hermes_tpx3_spidr_binary: Path
   ...
 ```
 
@@ -652,12 +665,12 @@ HermesTpx3AnalysisResults
 HermesTpx3UnpackingResult
   status: planned | running | completed | failed
   started_at: datetime | None
-  finished_at: datetime | None
+  completed_at: datetime | None
 
 HermesTpx3ReconstructionResult
   status: planned | running | completed | failed
   started_at: datetime | None
-  finished_at: datetime | None
+  completed_at: datetime | None
   photon_count: int
   rejected_count: int
   warnings: list[str]

--- a/docs/architecture/unpacker.md
+++ b/docs/architecture/unpacker.md
@@ -26,12 +26,30 @@ The Python runner should call the unpacker with the raw TPX3 file and the
 shared analysis directory:
 
 ```text
-<executable> <input.tpx3> <analysis_directory>
+<executable> --input <input.tpx3> [--output <analysis_directory>] [--overwrite] [--time-sort]
 ```
 
-The unpacker derives all category directories and output filenames from those
-two inputs. Do not add separate command options for category directories, a
-filename prefix, or a summary filename.
+The unpacker accepts exactly these options and no others:
+
+- `--input <input.tpx3>` — the raw TPX3 file to unpack. Required; the unpacker
+  raises an error if it is missing. Implemented.
+- `--output <analysis_directory>` — the shared analysis directory. The unpacker
+  creates all category directories and output filenames from it. Optional; when
+  omitted, the unpacker prints summary statistics only and writes no files. The
+  HERMES analysis workflow always supplies it. Implemented.
+- `--overwrite` — redo the unpacking or reconstruction and replace existing
+  output files instead of stopping. Optional, defaults to false. Without it the
+  unpacker preserves existing files (see below). Implemented.
+- `--time-sort` — sort output by canonical timestamp. Optional, defaults to
+  false. Not implemented yet.
+
+Do not add any option outside this list. In particular, do not add separate
+command options for category directories, a filename prefix, or a summary
+filename; the unpacker creates those from `--output`.
+
+The Python runner should keep this simple and clean: confirm the input file is
+set, then call the binary with the flags. Do not add helper functions or a
+builder abstraction for assembling the command.
 
 The HERMES state should save the raw TPX3 input files, shared analysis
 directory, unpacker program, and overall unpacking status and times. Each
@@ -82,8 +100,8 @@ The directory names and the corresponding Parquet data category names are:
 
 ## Parquet Filenames
 
-Every Parquet filename carries the raw TPX3 filename stem, chip index, and part
-index:
+Pixel data can come from more than one chip, so its filenames carry the raw TPX3
+filename stem, chip index, and part index:
 
 ```text
 <raw-file-stem>-chip-<chip-index>-part-<five-digit-part-index>.parquet
@@ -96,17 +114,32 @@ For example, the first pixel-data part for chip 0 from
 analysis/pixelHits/DT_2p0V_000000-chip-0-part-00000.parquet
 ```
 
-Part numbers start at zero independently for each raw file, chip, and data
-category. The category name does not need to be repeated in the filename
-because it is already stated by the parent directory. The chip index belongs in
-the filename and should not be repeated in its rows. When a schema includes
+The other categories (`tdcTriggers`, `globalTimestamps`, `controlPackets`, and
+`unknownPackets`) are not associated with a chip, so their filenames omit the
+chip index and carry only the raw TPX3 filename stem and part index:
+
+```text
+<raw-file-stem>-part-<five-digit-part-index>.parquet
+```
+
+For example, the first TDC-timestamps part from `DT_2p0V_000000.tpx3` is:
+
+```text
+analysis/tdcTriggers/DT_2p0V_000000-part-00000.parquet
+```
+
+Part numbers start at zero independently for each raw file, data category, and
+(for pixel data) chip. The category name does not need to be repeated in the
+filename because it is already stated by the parent directory. When a chip index
+is present it should not be repeated in the rows. When a schema includes
 `packet_index`, it is the packet index within its chunk.
 
 Raw TPX3 filename stems must be unique within one measurement. The HERMES
 runner must reject duplicate stems before launching any unpacker so one input
-cannot overwrite another input's files. Existing files with the same expected
-names must also cause the run to stop; the unpacker must not silently overwrite
-them.
+cannot overwrite another input's files. Without `--overwrite`, existing files
+with the same expected names must cause the run to stop; the unpacker must not
+silently overwrite them. With `--overwrite`, the unpacker redoes the run and
+replaces those files.
 
 Integrated-ToT packets should be unpacked and counted, but the first output
 format does not write them. A later acquisition-mode-specific version may add

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -28,6 +28,7 @@ from hermes.analysis.hermes.unpacker import (
     log_skipped_input,
     plan_unpacking,
 )
+from hermes.state.models.analysis.empir import EmpirAnalysisState
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisResults,
     HermesTpx3AnalysisState,
@@ -152,8 +153,20 @@ def run_hermes_analysis(
 ) -> list[FileReference]:
     state = state_manager.get_state()
     analysis = state.analysis
+    if isinstance(analysis, EmpirAnalysisState):
+        error = "EMPIR analysis is not implemented yet"
+        _ANALYSIS_LOGGER.error(
+            "Cannot run HERMES analysis: {error}",
+            event_type="analysis.hermes.invalid_mode",
+            error=error,
+            measurement_id=state.measurement_info.measurement_id,
+            run_number=state.measurement_info.run_number,
+            expected_analysis_mode="hermes",
+            actual_analysis_mode=getattr(analysis, "mode", None),
+        )
+        raise HermesAnalysisError(error)
     if not isinstance(analysis, HermesTpx3AnalysisState):
-        error = "the saved analysis mode is not HERMES"
+        error = "no valid HERMES analysis is configured"
         _ANALYSIS_LOGGER.error(
             "Cannot run HERMES analysis: {error}",
             event_type="analysis.hermes.invalid_mode",
@@ -208,7 +221,7 @@ def run_hermes_analysis(
             HermesTpx3UnpackingResult(
                 status="completed",
                 started_at=current_analysis.results.unpacking.started_at,
-                finished_at=utc_now(),
+                completed_at=utc_now(),
             ),
             justification="every raw TPX3 file passed unpacking validation",
         )
@@ -230,7 +243,7 @@ def run_hermes_analysis(
                 HermesTpx3UnpackingResult(
                     status="failed",
                     started_at=current_analysis.results.unpacking.started_at,
-                    finished_at=utc_now(),
+                    completed_at=utc_now(),
                 ),
                 justification=f"TPX3 SPIDR unpacking failed: {exc}",
             )
@@ -299,7 +312,7 @@ def _run_photon_reconstruction(
             HermesTpx3ReconstructionResult(
                 status="completed",
                 started_at=started_at,
-                finished_at=utc_now(),
+                completed_at=utc_now(),
                 photon_count=photon_count,
                 rejected_count=rejected_count,
             ),
@@ -322,7 +335,7 @@ def _run_photon_reconstruction(
             HermesTpx3ReconstructionResult(
                 status="failed",
                 started_at=started_at,
-                finished_at=utc_now(),
+                completed_at=utc_now(),
                 errors=[str(exc)],
             ),
             justification=f"photon reconstruction failed: {exc}",

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -68,10 +68,15 @@ def derive_unpacker_command(
     *,
     overwrite: bool = False,
 ) -> list[str]:
-    command = [str(analysis.unpacker_program.executable_path)]
+    command = [
+        str(analysis.unpacker_program.executable_path),
+        "--input",
+        str(raw_file.path),
+        "--output",
+        str(analysis.analysis_directory),
+    ]
     if overwrite:
         command.append("--overwrite")
-    command.extend([str(raw_file.path), str(analysis.analysis_directory)])
     return command
 
 
@@ -121,6 +126,9 @@ def execute_unpacker(
 ) -> Tpx3SpidrSummary:
     command = derive_unpacker_command(analysis, raw_file, overwrite=overwrite)
     summary_path = derive_summary_path(analysis, raw_file)
+    resolved_executable_path = (
+        analysis.unpacker_program.executable_path.resolve()
+    )
     started = perf_counter()
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_unpacking.started",
@@ -130,6 +138,7 @@ def execute_unpacker(
         analysis_directory=str(analysis.analysis_directory),
         summary_json_file=str(summary_path),
         executable_path=str(analysis.unpacker_program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
         executable_version=analysis.unpacker_program.version,
         command=command,
     )
@@ -255,7 +264,8 @@ def _validate_program_and_inputs(analysis: HermesTpx3AnalysisState) -> None:
     executable = analysis.unpacker_program.executable_path
     if not executable.is_file():
         raise HermesTpx3PreflightError(
-            f"unpacker executable does not exist: {executable}"
+            f"unpacker executable does not exist: {executable}; build the "
+            "binary (e.g. via pixi) and set unpacker_program.executable_path"
         )
 
     for raw_file in analysis.tpx3_files:

--- a/src/hermes/logging.py
+++ b/src/hermes/logging.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from loguru import logger
+
+
+def _domain_filter(domain: str) -> Callable[[dict], bool]:
+    return lambda record: record["extra"].get("domain") == domain
+
+
+def configure_logging(log_dir: Path) -> None:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logger.remove()
+
+    logger.add(
+        log_dir / "state.jsonl",
+        serialize=True,
+        enqueue=True,
+        rotation="50 MB",
+        retention="90 days",
+        filter=_domain_filter("state"),
+    )
+    logger.add(
+        log_dir / "workflow.jsonl",
+        serialize=True,
+        enqueue=True,
+        rotation="50 MB",
+        retention="90 days",
+        filter=_domain_filter("workflow"),
+    )
+    logger.add(
+        log_dir / "acquisition.serval.jsonl",
+        serialize=True,
+        enqueue=True,
+        rotation="100 MB",
+        retention="90 days",
+        filter=lambda record: (
+            record["extra"].get("domain") == "acquisition"
+            and record["extra"].get("backend") == "serval"
+        ),
+    )
+    logger.add(
+        log_dir / "analysis.jsonl",
+        serialize=True,
+        enqueue=True,
+        rotation="100 MB",
+        retention="90 days",
+        filter=_domain_filter("analysis"),
+    )

--- a/src/hermes/state/models/acquisition/serval.py
+++ b/src/hermes/state/models/acquisition/serval.py
@@ -264,7 +264,7 @@ class ServalAcquisitionResult(StrictBaseModel):
 
 class ServalAcquisitionState(StrictBaseModel):
     mode: Literal["serval"] = "serval"
-    serval_environment: ServalEnvironment | None = None
+    serval_environment: ServalEnvironment
     requested_plan: ServalAcquisitionPlan | None = None
     requested_detector_config: DetectorConfiguration | None = None
     requested_destination_configuration: DestinationConfiguration | None = None

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -8,14 +8,7 @@ from pydantic import Field, model_validator
 
 from hermes.state.models.shared_models import FileReference, StrictBaseModel
 
-AnalysisRunStatus = Literal[
-    "planned",
-    "running",
-    "completed",
-    "failed",
-    "skipped",
-    "unknown",
-]
+EmpirRunStatus = Literal["planned", "running", "completed", "failed"]
 EmpirExternalTriggerMode = Literal["ignore", "reference", "frameSync"]
 EmpirTiffFormat = Literal["tiff_w4", "tiff_w8"]
 
@@ -28,7 +21,7 @@ class EmpirPixelToPhotonSettings(StrictBaseModel):
 
 
 class EmpirPixelToPhotonResult(StrictBaseModel):
-    status: AnalysisRunStatus = "planned"
+    status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
     exit_code: int | None = None
@@ -59,7 +52,7 @@ class EmpirPhotonToEventSettings(StrictBaseModel):
 
 
 class EmpirPhotonToEventResult(StrictBaseModel):
-    status: AnalysisRunStatus = "planned"
+    status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
     exit_code: int | None = None
@@ -122,7 +115,7 @@ class EmpirEventToImageSettings(StrictBaseModel):
 
 
 class EmpirEventToImageResult(StrictBaseModel):
-    status: AnalysisRunStatus = "planned"
+    status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
     exit_code: int | None = None

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -8,7 +8,7 @@ from pydantic import Field, field_validator, model_validator
 
 from hermes.state.models.shared_models import FileReference, StrictBaseModel
 
-AnalysisRunStatus = Literal["planned", "running", "completed", "failed"]
+HermesTpx3RunStatus = Literal["planned", "running", "completed", "failed"]
 SortingStrategy = Literal["in_memory", "external_merge"]
 ClusteringAlgorithm = Literal["connected_components", "dbscan"]
 PhotonTimeEstimator = Literal[
@@ -27,9 +27,9 @@ class Tpx3SpidrUnpackerProgram(StrictBaseModel):
 
 
 class HermesTpx3UnpackingResult(StrictBaseModel):
-    status: AnalysisRunStatus = "planned"
+    status: HermesTpx3RunStatus = "planned"
     started_at: datetime | None = None
-    finished_at: datetime | None = None
+    completed_at: datetime | None = None
 
 
 class PhotonReconstructorProgram(StrictBaseModel):
@@ -88,9 +88,9 @@ class Tpx3PhotonReconstructionConfiguration(StrictBaseModel):
 
 
 class HermesTpx3ReconstructionResult(StrictBaseModel):
-    status: AnalysisRunStatus = "planned"
+    status: HermesTpx3RunStatus = "planned"
     started_at: datetime | None = None
-    finished_at: datetime | None = None
+    completed_at: datetime | None = None
     photon_count: int = Field(default=0, ge=0)
     rejected_count: int = Field(default=0, ge=0)
     warnings: list[str] = Field(default_factory=list)

--- a/src/hermes/state/models/environment.py
+++ b/src/hermes/state/models/environment.py
@@ -122,10 +122,6 @@ class RuntimeEnvironment(StrictBaseModel):
     log_dir: DirectoryState = Field(default_factory=_directory_state)
     preview_dir: DirectoryState = Field(default_factory=_directory_state)
     config_dir: DirectoryState = Field(default_factory=_directory_state)
-    empir_path: Path | None = None
-    empir_version: str | None = None
-    hermes_tpx3_spidr_binary: Path | None = None
-    hermes_tpx3_spidr_version: str | None = None
     hermes_version: str | None = None
     python_version: str | None = None
     platform: str | None = None
@@ -153,10 +149,6 @@ class RuntimeEnvironment(StrictBaseModel):
                     base=working_dir_base,
                     required_default=False,
                 )
-
-        for key in ("config_dir", "empir_path", "hermes_tpx3_spidr_binary"):
-            if key not in DIRECTORY_FIELDS and resolved.get(key) is not None:
-                resolved[key] = _resolve_path(resolved[key], working_dir_base)
 
         return resolved
 

--- a/src/hermes/workflows/workflow.py
+++ b/src/hermes/workflows/workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from hermes.analysis.hermes.run import run_hermes_analysis
+from hermes.logging import configure_logging
 from hermes.state.models.shared_models import FileReference
 from hermes.state.state import HermesRecord
 from hermes.state_service.shared_types import StateServiceConfig
@@ -11,6 +12,9 @@ class Workflow:
     """Run HERMES operations against one measurement record."""
 
     def __init__(self, record: HermesRecord) -> None:
+        log_dir = record.environment.log_dir.resolved_path
+        if log_dir is not None:
+            configure_logging(log_dir)
         self._state_manager = StateManager(
             record,
             config=StateServiceConfig(allow_trusted_workflow_bypass=True),

--- a/tests/unit/hermes/analysis/hermes/test_reconstruction.py
+++ b/tests/unit/hermes/analysis/hermes/test_reconstruction.py
@@ -471,8 +471,9 @@ def _write_fake_unpacker(executable: Path) -> None:
         import pyarrow as pa
         import pyarrow.parquet as pq
 
-        raw_file = Path(sys.argv[1])
-        analysis_dir = Path(sys.argv[2])
+        args = sys.argv[1:]
+        raw_file = Path(args[args.index("--input") + 1])
+        analysis_dir = Path(args[args.index("--output") + 1])
         stem = raw_file.stem
 
         pixel_hits = analysis_dir / "pixelHits"
@@ -568,7 +569,7 @@ def test_run_hermes_analysis_completes_reconstruction(tmp_path: Path) -> None:
     assert results.reconstruction is not None
     assert results.reconstruction.status == "completed"
     assert results.reconstruction.started_at is not None
-    assert results.reconstruction.finished_at is not None
+    assert results.reconstruction.completed_at is not None
     assert results.reconstruction.photon_count == 4
 
 

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -196,8 +196,9 @@ def _write_fake_unpacker(executable: Path) -> None:
         import pyarrow as pa
         import pyarrow.parquet as pq
 
-        raw_file = Path(sys.argv[1])
-        analysis_directory = Path(sys.argv[2])
+        args = sys.argv[1:]
+        raw_file = Path(args[args.index("--input") + 1])
+        analysis_directory = Path(args[args.index("--output") + 1])
         raw_stem = raw_file.stem
         mode = raw_file.read_text(encoding="utf-8").strip() or "success"
 
@@ -325,7 +326,9 @@ def test_derives_command_and_input_specific_summary_path(tmp_path: Path) -> None
 
     assert derive_unpacker_command(analysis, raw_file) == [
         str(analysis.unpacker_program.executable_path),
+        "--input",
         str(raw_file.path),
+        "--output",
         str(analysis.analysis_directory),
     ]
     assert derive_summary_path(analysis, raw_file) == (
@@ -448,7 +451,7 @@ def test_run_marks_analysis_only_state_running_through_state_manager(
     result = manager.get_state().analysis.results.unpacking
     assert result.status == "completed"
     assert result.started_at is not None
-    assert result.finished_at is not None
+    assert result.completed_at is not None
     assert state_logger.changes[-1].path == "analysis.results"
     assert state_logger.changes[-1].origin == "trusted_workflow"
     assert state_logger.changes[-1].proposer == "tpx3_spidr_unpacking"
@@ -470,10 +473,10 @@ def test_run_with_only_completed_files_does_not_mark_running(
     result = manager.get_state().analysis.results.unpacking
     assert result.status == "completed"
     assert result.started_at is None
-    assert result.finished_at is not None
+    assert result.completed_at is not None
 
 
-def test_run_rejects_non_hermes_analysis(tmp_path: Path) -> None:
+def test_run_rejects_empir_analysis(tmp_path: Path) -> None:
     empir = EmpirAnalysisState.model_construct(mode="empir")
     manager = StateManager(_record(tmp_path, empir), state_logger=CapturingStateLogger())
     records: list[dict[str, Any]] = []
@@ -483,7 +486,7 @@ def test_run_rejects_non_hermes_analysis(tmp_path: Path) -> None:
     )
 
     try:
-        with pytest.raises(HermesAnalysisError, match="not HERMES"):
+        with pytest.raises(HermesAnalysisError, match="EMPIR analysis is not implemented"):
             run_hermes_analysis(manager)
     finally:
         logger.remove(sink_id)
@@ -499,6 +502,29 @@ def test_run_rejects_non_hermes_analysis(tmp_path: Path) -> None:
     assert invalid_mode["extra"]["run_number"] == 1
     assert invalid_mode["extra"]["expected_analysis_mode"] == "hermes"
     assert invalid_mode["extra"]["actual_analysis_mode"] == "empir"
+
+
+def test_run_rejects_missing_analysis(tmp_path: Path) -> None:
+    manager = StateManager(_record(tmp_path, None), state_logger=CapturingStateLogger())
+    records: list[dict[str, Any]] = []
+    sink_id = logger.add(
+        lambda message: records.append(message.record),
+        filter=lambda record: record["extra"].get("domain") == "analysis",
+    )
+
+    try:
+        with pytest.raises(HermesAnalysisError, match="no valid HERMES analysis"):
+            run_hermes_analysis(manager)
+    finally:
+        logger.remove(sink_id)
+
+    invalid_mode = next(
+        record
+        for record in records
+        if record["extra"].get("event_type") == "analysis.hermes.invalid_mode"
+    )
+    assert invalid_mode["level"].name == "ERROR"
+    assert invalid_mode["extra"]["actual_analysis_mode"] is None
 
 
 def test_disabled_bypass_leaves_pending_change_before_process_execution(
@@ -556,7 +582,7 @@ def test_run_executes_fake_unpacker_logs_details_and_round_trips_yaml(
     result = manager.get_state().analysis.results.unpacking
     assert result.status == "completed"
     assert result.started_at is not None
-    assert result.finished_at is not None
+    assert result.completed_at is not None
 
     started = next(
         record
@@ -674,7 +700,7 @@ def test_run_saves_failed_state_before_raising_for_output_failures(
     result = manager.get_state().analysis.results.unpacking
     assert result.status == "failed"
     assert result.started_at is not None
-    assert result.finished_at is not None
+    assert result.completed_at is not None
     failures = [
         record
         for record in records
@@ -714,7 +740,7 @@ def test_run_saves_failed_state_for_preflight_failure(tmp_path: Path) -> None:
     result = manager.get_state().analysis.results.unpacking
     assert result.status == "failed"
     assert result.started_at is None
-    assert result.finished_at is not None
+    assert result.completed_at is not None
 
 
 def test_resource_limit_percent_field_defaults_to_90(tmp_path: Path) -> None:

--- a/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
@@ -87,7 +87,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     assert completed_state.acquisition is None
     assert completed_state.analysis.results.unpacking.status == "completed"
     assert completed_state.analysis.results.unpacking.started_at is not None
-    assert completed_state.analysis.results.unpacking.finished_at is not None
+    assert completed_state.analysis.results.unpacking.completed_at is not None
 
     summaries: list[Tpx3SpidrSummary] = []
     generated_paths: set[Path] = set()
@@ -140,7 +140,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     assert set(saved_analysis["results"]["unpacking"]) == {
         "status",
         "started_at",
-        "finished_at",
+        "completed_at",
     }
     assert not _contains_key(
         saved_analysis,

--- a/tests/unit/hermes/state/models/test_environment.py
+++ b/tests/unit/hermes/state/models/test_environment.py
@@ -43,7 +43,6 @@ def test_runtime_environment_resolves_explicit_relative_paths(tmp_path: Path) ->
         working_dir=run_dir,
         preview_dir="fast-preview",
         raw_data_dir={"path": "data/tpx3", "required": True},
-        hermes_tpx3_spidr_binary="bin/hermes-tpx3-spidr",
     )
 
     assert environment.preview_dir.path == Path("fast-preview")
@@ -51,7 +50,6 @@ def test_runtime_environment_resolves_explicit_relative_paths(tmp_path: Path) ->
     assert environment.raw_data_dir.required
     assert environment.raw_data_dir.path == Path("data/tpx3")
     assert environment.raw_data_dir.resolved_path == (run_dir / "data" / "tpx3").resolve()
-    assert environment.hermes_tpx3_spidr_binary == (run_dir / "bin/hermes-tpx3-spidr").resolve()
 
 
 def test_runtime_environment_keeps_explicit_absolute_paths(tmp_path: Path) -> None:

--- a/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
+++ b/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
@@ -37,7 +37,7 @@ def _analysis_state(tmp_path: Path, *raw_names: str) -> HermesTpx3AnalysisState:
             unpacking=HermesTpx3UnpackingResult(
                 status="completed",
                 started_at=datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc),
-                finished_at=datetime(2026, 7, 23, 12, 1, tzinfo=timezone.utc),
+                completed_at=datetime(2026, 7, 23, 12, 1, tzinfo=timezone.utc),
             )
         ),
     )
@@ -334,7 +334,7 @@ def test_reconstruction_result_defaults_and_rejects_undefined_fields() -> None:
 
     assert result.status == "planned"
     assert result.started_at is None
-    assert result.finished_at is None
+    assert result.completed_at is None
     assert result.photon_count == 0
     assert result.rejected_count == 0
     assert result.warnings == []

--- a/tests/unit/hermes/state/models/test_serval.py
+++ b/tests/unit/hermes/state/models/test_serval.py
@@ -316,6 +316,7 @@ def test_serval_config_load_validates_http_status_code(
 def test_serval_acquisition_state_separates_requested_and_applied_config() -> None:
     state = ServalAcquisitionState.model_validate(
         {
+            "serval_environment": {"serval_url": "http://localhost:8080"},
             "requested_detector_config": {
                 "TriggerMode": "AUTOTRIGSTART_TIMERSTOP",
                 "ExposureTime": 0.0002,

--- a/tests/unit/hermes/state/test_state.py
+++ b/tests/unit/hermes/state/test_state.py
@@ -8,6 +8,7 @@ from hermes.state.models.acquisition.serval import (
     PixelConfigFile,
     ServalAcquisitionResult,
     ServalAcquisitionState,
+    ServalEnvironment,
 )
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisResults,
@@ -39,6 +40,7 @@ def test_hermes_record_serializes_paths_datetimes_and_mode_tags(tmp_path: Path) 
         ),
         environment=RuntimeEnvironment(working_dir=tmp_path / "run-001"),
         acquisition=ServalAcquisitionState(
+            serval_environment=ServalEnvironment(serval_url="http://localhost:8080"),
             result=ServalAcquisitionResult(status="completed", output_files=[raw_file])
         ),
         analysis=HermesTpx3AnalysisState(
@@ -88,6 +90,7 @@ def test_hermes_record_serializes_serval_requested_applied_and_calibration(
         measurement_info=MeasurementInfo(measurement_id="LC-20231024", run_number=2),
         environment=RuntimeEnvironment(working_dir=tmp_path / "run-002"),
         acquisition=ServalAcquisitionState(
+            serval_environment=ServalEnvironment(serval_url="http://localhost:8080"),
             requested_detector_config={
                 "TriggerMode": "AUTOTRIGSTART_TIMERSTOP",
                 "ExposureTime": 0.0002,

--- a/tests/unit/hermes/state_service/test_state_io.py
+++ b/tests/unit/hermes/state_service/test_state_io.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from hermes.state.models.acquisition.serval import (
     ServalAcquisitionResult,
     ServalAcquisitionState,
+    ServalEnvironment,
 )
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
@@ -64,6 +65,7 @@ def _example_record(tmp_path: Path) -> HermesRecord:
             log_dir="logs",
         ),
         acquisition=ServalAcquisitionState(
+            serval_environment=ServalEnvironment(serval_url="http://localhost:8080"),
             result=ServalAcquisitionResult(
                 status="completed",
                 started_at=NOW,
@@ -156,7 +158,7 @@ def test_load_partial_hermes_analysis_yaml_applies_nested_defaults(
     assert loaded.analysis.photon_reconstruction is None
     assert loaded.analysis.results.unpacking.status == "planned"
     assert loaded.analysis.results.unpacking.started_at is None
-    assert loaded.analysis.results.unpacking.finished_at is None
+    assert loaded.analysis.results.unpacking.completed_at is None
     assert loaded.analysis.results.reconstruction is None
 
     raw_file = loaded.analysis.tpx3_files[0]

--- a/tests/unit/hermes/state_service/test_state_manager.py
+++ b/tests/unit/hermes/state_service/test_state_manager.py
@@ -8,6 +8,7 @@ import pytest
 from hermes.state.models.acquisition.serval import (
     ServalAcquisitionResult,
     ServalAcquisitionState,
+    ServalEnvironment,
 )
 from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
@@ -58,6 +59,9 @@ def _record(tmp_path: Path, *, acquisition: bool = True) -> HermesRecord:
         environment=RuntimeEnvironment(working_dir=tmp_path / "run-001"),
         acquisition=(
             ServalAcquisitionState(
+                serval_environment=ServalEnvironment(
+                    serval_url="http://localhost:8080"
+                ),
                 result=ServalAcquisitionResult(status="planned", frames=0)
             )
             if acquisition
@@ -209,7 +213,11 @@ def test_state_manager_can_initialize_optional_top_level_acquisition(
     )
     change = manager.propose_change(
         "acquisition",
-        {"mode": "serval", "result": {"status": "planned"}},
+        {
+            "mode": "serval",
+            "serval_environment": {"serval_url": "http://localhost:8080"},
+            "result": {"status": "planned"},
+        },
         origin="trusted_workflow",
         proposer="serval_workflow",
     )


### PR DESCRIPTION
This pull request updates the TPX3 SPIDR unpacker CLI and its integration in the HERMES analysis workflow to use explicit `--input` and `--output` options, improves error handling, and clarifies documentation. It also standardizes result field names and strengthens type and mode checks in the analysis runner. The most important changes are:

**Command-line interface and argument parsing:**
- The TPX3 SPIDR unpacker (`tpx3SpidrUnpacker.cpp`) now accepts only `--input <input.tpx3>`, `--output <analysis_directory>`, and `--overwrite` options (removing positional arguments), with improved help messages, error handling for missing/invalid arguments, and clear separation of summary-only vs. file-writing modes. (`[[1]](diffhunk://#diff-56c2fe93e26e264a9618760b819878a73d31e8876fd9d9240aae6749f9558380L3-R23)`, `[[2]](diffhunk://#diff-56c2fe93e26e264a9618760b819878a73d31e8876fd9d9240aae6749f9558380L34-R34)`, `[[3]](diffhunk://#diff-56c2fe93e26e264a9618760b819878a73d31e8876fd9d9240aae6749f9558380L46-R105)`, `[[4]](diffhunk://#diff-56c2fe93e26e264a9618760b819878a73d31e8876fd9d9240aae6749f9558380L105-L112)`)
- The Python runner now constructs the unpacker command using these explicit options, removing positional argument handling and ensuring the command is always formed consistently. (`[[1]](diffhunk://#diff-289fa7a93126795a23e391d2b5610d9bd8db330337e2cae1c1128f90497b085eL71-L74)`, `[[2]](diffhunk://#diff-289fa7a93126795a23e391d2b5610d9bd8db330337e2cae1c1128f90497b085eR129-R131)`)

**Documentation updates:**
- Documentation for the unpacker and analysis entry point is rewritten to reflect the new CLI, clarify required/optional arguments, and specify that only the listed options are supported. It also describes the filename conventions for Parquet outputs and the rationale for not adding extra options. (`[[1]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afL29-R52)`, `[[2]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afL85-R104)`, `[[3]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afL99-R142)`, `[[4]](diffhunk://#diff-3de6297c0debf34b4727dd407fc31afb4504bb7ec2deac4e50f35203c5a86216L106-R137)`)
- The state model documentation is updated to clarify field optionality, move tool paths to mode-specific models, and rename result fields from `finished_at` to `completed_at`. (`[[1]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbR22-R36)`, `[[2]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL289-L290)`, `[[3]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL655-R673)`)

**Analysis runner improvements:**
- The runner now explicitly checks for the correct analysis mode and type, raising clear errors if an unsupported or missing mode is configured, and logs these errors with additional context. (`[[1]](diffhunk://#diff-d7b2ce56f77a291a35e826e0cd0cc928e8025f5b56e18e440837417782875603R31)`, `[[2]](diffhunk://#diff-d7b2ce56f77a291a35e826e0cd0cc928e8025f5b56e18e440837417782875603R156-R169)`)
- Result models use `completed_at` instead of `finished_at` for clarity and consistency. (`[[1]](diffhunk://#diff-d7b2ce56f77a291a35e826e0cd0cc928e8025f5b56e18e440837417782875603L211-R224)`, `[[2]](diffhunk://#diff-d7b2ce56f77a291a35e826e0cd0cc928e8025f5b56e18e440837417782875603L233-R246)`, `[[3]](diffhunk://#diff-d7b2ce56f77a291a35e826e0cd0cc928e8025f5b56e18e440837417782875603L302-R315)`, `[[4]](diffhunk://#diff-d7b2ce56f77a291a35e826e0cd0cc928e8025f5b56e18e440837417782875603L325-R338)`)

**Provenance and logging:**
- The Python runner logs both the configured and resolved unpacker executable paths, improving provenance and debugging. (`[src/hermes/analysis/hermes/unpacker.pyR141](diffhunk://#diff-289fa7a93126795a23e391d2b5610d9bd8db330337e2cae1c1128f90497b085eR141)`)

These changes ensure a more robust, explicit, and maintainable interface between the Python runner and the C++ unpacker, and bring the documentation and state models in line with the implementation.