### PR TITLE
44 recon clis

### DIFF
--- a/backends/reconstruction/photons/cpp/inc/photon_writer.h
+++ b/backends/reconstruction/photons/cpp/inc/photon_writer.h
@@ -55,22 +55,27 @@ struct PhotonWriteResult {
 // "<stem>-chip-<chip>-photon-events-part-<00000>.parquet". Photons carry an
 // implicit zero-based photon_id equal to their index in the vector. Appends to
 // errors and returns an empty result on failure. Writes nothing when photons is
-// empty.
+// empty. When overwrite is false, refuses to replace an existing file; when
+// true, replaces it.
 PhotonWriteResult writePhotonEventsParquet(
     const std::vector<Photon>& photons,
     const std::string& photon_output_directory,
     const PhotonFileMetadata& metadata,
     std::uint64_t rows_per_part,
+    bool overwrite,
     std::vector<std::string>& errors);
 
 // Writes photon_pixels for one raw stem and chip. Files are named
 // "<stem>-chip-<chip>-photon-pixels-part-<00000>.parquet". Rows are written in
 // the given order. Appends to errors on failure. Writes nothing when rows empty.
+// When overwrite is false, refuses to replace an existing file; when true,
+// replaces it.
 PhotonWriteResult writePhotonPixelsParquet(
     const std::vector<PhotonPixelRow>& rows,
     const std::string& photon_output_directory,
     const PhotonFileMetadata& metadata,
     std::uint64_t rows_per_part,
+    bool overwrite,
     std::vector<std::string>& errors);
 
 }  // namespace hermes_photon_clusterer

--- a/backends/reconstruction/photons/cpp/inc/summary_writer.h
+++ b/backends/reconstruction/photons/cpp/inc/summary_writer.h
@@ -81,11 +81,13 @@ struct ReconstructionSummaryContent {
 std::string generateReconstructionSummaryJson(
     const ReconstructionSummaryContent& content);
 
-// Writes the summary JSON to output_path, refusing to overwrite an existing
-// file. Throws std::runtime_error on an existing file or a write failure.
+// Writes the summary JSON to output_path. When overwrite is false, refuses to
+// replace an existing file; when true, replaces it. Throws std::runtime_error
+// on a refused existing file or a write failure.
 void writeReconstructionSummaryJson(
     const std::string& output_path,
-    const ReconstructionSummaryContent& content);
+    const ReconstructionSummaryContent& content,
+    bool overwrite);
 
 }  // namespace hermes_photon_clusterer
 

--- a/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
+++ b/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
@@ -37,20 +37,31 @@ void printHelp(const char* program_name) {
     std::cout << "HERMES Photon Clusterer v" << hermes_photon_clusterer::kVersion
               << "\n\n";
     std::cout << "Usage: " << program_name
-              << " [OPTIONS] <analysis_directory> <raw_file_stem>\n\n";
-    std::cout << "Arguments:\n";
-    std::cout << "  <analysis_directory>  Shared analysis directory; pixelHits/, "
-                 "photons/, and logs/\n";
-    std::cout << "                        are derived from it\n";
-    std::cout << "  <raw_file_stem>       Raw TPX3 filename stem selecting the "
-                 "pixel_data files\n\n";
+              << " --input <analysis_directory> --base-file-name <name>"
+                 " [--settings <file>] [--output <analysis_directory>]"
+                 " [--overwrite]\n\n";
     std::cout << "Options:\n";
-    std::cout << "  -s, --settings <file>  JSON file overriding individual "
-                 "clustering settings\n";
-    std::cout << "                         (any field omitted keeps its "
-                 "built-in default)\n";
-    std::cout << "  -h, --help             Show this help message\n";
-    std::cout << "  -v, --version          Show version information\n";
+    std::cout << "  --input <analysis_directory>   Directory holding pixelHits/ "
+                 "to read (required)\n";
+    std::cout << "  --base-file-name <name>        Base name of the raw file "
+                 "selecting the\n";
+    std::cout << "                                 pixel_data files to read "
+                 "(required)\n";
+    std::cout << "  --settings <file>              JSON file overriding "
+                 "individual clustering\n";
+    std::cout << "                                 settings (any field omitted "
+                 "keeps its default)\n";
+    std::cout << "  --output <analysis_directory>  Directory to write photons/ "
+                 "and logs/ (optional)\n";
+    std::cout << "  --overwrite                    Overwrite existing photon and "
+                 "summary files\n";
+    std::cout << "  -h, --help                     Show this help message\n";
+    std::cout << "  -v, --version                  Show version information\n\n";
+    std::cout << "Output Modes:\n";
+    std::cout << "  Without --output:\n";
+    std::cout << "    Prints summary counts only; writes no files.\n\n";
+    std::cout << "  With --output:\n";
+    std::cout << "    Writes photons/ and logs/ under the output directory.\n";
 }
 
 void printVersion() {
@@ -123,8 +134,14 @@ std::vector<std::pair<std::string, double>> correctionParameters(
 }  // namespace
 
 int main(const int argc, char* argv[]) {
+    std::string input_dir;
+    std::string base_file_name;
     std::string settings_file;
-    std::vector<std::string> positionals;
+    std::string output_dir;
+    bool overwrite = false;
+    bool have_input = false;
+    bool have_base_name = false;
+    bool have_output = false;
 
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
@@ -136,30 +153,58 @@ int main(const int argc, char* argv[]) {
             printVersion();
             return 0;
         }
-        if (arg == "-s" || arg == "--settings") {
+        if (arg == "--overwrite") {
+            overwrite = true;
+            continue;
+        }
+        if (arg == "--input") {
             if (i + 1 >= argc) {
-                std::cerr << "Error: " << arg << " requires a file path\n";
+                std::cerr << "Error: --input requires a directory path\n";
+                return 2;
+            }
+            input_dir = argv[++i];
+            have_input = true;
+            continue;
+        }
+        if (arg == "--base-file-name") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --base-file-name requires a name\n";
+                return 2;
+            }
+            base_file_name = argv[++i];
+            have_base_name = true;
+            continue;
+        }
+        if (arg == "--settings") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --settings requires a file path\n";
                 return 2;
             }
             settings_file = argv[++i];
             continue;
         }
-        if (!arg.empty() && arg[0] == '-') {
-            std::cerr << "Error: unknown option '" << arg << "'\n";
-            std::cerr << "Try '" << argv[0] << " --help' for more information.\n";
-            return 2;
+        if (arg == "--output") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --output requires a directory path\n";
+                return 2;
+            }
+            output_dir = argv[++i];
+            have_output = true;
+            continue;
         }
-        positionals.push_back(arg);
-    }
-
-    if (positionals.size() != 2) {
-        std::cerr << "Error: expected <analysis_directory> and "
-                     "<raw_file_stem>\n";
+        std::cerr << "Error: unrecognized argument: " << arg << "\n\n";
         std::cerr << "Try '" << argv[0] << " --help' for more information.\n";
         return 2;
     }
-    const std::string analysis_directory = positionals[0];
-    const std::string raw_file_stem = positionals[1];
+
+    if (!have_input) {
+        std::cerr << "Error: --input <analysis_directory> is required\n";
+        return 2;
+    }
+    if (!have_base_name) {
+        std::cerr << "Error: --base-file-name <name> is required\n";
+        return 2;
+    }
 
     // Start from built-in defaults; a settings file overrides only named fields.
     hermes_photon_clusterer::ClusteringSettings settings;
@@ -190,20 +235,30 @@ int main(const int argc, char* argv[]) {
         }
     }
 
-    const fs::path analysis_path(analysis_directory);
-    const std::string pixel_hits_dir = (analysis_path / "pixelHits").string();
-    const std::string photons_dir = (analysis_path / "photons").string();
-    const std::string logs_dir = (analysis_path / "logs").string();
-    const std::string summary_path =
-        (fs::path(logs_dir) /
-         (raw_file_stem + "-reconstruction-summary.json"))
-            .string();
+    const fs::path input_path(input_dir);
+    const std::string pixel_hits_dir = (input_path / "pixelHits").string();
+
+    // Output paths are only used when --output is supplied; otherwise the run
+    // prints summary counts and writes nothing.
+    std::string photons_dir;
+    std::string logs_dir;
+    std::string summary_path;
+    if (have_output) {
+        const fs::path output_path(output_dir);
+        photons_dir = (output_path / "photons").string();
+        logs_dir = (output_path / "logs").string();
+        summary_path =
+            (fs::path(logs_dir) /
+             (base_file_name + "-reconstruction-summary.json"))
+                .string();
+    }
 
     const auto total_start = Clock::now();
 
-    // Discover the pixel_data files for this stem, grouped and ordered per chip.
+    // Discover the pixel_data files for this base name, grouped and ordered per
+    // chip.
     auto groups = hermes_photon_clusterer::discoverPixelFiles(pixel_hits_dir,
-                                                              raw_file_stem);
+                                                              base_file_name);
     if (!groups.errors.empty()) {
         for (const auto& error : groups.errors) {
             std::cerr << "Error: " << error << "\n";
@@ -213,7 +268,7 @@ int main(const int argc, char* argv[]) {
 
     // Shared photon-file metadata; chip_index is filled in per chip.
     hermes_photon_clusterer::PhotonFileMetadata metadata;
-    metadata.raw_file_stem = raw_file_stem;
+    metadata.raw_file_stem = base_file_name;
     metadata.canonical_tick_seconds = kCanonicalTickSeconds;
     metadata.clustering_algorithm = "connected_components";
     metadata.clustering_settings_json = settingsToJson(settings).dump();
@@ -256,10 +311,10 @@ int main(const int argc, char* argv[]) {
 
     // Reconstruct each chip independently and accumulate counts and output.
     for (const auto& [chip, files] : groups.files_by_chip) {
-        // Record the input files relative to the analysis directory.
+        // Record the input files relative to the input directory.
         for (const auto& file : files) {
             summary.input_pixel_data_files.push_back(
-                fs::relative(file, analysis_path).string());
+                fs::relative(file, input_path).string());
         }
 
         // Read the chip's ordered pixel_data into memory in timestamp order.
@@ -318,12 +373,16 @@ int main(const int argc, char* argv[]) {
         summary.bridged_components_count +=
             result.counts.bridged_components_count;
 
-        // Write this chip's photon output.
+        // Write this chip's photon output only when --output was supplied.
+        if (!have_output) {
+            continue;
+        }
         metadata.chip_index = chip;
         const auto write_start = Clock::now();
         std::vector<std::string> write_errors;
         auto events_result = hermes_photon_clusterer::writePhotonEventsParquet(
-            result.photons, photons_dir, metadata, kRowsPerPart, write_errors);
+            result.photons, photons_dir, metadata, kRowsPerPart, overwrite,
+            write_errors);
         if (!write_errors.empty()) {
             for (const auto& error : write_errors) {
                 std::cerr << "Error: " << error << "\n";
@@ -339,7 +398,7 @@ int main(const int argc, char* argv[]) {
             auto pixels_result =
                 hermes_photon_clusterer::writePhotonPixelsParquet(
                     result.photon_pixels, photons_dir, metadata, kRowsPerPart,
-                    write_errors);
+                    overwrite, write_errors);
             if (!write_errors.empty()) {
                 for (const auto& error : write_errors) {
                     std::cerr << "Error: " << error << "\n";
@@ -359,7 +418,18 @@ int main(const int argc, char* argv[]) {
     summary.parquet_writing_seconds = writing_seconds;
     summary.total_seconds = secondsSince(total_start);
 
-    // Write the whole-stem reconstruction summary under logs/.
+    std::cout << "Reconstructed " << summary.photon_count << " photons from "
+              << summary.pixel_rows_read << " pixel rows across "
+              << groups.files_by_chip.size() << " chip(s).\n";
+
+    // Without --output, print the summary counts and write no files.
+    if (!have_output) {
+        std::cout << "Rejected " << summary.rejected_component_count
+                  << " component(s); no files written (no --output).\n";
+        return 0;
+    }
+
+    // Write the whole-base-name reconstruction summary under logs/.
     std::error_code ec;
     fs::create_directories(logs_dir, ec);
     if (ec) {
@@ -368,16 +438,13 @@ int main(const int argc, char* argv[]) {
         return 1;
     }
     try {
-        hermes_photon_clusterer::writeReconstructionSummaryJson(summary_path,
-                                                                summary);
+        hermes_photon_clusterer::writeReconstructionSummaryJson(
+            summary_path, summary, overwrite);
     } catch (const std::exception& error) {
         std::cerr << "Error: " << error.what() << "\n";
         return 1;
     }
 
-    std::cout << "Reconstructed " << summary.photon_count << " photons from "
-              << summary.pixel_rows_read << " pixel rows across "
-              << groups.files_by_chip.size() << " chip(s).\n";
     std::cout << "Summary: " << summary_path << "\n";
     return 0;
 }

--- a/backends/reconstruction/photons/cpp/src/photon_writer.cpp
+++ b/backends/reconstruction/photons/cpp/src/photon_writer.cpp
@@ -90,14 +90,16 @@ bool ensureDirectory(const std::string& path, std::vector<std::string>& errors) 
     return true;
 }
 
-// Writes one Arrow table to a Parquet part file, refusing to overwrite.
+// Writes one Arrow table to a Parquet part file. When overwrite is false,
+// refuses to replace an existing file; when true, replaces it.
 bool writeTablePart(const std::shared_ptr<arrow::Table>& table,
                     const std::string& directory,
                     const std::string& filename,
                     std::uint64_t rows_per_part,
+                    bool overwrite,
                     std::vector<std::string>& errors) {
     const std::string full_path = directory + "/" + filename;
-    if (std::filesystem::exists(full_path)) {
+    if (!overwrite && std::filesystem::exists(full_path)) {
         errors.push_back("Refusing to overwrite existing photon file " +
                          full_path);
         return false;
@@ -220,6 +222,7 @@ PhotonWriteResult writePhotonEventsParquet(
     const std::string& photon_output_directory,
     const PhotonFileMetadata& metadata,
     std::uint64_t rows_per_part,
+    bool overwrite,
     std::vector<std::string>& errors) {
     PhotonWriteResult result;
     if (photons.empty()) {
@@ -239,7 +242,7 @@ PhotonWriteResult writePhotonEventsParquet(
         const std::string filename = makePhotonFileName(
             metadata.raw_file_stem, metadata.chip_index, "photon-events", part);
         if (!writeTablePart(table, photon_output_directory, filename,
-                            rows_per_part, errors)) {
+                            rows_per_part, overwrite, errors)) {
             return {};
         }
         result.files.push_back(filename);
@@ -253,6 +256,7 @@ PhotonWriteResult writePhotonPixelsParquet(
     const std::string& photon_output_directory,
     const PhotonFileMetadata& metadata,
     std::uint64_t rows_per_part,
+    bool overwrite,
     std::vector<std::string>& errors) {
     PhotonWriteResult result;
     if (rows.empty()) {
@@ -272,7 +276,7 @@ PhotonWriteResult writePhotonPixelsParquet(
         const std::string filename = makePhotonFileName(
             metadata.raw_file_stem, metadata.chip_index, "photon-pixels", part);
         if (!writeTablePart(table, photon_output_directory, filename,
-                            rows_per_part, errors)) {
+                            rows_per_part, overwrite, errors)) {
             return {};
         }
         result.files.push_back(filename);
@@ -288,6 +292,7 @@ PhotonWriteResult writePhotonEventsParquet(
     const std::string& /*photon_output_directory*/,
     const PhotonFileMetadata& /*metadata*/,
     std::uint64_t /*rows_per_part*/,
+    bool /*overwrite*/,
     std::vector<std::string>& errors) {
     errors.push_back("photon_events writing requires Arrow/Parquet support");
     return {};
@@ -298,6 +303,7 @@ PhotonWriteResult writePhotonPixelsParquet(
     const std::string& /*photon_output_directory*/,
     const PhotonFileMetadata& /*metadata*/,
     std::uint64_t /*rows_per_part*/,
+    bool /*overwrite*/,
     std::vector<std::string>& errors) {
     errors.push_back("photon_pixels writing requires Arrow/Parquet support");
     return {};

--- a/backends/reconstruction/photons/cpp/src/photon_writer.cpp
+++ b/backends/reconstruction/photons/cpp/src/photon_writer.cpp
@@ -125,6 +125,28 @@ bool writeTablePart(const std::shared_ptr<arrow::Table>& table,
     return true;
 }
 
+// Refuses the whole write up front if any expected part file already exists, so
+// a refused overwrite never leaves some parts written and others not. Only used
+// when overwrite is false. Returns false and appends an error on the first
+// existing part.
+bool ensureNoExistingParts(const std::string& directory,
+                           const std::string& stem,
+                           int chip_index,
+                           const std::string& group,
+                           std::uint64_t parts,
+                           std::vector<std::string>& errors) {
+    for (std::uint64_t part = 0; part < parts; ++part) {
+        const std::string full_path =
+            directory + "/" + makePhotonFileName(stem, chip_index, group, part);
+        if (std::filesystem::exists(full_path)) {
+            errors.push_back("Refusing to overwrite existing photon file " +
+                             full_path);
+            return false;
+        }
+    }
+    return true;
+}
+
 std::shared_ptr<arrow::Table> buildEventsTable(
     const std::vector<Photon>& photons,
     std::uint64_t start,
@@ -235,6 +257,12 @@ PhotonWriteResult writePhotonEventsParquet(
     const auto kv = buildFileMetadata(metadata, kPhotonEventsSchemaName);
     const std::uint64_t total = photons.size();
     const std::uint64_t parts = (total + rows_per_part - 1) / rows_per_part;
+    if (!overwrite &&
+        !ensureNoExistingParts(photon_output_directory, metadata.raw_file_stem,
+                               metadata.chip_index, "photon-events", parts,
+                               errors)) {
+        return {};
+    }
     for (std::uint64_t part = 0; part < parts; ++part) {
         const std::uint64_t start = part * rows_per_part;
         const std::uint64_t count = std::min(rows_per_part, total - start);
@@ -269,6 +297,12 @@ PhotonWriteResult writePhotonPixelsParquet(
     const auto kv = buildFileMetadata(metadata, kPhotonPixelsSchemaName);
     const std::uint64_t total = rows.size();
     const std::uint64_t parts = (total + rows_per_part - 1) / rows_per_part;
+    if (!overwrite &&
+        !ensureNoExistingParts(photon_output_directory, metadata.raw_file_stem,
+                               metadata.chip_index, "photon-pixels", parts,
+                               errors)) {
+        return {};
+    }
     for (std::uint64_t part = 0; part < parts; ++part) {
         const std::uint64_t start = part * rows_per_part;
         const std::uint64_t count = std::min(rows_per_part, total - start);

--- a/backends/reconstruction/photons/cpp/src/summary_writer.cpp
+++ b/backends/reconstruction/photons/cpp/src/summary_writer.cpp
@@ -136,8 +136,9 @@ std::string generateReconstructionSummaryJson(
 
 void writeReconstructionSummaryJson(
     const std::string& output_path,
-    const ReconstructionSummaryContent& content) {
-    if (std::filesystem::exists(output_path)) {
+    const ReconstructionSummaryContent& content,
+    bool overwrite) {
+    if (!overwrite && std::filesystem::exists(output_path)) {
         throw std::runtime_error(
             "Refusing to overwrite existing reconstruction summary file: " +
             output_path);

--- a/backends/reconstruction/photons/cpp/tests/photon_writer_tests.cpp
+++ b/backends/reconstruction/photons/cpp/tests/photon_writer_tests.cpp
@@ -83,7 +83,8 @@ int main() {
         std::vector<std::string> errors;
         const auto dir = (base / "events").string();
         auto result = writePhotonEventsParquet(photons, dir,
-                                               sampleMetadata(), 1000, errors);
+                                               sampleMetadata(), 1000, false,
+                                               errors);
         test.expect(errors.empty(), "events write reports no errors");
         test.expectEqual(result.row_count, std::uint64_t{2}, "two events written");
         test.expectEqual(result.files.size(), std::size_t{1}, "one events part");
@@ -132,7 +133,8 @@ int main() {
         std::vector<std::string> errors;
         const auto dir = (base / "pixels").string();
         auto result = writePhotonPixelsParquet(rows, dir,
-                                               sampleMetadata(), 1000, errors);
+                                               sampleMetadata(), 1000, false,
+                                               errors);
         test.expect(errors.empty(), "pixels write reports no errors");
         test.expectEqual(result.row_count, std::uint64_t{3}, "three pixels");
         if (result.files.size() == 1) {
@@ -154,7 +156,8 @@ int main() {
     {
         std::vector<std::string> errors;
         auto result = writePhotonEventsParquet({}, (base / "empty").string(),
-                                               sampleMetadata(), 1000, errors);
+                                               sampleMetadata(), 1000, false,
+                                               errors);
         test.expect(errors.empty(), "empty events write has no errors");
         test.expectEqual(result.row_count, std::uint64_t{0}, "no rows");
         test.expect(result.files.empty(), "no files for empty events");
@@ -165,11 +168,47 @@ int main() {
         std::vector<Photon> photons(5, Photon{1.0, 1.0, 1.0, 1, 0});
         std::vector<std::string> errors;
         auto result = writePhotonEventsParquet(photons, (base / "multi").string(),
-                                               sampleMetadata(), 2, errors);
+                                               sampleMetadata(), 2, false,
+                                               errors);
         test.expect(errors.empty(), "multi-part write has no errors");
         test.expectEqual(result.files.size(), std::size_t{3},
                          "five rows at two per part yields three files");
         test.expectEqual(result.row_count, std::uint64_t{5}, "row count is five");
+    }
+
+    // overwrite == false refuses an existing part; overwrite == true replaces it.
+    {
+        const auto dir = (base / "overwrite").string();
+        std::vector<Photon> first = {Photon{1.0, 1.0, 1.0, 1, 0}};
+        std::vector<std::string> errors;
+        auto initial = writePhotonEventsParquet(first, dir, sampleMetadata(),
+                                                1000, false, errors);
+        test.expect(errors.empty() && initial.row_count == 1,
+                    "initial events write succeeds");
+
+        // A second write to the same file with overwrite == false must refuse.
+        std::vector<std::string> refuse_errors;
+        auto refused = writePhotonEventsParquet(first, dir, sampleMetadata(),
+                                                1000, false, refuse_errors);
+        test.expect(!refuse_errors.empty() && refused.row_count == 0,
+                    "overwrite == false refuses existing photon file");
+
+        // With overwrite == true the file is replaced with new contents.
+        std::vector<Photon> second = {
+            Photon{2.0, 2.0, 2.0, 2, 0},
+            Photon{3.0, 3.0, 3.0, 3, 0},
+        };
+        std::vector<std::string> replace_errors;
+        auto replaced = writePhotonEventsParquet(second, dir, sampleMetadata(),
+                                                 1000, true, replace_errors);
+        test.expect(replace_errors.empty() && replaced.row_count == 2,
+                    "overwrite == true replaces existing photon file");
+        if (replaced.files.size() == 1) {
+            auto table = readTable(
+                (std::filesystem::path(dir) / replaced.files[0]).string());
+            test.expectEqual(table->num_rows(), std::int64_t{2},
+                             "replaced file holds the new rows");
+        }
     }
 
     std::filesystem::remove_all(base);

--- a/backends/reconstruction/photons/cpp/tests/summary_writer_tests.cpp
+++ b/backends/reconstruction/photons/cpp/tests/summary_writer_tests.cpp
@@ -1,4 +1,7 @@
 #include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
 #include <string>
 
 #include <nlohmann/json.hpp>
@@ -10,6 +13,14 @@ namespace {
 
 using hermes_photon_clusterer::ReconstructionSummaryContent;
 using hermes_photon_clusterer::generateReconstructionSummaryJson;
+using hermes_photon_clusterer::writeReconstructionSummaryJson;
+
+std::string readFile(const std::string& path) {
+    std::ifstream in(path);
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    return buffer.str();
+}
 
 // A content struct whose counts satisfy the summary's cross-field validators:
 // pixel_rows_below_min_tot <= pixel_rows_read, photon_count +
@@ -129,6 +140,40 @@ int main() {
                             ["pixels_per_second"]
                         .get<double>() == 0.0,
                     "zero total time gives zero throughput");
+    }
+
+    // overwrite == false refuses an existing summary; overwrite == true replaces.
+    {
+        const auto base = std::filesystem::temp_directory_path() /
+                           "hermes_summary_writer_tests";
+        std::filesystem::remove_all(base);
+        std::filesystem::create_directories(base);
+        const auto path = (base / "summary.json").string();
+
+        auto content = consistentContent();
+        content.photon_count = 70;
+        writeReconstructionSummaryJson(path, content, false);
+        test.expect(std::filesystem::exists(path), "summary written initially");
+
+        // A second write with overwrite == false must throw.
+        bool refused = false;
+        try {
+            writeReconstructionSummaryJson(path, content, false);
+        } catch (const std::exception&) {
+            refused = true;
+        }
+        test.expect(refused, "overwrite == false refuses existing summary");
+
+        // With overwrite == true the file is replaced with the new content.
+        auto replacement = consistentContent();
+        replacement.photon_count = 12;
+        replacement.rejected_component_count = 88;  // keeps components_formed
+        writeReconstructionSummaryJson(path, replacement, true);
+        auto j = nlohmann::json::parse(readFile(path));
+        test.expectEqual(j["reconstruction"]["photon_count"].get<int>(), 12,
+                         "overwrite == true replaces the summary content");
+
+        std::filesystem::remove_all(base);
     }
 
     return test.finish();

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -1,3 +1,10 @@
+"""Runs the C++ photon reconstruction binary over unpacked pixel data.
+
+The flow is: plan_reconstruction decides which raw files still need work,
+execute_reconstruction runs the binary on one file and checks its output, and
+the helpers below validate that the files it produced are complete and safe.
+"""
+
 from __future__ import annotations
 
 import json
@@ -50,6 +57,8 @@ def derive_summary_path(
     analysis: HermesTpx3AnalysisState,
     raw_file: FileReference,
 ) -> Path:
+    """Return the path of the summary JSON the binary writes for one raw file."""
+    # The file is named after the raw file (without its extension), under logs/.
     return (
         analysis.analysis_directory
         / "logs"
@@ -65,6 +74,10 @@ def derive_reconstruction_command(
     *,
     overwrite: bool = False,
 ) -> list[str]:
+    """Build the command line that launches the reconstruction binary."""
+    # Reads pixel data from and writes results to the same analysis directory.
+    # --overwrite lets it replace files from a previous run; without it the
+    # binary refuses and stops.
     command = [
         str(reconstruction.program.executable_path),
         "--input",
@@ -86,20 +99,29 @@ def plan_reconstruction(
     *,
     overwrite: bool = False,
 ) -> ReconstructionPlan:
+    """Decide, per raw file, whether to "run" reconstruction or "skip" it.
+
+    A file is skipped when valid results already exist. This runs before any
+    binary is launched, so problems are caught up front.
+    """
     reconstruction = _require_reconstruction(analysis)
     _validate_program_and_algorithm(reconstruction)
 
+    # With overwrite, redo every file regardless of existing output.
     if overwrite:
         return [(raw_file, "run") for raw_file in analysis.tpx3_files]
 
     plan: ReconstructionPlan = []
     for raw_file in analysis.tpx3_files:
         summary_path = derive_summary_path(analysis, raw_file)
+        # Photon files already sitting in the output directory for this file.
         matching_photon_files = _matching_photon_files(
             reconstruction.photon_output_directory,
             raw_file.path.stem,
         )
 
+        # A summary exists: only skip if it matches the requested settings and
+        # its files check out. A mismatch means the existing results are stale.
         if summary_path.exists():
             summary = _load_summary(summary_path)
             if (
@@ -117,11 +139,14 @@ def plan_reconstruction(
                 raw_file.path.stem,
             )
             plan.append((raw_file, "skip"))
+        # Photon files but no summary means a half-finished or corrupt run; stop
+        # rather than silently overwrite or trust them.
         elif matching_photon_files:
             raise HermesReconstructionPreflightError(
                 f"photon files exist without a valid summary for "
                 f"{raw_file.path}: {matching_photon_files[0]}"
             )
+        # Nothing on disk yet: this file needs reconstruction.
         else:
             plan.append((raw_file, "run"))
 
@@ -134,6 +159,11 @@ def execute_reconstruction(
     *,
     overwrite: bool = False,
 ) -> Tpx3PhotonReconstructionSummary:
+    """Run the binary on one raw file and return its validated summary.
+
+    Raises a HermesReconstructionError if the binary fails to launch, exits with
+    an error, or produces output that does not pass validation.
+    """
     reconstruction = _require_reconstruction(analysis)
     summary_path = derive_summary_path(analysis, raw_file)
     started = perf_counter()
@@ -172,6 +202,8 @@ def execute_reconstruction(
     )
 
     try:
+        # Launch the binary and wait for it. shell=False avoids shell parsing;
+        # check=False lets us inspect the exit code ourselves below.
         try:
             process = subprocess.run(
                 command,
@@ -210,6 +242,8 @@ def execute_reconstruction(
                 f"{raw_file.path}"
             )
 
+        # The binary exited cleanly; now confirm the output it left behind is
+        # complete and matches what we asked for before trusting it.
         summary: Tpx3PhotonReconstructionSummary | None = None
         try:
             summary = _load_summary(summary_path)
@@ -244,6 +278,7 @@ def execute_reconstruction(
             )
             raise
     finally:
+        # Always remove the temporary settings file, even if the run failed.
         settings_file.unlink(missing_ok=True)
 
     _ANALYSIS_LOGGER.info(
@@ -267,6 +302,7 @@ def log_skipped_input(
     analysis: HermesTpx3AnalysisState,
     raw_file: FileReference,
 ) -> None:
+    """Log that one raw file was skipped because valid results already exist."""
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_reconstruction.skipped",
         event_type="analysis.tpx3_reconstruction.skipped",
@@ -282,6 +318,7 @@ def log_overall_completion(
     raw_file_count: int,
     reconstructed_file_count: int,
 ) -> None:
+    """Log a summary line once every raw file has been handled."""
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_reconstruction.completed",
         event_type="analysis.tpx3_reconstruction.completed",
@@ -293,6 +330,7 @@ def log_overall_completion(
 
 
 def log_overall_failure(error: Exception) -> None:
+    """Log that the overall reconstruction run failed."""
     _ANALYSIS_LOGGER.error(
         "analysis.tpx3_reconstruction.failed",
         event_type="analysis.tpx3_reconstruction.failed",
@@ -304,6 +342,7 @@ def log_overall_failure(error: Exception) -> None:
 def _require_reconstruction(
     analysis: HermesTpx3AnalysisState,
 ) -> Tpx3PhotonReconstructionConfiguration:
+    """Return the reconstruction config, or raise if it is not set up."""
     reconstruction = analysis.photon_reconstruction
     if reconstruction is None:
         raise HermesReconstructionPreflightError(
@@ -315,6 +354,7 @@ def _require_reconstruction(
 def _validate_program_and_algorithm(
     reconstruction: Tpx3PhotonReconstructionConfiguration,
 ) -> None:
+    """Check the algorithm is supported and the binary exists before running."""
     if reconstruction.clustering_algorithm != "connected_components":
         raise HermesReconstructionPreflightError(
             f"clustering_algorithm={reconstruction.clustering_algorithm!r} is "
@@ -328,6 +368,7 @@ def _validate_program_and_algorithm(
 
 
 def _load_summary(summary_path: Path) -> Tpx3PhotonReconstructionSummary:
+    """Read and parse a summary JSON file into a validated model object."""
     if not summary_path.is_file():
         raise HermesReconstructionPreflightError(
             f"summary path is not a regular file: {summary_path}"
@@ -352,11 +393,19 @@ def _validate_completed_files(
     analysis_directory: Path,
     raw_file_stem: str,
 ) -> None:
+    """Confirm the files the summary claims to have produced are real and sane.
+
+    Guards against a summary that reports errors, lists files that are missing,
+    misnamed, duplicated, or point outside the analysis directory, has row
+    counts that disagree with the files, or leaves stray files on disk. Any of
+    these raises HermesReconstructionOutputError.
+    """
     if summary.reconstruction.errors:
         raise HermesReconstructionOutputError(
             f"summary reports reconstruction errors: {summary_path}"
         )
 
+    # Used below to make sure no listed file escapes the analysis directory.
     analysis_root = analysis_directory.resolve()
 
     # photon_events is always written; photon_pixels only when it was requested.
@@ -381,6 +430,8 @@ def _validate_completed_files(
         rf"^{re.escape(raw_file_stem)}-chip-(\d+)-(photon-events|photon-pixels)"
         rf"-part-(\d{{5}})\.parquet$"
     )
+    # Check every file the summary lists: correct name, no duplicates, inside
+    # the directory, and actually present on disk.
     for filename_marker, category, _always in file_groups:
         parts_by_chip: dict[int, list[int]] = {}
         for relative_path in category.files:
@@ -418,6 +469,7 @@ def _validate_completed_files(
                 )
             listed_files.add(relative_path)
 
+        # Each chip's parts must be numbered 0, 1, 2, ... with no gaps.
         for chip_index, part_indexes in parts_by_chip.items():
             if sorted(part_indexes) != list(range(len(part_indexes))):
                 raise HermesReconstructionOutputError(
@@ -463,6 +515,7 @@ def _matching_photon_files(
     photon_output_directory: Path,
     raw_file_stem: str,
 ) -> list[Path]:
+    """List the photon files on disk that belong to one raw file."""
     if not photon_output_directory.is_dir():
         return []
     pattern = f"{raw_file_stem}-*.parquet"
@@ -470,6 +523,7 @@ def _matching_photon_files(
 
 
 def _bounded_text(text: str) -> str:
+    """Trim text so a single log entry cannot grow without bound."""
     return text[:_LOG_TEXT_LIMIT]
 
 
@@ -484,6 +538,7 @@ def _log_process_failure(
     stderr_excerpt: str = "",
     summary: dict[str, object] | None = None,
 ) -> None:
+    """Log a failure for one raw file with the command output for debugging."""
     _ANALYSIS_LOGGER.error(
         "analysis.tpx3_reconstruction.failed",
         event_type="analysis.tpx3_reconstruction.failed",

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -62,19 +62,35 @@ def derive_reconstruction_command(
     analysis_directory: Path,
     raw_file_stem: str,
     settings_file: Path,
+    *,
+    overwrite: bool = False,
 ) -> list[str]:
-    return [
+    command = [
         str(reconstruction.program.executable_path),
+        "--input",
         str(analysis_directory),
+        "--base-file-name",
         raw_file_stem,
+        "--output",
+        str(analysis_directory),
         "--settings",
         str(settings_file),
     ]
+    if overwrite:
+        command.append("--overwrite")
+    return command
 
 
-def plan_reconstruction(analysis: HermesTpx3AnalysisState) -> ReconstructionPlan:
+def plan_reconstruction(
+    analysis: HermesTpx3AnalysisState,
+    *,
+    overwrite: bool = False,
+) -> ReconstructionPlan:
     reconstruction = _require_reconstruction(analysis)
     _validate_program_and_algorithm(reconstruction)
+
+    if overwrite:
+        return [(raw_file, "run") for raw_file in analysis.tpx3_files]
 
     plan: ReconstructionPlan = []
     for raw_file in analysis.tpx3_files:
@@ -115,6 +131,8 @@ def plan_reconstruction(analysis: HermesTpx3AnalysisState) -> ReconstructionPlan
 def execute_reconstruction(
     analysis: HermesTpx3AnalysisState,
     raw_file: FileReference,
+    *,
+    overwrite: bool = False,
 ) -> Tpx3PhotonReconstructionSummary:
     reconstruction = _require_reconstruction(analysis)
     summary_path = derive_summary_path(analysis, raw_file)
@@ -138,6 +156,7 @@ def execute_reconstruction(
         analysis.analysis_directory,
         raw_file.path.stem,
         settings_file,
+        overwrite=overwrite,
     )
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_reconstruction.started",

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -231,7 +231,9 @@ def run_hermes_analysis(
         )
 
         if current_analysis.photon_reconstruction is not None:
-            _run_photon_reconstruction(state_manager, current_analysis)
+            _run_photon_reconstruction(
+                state_manager, current_analysis, overwrite=overwrite
+            )
 
         return unpacked_files
     except HermesTpx3Error as exc:
@@ -275,10 +277,12 @@ def _apply_unpacking_result(
 def _run_photon_reconstruction(
     state_manager: StateManager,
     analysis: HermesTpx3AnalysisState,
+    *,
+    overwrite: bool = False,
 ) -> None:
     """Reconstruct photons for every raw stem, applying status on the main thread."""
     try:
-        reconstruction_plan = plan_reconstruction(analysis)
+        reconstruction_plan = plan_reconstruction(analysis, overwrite=overwrite)
         files_to_run = [
             raw_file
             for raw_file, action in reconstruction_plan
@@ -303,7 +307,9 @@ def _run_photon_reconstruction(
             if action == "skip":
                 log_reconstruction_skipped(analysis, raw_file)
                 continue
-            summary = execute_reconstruction(analysis, raw_file)
+            summary = execute_reconstruction(
+                analysis, raw_file, overwrite=overwrite
+            )
             photon_count += summary.reconstruction.photon_count
             rejected_count += summary.reconstruction.rejected_component_count
 

--- a/tests/unit/hermes/analysis/hermes/test_reconstruction.py
+++ b/tests/unit/hermes/analysis/hermes/test_reconstruction.py
@@ -257,11 +257,23 @@ def _write_fake_clusterer(
         import pyarrow as pa
         import pyarrow.parquet as pq
 
-        analysis_dir = Path(sys.argv[1])
-        stem = sys.argv[2]
+        args = sys.argv[1:]
+        values = {{}}
+        i = 0
+        while i < len(args):
+            flag = args[i]
+            if flag == "--overwrite":
+                values[flag] = True
+                i += 1
+                continue
+            values[flag] = args[i + 1]
+            i += 2
+
+        # --output is where files go; --input holds pixelHits/ (same dir here).
+        analysis_dir = Path(values["--output"])
+        stem = values["--base-file-name"]
         # settings arrive via --settings <file>; read to prove it is passed.
-        assert sys.argv[3] == "--settings"
-        settings = json.loads(Path(sys.argv[4]).read_text())
+        settings = json.loads(Path(values["--settings"]).read_text())
 
         exit_code = {exit_code}
         write_summary = {write_summary}
@@ -398,7 +410,7 @@ def test_plan_rejects_summary_requesting_missing_pixels(tmp_path: Path) -> None:
 # ---- derive_reconstruction_command --------------------------------------
 
 
-def test_command_passes_analysis_stem_and_settings(tmp_path: Path) -> None:
+def test_command_passes_named_flags_and_settings(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "run_000000.tpx3")
     reconstruction = analysis.photon_reconstruction
     command = derive_reconstruction_command(
@@ -407,9 +419,29 @@ def test_command_passes_analysis_stem_and_settings(tmp_path: Path) -> None:
         "run_000000",
         tmp_path / "settings.json",
     )
-    assert command[1] == str(analysis.analysis_directory)
-    assert command[2] == "run_000000"
-    assert command[3] == "--settings"
+    assert command[1:] == [
+        "--input",
+        str(analysis.analysis_directory),
+        "--base-file-name",
+        "run_000000",
+        "--output",
+        str(analysis.analysis_directory),
+        "--settings",
+        str(tmp_path / "settings.json"),
+    ]
+    assert "--overwrite" not in command
+
+
+def test_command_appends_overwrite_when_requested(tmp_path: Path) -> None:
+    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    command = derive_reconstruction_command(
+        analysis.photon_reconstruction,
+        analysis.analysis_directory,
+        "run_000000",
+        tmp_path / "settings.json",
+        overwrite=True,
+    )
+    assert command[-1] == "--overwrite"
 
 
 # ---- execute_reconstruction ---------------------------------------------


### PR DESCRIPTION
This pull request updates the photon clusterer command-line interface and output logic to add support for an `--overwrite` option, which allows users to explicitly permit overwriting existing output files. The changes affect both the user interface and the underlying file-writing functions, ensuring that output files (photon Parquet files and summary JSON) are only overwritten when requested. The argument parsing and help text are also modernized and clarified, and the positional arguments are replaced with named options.

**Command-line interface and argument parsing:**
- Switched from positional arguments to named options: `--input`, `--base-file-name`, `--settings`, `--output`, and new `--overwrite` flag. The program now requires explicit options for input and base file name, and only writes outputs when `--output` is supplied. (`[[1]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL40-R64)`, `[[2]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL139-R207)`)
- Updated help text to reflect the new interface, required/optional arguments, and the behavior of the `--overwrite` flag. (`[backends/reconstruction/photons/cpp/src/photonClusterer.cppL40-R64](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL40-R64)`)

**Overwrite support for output files:**
- Added `overwrite` parameter to photon Parquet file writing functions (`writePhotonEventsParquet`, `writePhotonPixelsParquet`) and the summary JSON writer (`writeReconstructionSummaryJson`). These functions now refuse to overwrite existing files unless `overwrite` is true. (`[[1]](diffhunk://#diff-61bac45c51177b7ae0ff0c04961c6e209701d372729622398bb2d0230ebc166dL58-R78)`, `[[2]](diffhunk://#diff-acfc1897440c3bba6e2a8e9cfc27c452b42fde31f1bd016e6513510e37290e72L93-R102)`, `[[3]](diffhunk://#diff-acfc1897440c3bba6e2a8e9cfc27c452b42fde31f1bd016e6513510e37290e72R225)`, `[[4]](diffhunk://#diff-acfc1897440c3bba6e2a8e9cfc27c452b42fde31f1bd016e6513510e37290e72L242-R245)`, `[[5]](diffhunk://#diff-acfc1897440c3bba6e2a8e9cfc27c452b42fde31f1bd016e6513510e37290e72R259)`, `[[6]](diffhunk://#diff-acfc1897440c3bba6e2a8e9cfc27c452b42fde31f1bd016e6513510e37290e72L275-R279)`, `[[7]](diffhunk://#diff-acfc1897440c3bba6e2a8e9cfc27c452b42fde31f1bd016e6513510e37290e72R295)`, `[[8]](diffhunk://#diff-acfc1897440c3bba6e2a8e9cfc27c452b42fde31f1bd016e6513510e37290e72R306)`, `[[9]](diffhunk://#diff-b22253f0b014c7355e3369031dbaea6cd9776066ff2e9d81ba72e634a4a3173bL139-R141)`, `[[10]](diffhunk://#diff-d8979a53b27974e552bc3c24a44d6f6c985aa9b5a91a5517ae7f04676cced796L84-R90)`)
- The `--overwrite` flag is now passed through the main program logic to all relevant output functions. (`[[1]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL321-R385)`, `[[2]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL342-R401)`, `[[3]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL371-L380)`)

**Output logic and user feedback:**
- The program prints summary counts and does not write any files unless `--output` is specified. Output directories and summary files are only created when requested. (`[[1]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL193-R261)`, `[[2]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL321-R385)`, `[[3]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL362-R432)`)
- Improved error messages and argument validation for missing or incorrect options. (`[backends/reconstruction/photons/cpp/src/photonClusterer.cppL139-R207](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL139-R207)`)

**Tests:**
- Updated tests to pass the new `overwrite` parameter to photon writer functions. (`[backends/reconstruction/photons/cpp/tests/photon_writer_tests.cppL86-R87](diffhunk://#diff-25c861f629838c2b39b87c4fd46d459c41f8ecc4b4a0c1a24b4469ecdf19217dL86-R87)`)

These changes ensure safer file handling, clearer user interaction, and more robust command-line parsing.