### PR TITLE
46 improve analysis

### DIFF
--- a/backends/reconstruction/photons/cpp/inc/photon_writer.h
+++ b/backends/reconstruction/photons/cpp/inc/photon_writer.h
@@ -44,37 +44,32 @@ struct PhotonPixelRow {
     std::uint64_t timestamp_canonical = 0;
 };
 
-// Result of writing one file group: the relative paths written and the row count.
+// Result of writing one photon file: the path written and the row count.
 struct PhotonWriteResult {
-    std::vector<std::string> files;
+    std::string file;
     std::uint64_t row_count = 0;
 };
 
-// Writes photon_events for one raw stem and chip under photon_output_directory,
-// splitting into parts of rows_per_part rows. Files are named
-// "<stem>-chip-<chip>-photon-events-part-<00000>.parquet". Photons carry an
-// implicit zero-based photon_id equal to their index in the vector. Appends to
-// errors and returns an empty result on failure. Writes nothing when photons is
-// empty. When overwrite is false, refuses to replace an existing file; when
-// true, replaces it.
+// Writes photon_events for one input file to output_file_path as a single
+// Parquet file. Photons carry an implicit zero-based photon_id equal to their
+// index in the vector. Appends to errors and returns an empty result on
+// failure. Writes nothing when photons is empty. When overwrite is false,
+// refuses to replace an existing file; when true, replaces it.
 PhotonWriteResult writePhotonEventsParquet(
     const std::vector<Photon>& photons,
-    const std::string& photon_output_directory,
+    const std::string& output_file_path,
     const PhotonFileMetadata& metadata,
-    std::uint64_t rows_per_part,
     bool overwrite,
     std::vector<std::string>& errors);
 
-// Writes photon_pixels for one raw stem and chip. Files are named
-// "<stem>-chip-<chip>-photon-pixels-part-<00000>.parquet". Rows are written in
-// the given order. Appends to errors on failure. Writes nothing when rows empty.
-// When overwrite is false, refuses to replace an existing file; when true,
-// replaces it.
+// Writes photon_pixels for one input file to output_file_path as a single
+// Parquet file. Rows are written in the given order. Appends to errors on
+// failure. Writes nothing when rows empty. When overwrite is false, refuses to
+// replace an existing file; when true, replaces it.
 PhotonWriteResult writePhotonPixelsParquet(
     const std::vector<PhotonPixelRow>& rows,
-    const std::string& photon_output_directory,
+    const std::string& output_file_path,
     const PhotonFileMetadata& metadata,
-    std::uint64_t rows_per_part,
     bool overwrite,
     std::vector<std::string>& errors);
 

--- a/backends/reconstruction/photons/cpp/inc/pixel_reader.h
+++ b/backends/reconstruction/photons/cpp/inc/pixel_reader.h
@@ -3,7 +3,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <map>
 #include <string>
 #include <vector>
 
@@ -20,21 +19,6 @@ struct PixelHit {
     // reference the source pixel in photon_pixels output.
     std::uint64_t pixel_event_id = 0;
 };
-
-// Pixel-data Parquet files for one raw stem, grouped by chip index and ordered
-// by part number. The unpacker writes each chip's parts in timestamp order and
-// numbers them contiguously from zero, so reading parts in order yields a
-// time-sorted stream per chip.
-struct PixelFileGroups {
-    std::map<int, std::vector<std::string>> files_by_chip;
-    std::vector<std::string> errors;
-};
-
-// Discover pixel_data files named "<stem>-chip-<chip>-part-<00000>.parquet" in
-// pixel_data_directory for the given raw stem. Reports an error when a chip's
-// part numbers are not contiguous from zero.
-PixelFileGroups discoverPixelFiles(const std::string& pixel_data_directory,
-                                   const std::string& raw_file_stem);
 
 // Stream the pixel_data rows of the ordered files, invoking on_hit for each row
 // in file/part order. Returns false and appends to errors on a read failure.

--- a/backends/reconstruction/photons/cpp/inc/summary_writer.h
+++ b/backends/reconstruction/photons/cpp/inc/summary_writer.h
@@ -9,37 +9,9 @@
 
 namespace hermes_photon_clusterer {
 
-// The complete clustering settings, mirrored into the summary's
-// clustering.settings block. Field names match Tpx3PhotonClusteringSettings.
-struct SummaryClusteringSettings {
-    std::uint64_t max_time_spread_ticks = 0;
-    std::uint32_t min_cluster_size = 0;
-    std::uint32_t max_cluster_size = 0;
-    std::uint16_t min_pixel_tot_raw = 0;
-    std::uint64_t min_cluster_tot_raw = 0;
-    std::uint64_t max_cluster_tot_raw = 0;
-    double max_aspect_ratio = 0.0;
-    double min_filled_fraction = 0.0;
-    int adjacency = 8;
-    std::string position_averaging = "arithmetic";
-    std::string photon_time_estimator = "leading_edge";
-    // Empty string means no calibration file was supplied.
-    std::string timewalk_calibration_file;
-    bool save_photon_pixels = false;
-};
-
-// Timing block. correction_model is "none", "inverse", or "linear". When "none",
-// calibration_file is empty, parameters is empty, and high_tot_anchor is unset.
-struct SummaryPhotonTiming {
-    std::string estimator = "leading_edge";
-    std::string correction_model = "none";
-    std::string calibration_file;
-    std::vector<std::pair<std::string, double>> parameters;
-    bool has_high_tot_anchor = false;
-    double high_tot_anchor = 0.0;
-};
-
-// All content needed to render one raw stem's reconstruction summary.
+// All content needed to render one input file's reconstruction summary. The
+// summary is purely informational (counts and timing); settings provenance
+// lives in the photon-file metadata, not here.
 struct ReconstructionSummaryContent {
     // reconstruction counts
     std::uint64_t pixel_rows_read = 0;
@@ -52,21 +24,6 @@ struct ReconstructionSummaryContent {
     std::uint64_t bridged_components_count = 0;
     std::vector<std::string> warnings;
     std::vector<std::string> errors;
-
-    // clustering
-    std::string algorithm = "connected_components";
-    SummaryClusteringSettings settings;
-
-    // photon timing
-    SummaryPhotonTiming photon_timing;
-
-    // parquet (paths relative to the analysis directory)
-    std::vector<std::string> input_pixel_data_files;
-    std::uint64_t photon_events_row_count = 0;
-    std::vector<std::string> photon_events_files;
-    bool photon_pixels_requested = false;
-    std::uint64_t photon_pixels_row_count = 0;
-    std::vector<std::string> photon_pixels_files;
 
     // processing times (seconds)
     double parquet_reading_seconds = 0.0;

--- a/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
+++ b/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
@@ -26,9 +26,6 @@ using Clock = std::chrono::steady_clock;
 // 12,288 fine steps the unpacker uses. Written into the photon file metadata.
 constexpr double kCanonicalTickSeconds = 25.0e-9 / 12288.0;
 
-// Photon rows per Parquet part file.
-constexpr std::uint64_t kRowsPerPart = 1'000'000;
-
 double secondsSince(const Clock::time_point start) {
     return std::chrono::duration<double>(Clock::now() - start).count();
 }
@@ -37,22 +34,17 @@ void printHelp(const char* program_name) {
     std::cout << "HERMES Photon Clusterer v" << hermes_photon_clusterer::kVersion
               << "\n\n";
     std::cout << "Usage: " << program_name
-              << " --input <analysis_directory> --base-file-name <name>"
-                 " [--settings <file>] [--output <analysis_directory>]"
-                 " [--overwrite]\n\n";
+              << " --input <pixel_file> [--output <photon_file>]"
+                 " [--settings <file>] [--overwrite]\n\n";
     std::cout << "Options:\n";
-    std::cout << "  --input <analysis_directory>   Directory holding pixelHits/ "
-                 "to read (required)\n";
-    std::cout << "  --base-file-name <name>        Base name of the raw file "
-                 "selecting the\n";
-    std::cout << "                                 pixel_data files to read "
-                 "(required)\n";
+    std::cout << "  --input <pixel_file>           One pixelHits Parquet file "
+                 "to reconstruct (required)\n";
+    std::cout << "  --output <photon_file>         Full path of the photon file "
+                 "to write (optional)\n";
     std::cout << "  --settings <file>              JSON file overriding "
                  "individual clustering\n";
     std::cout << "                                 settings (any field omitted "
                  "keeps its default)\n";
-    std::cout << "  --output <analysis_directory>  Directory to write photons/ "
-                 "and logs/ (optional)\n";
     std::cout << "  --overwrite                    Overwrite existing photon and "
                  "summary files\n";
     std::cout << "  -h, --help                     Show this help message\n";
@@ -61,7 +53,8 @@ void printHelp(const char* program_name) {
     std::cout << "  Without --output:\n";
     std::cout << "    Prints summary counts only; writes no files.\n\n";
     std::cout << "  With --output:\n";
-    std::cout << "    Writes photons/ and logs/ under the output directory.\n";
+    std::cout << "    Writes one photon file at the given path, a photon_pixels\n";
+    std::cout << "    sidecar when enabled, and a reconstruction-summary JSON.\n";
 }
 
 void printVersion() {
@@ -93,26 +86,6 @@ json settingsToJson(const hermes_photon_clusterer::ClusteringSettings& s) {
     return j;
 }
 
-// Copies the clustering settings into the summary's settings block.
-hermes_photon_clusterer::SummaryClusteringSettings summarySettings(
-    const hermes_photon_clusterer::ClusteringSettings& s) {
-    hermes_photon_clusterer::SummaryClusteringSettings out;
-    out.max_time_spread_ticks = s.max_time_spread_ticks;
-    out.min_cluster_size = s.min_cluster_size;
-    out.max_cluster_size = s.max_cluster_size;
-    out.min_pixel_tot_raw = s.min_pixel_tot_raw;
-    out.min_cluster_tot_raw = s.min_cluster_tot_raw;
-    out.max_cluster_tot_raw = s.max_cluster_tot_raw;
-    out.max_aspect_ratio = s.max_aspect_ratio;
-    out.min_filled_fraction = s.min_filled_fraction;
-    out.adjacency = s.adjacency;
-    out.position_averaging = s.position_averaging;
-    out.photon_time_estimator = s.photon_time_estimator;
-    out.timewalk_calibration_file = s.timewalk_calibration_file;
-    out.save_photon_pixels = s.save_photon_pixels;
-    return out;
-}
-
 // Model name written into metadata and the summary.
 std::string correctionModelName(
     const hermes_photon_clusterer::TimewalkCorrection& c) {
@@ -134,13 +107,11 @@ std::vector<std::pair<std::string, double>> correctionParameters(
 }  // namespace
 
 int main(const int argc, char* argv[]) {
-    std::string input_dir;
-    std::string base_file_name;
+    std::string input_file;
+    std::string output_file;
     std::string settings_file;
-    std::string output_dir;
     bool overwrite = false;
     bool have_input = false;
-    bool have_base_name = false;
     bool have_output = false;
 
     for (int i = 1; i < argc; ++i) {
@@ -159,20 +130,11 @@ int main(const int argc, char* argv[]) {
         }
         if (arg == "--input") {
             if (i + 1 >= argc) {
-                std::cerr << "Error: --input requires a directory path\n";
+                std::cerr << "Error: --input requires a file path\n";
                 return 2;
             }
-            input_dir = argv[++i];
+            input_file = argv[++i];
             have_input = true;
-            continue;
-        }
-        if (arg == "--base-file-name") {
-            if (i + 1 >= argc) {
-                std::cerr << "Error: --base-file-name requires a name\n";
-                return 2;
-            }
-            base_file_name = argv[++i];
-            have_base_name = true;
             continue;
         }
         if (arg == "--settings") {
@@ -185,10 +147,10 @@ int main(const int argc, char* argv[]) {
         }
         if (arg == "--output") {
             if (i + 1 >= argc) {
-                std::cerr << "Error: --output requires a directory path\n";
+                std::cerr << "Error: --output requires a file path\n";
                 return 2;
             }
-            output_dir = argv[++i];
+            output_file = argv[++i];
             have_output = true;
             continue;
         }
@@ -198,11 +160,7 @@ int main(const int argc, char* argv[]) {
     }
 
     if (!have_input) {
-        std::cerr << "Error: --input <analysis_directory> is required\n";
-        return 2;
-    }
-    if (!have_base_name) {
-        std::cerr << "Error: --base-file-name <name> is required\n";
+        std::cerr << "Error: --input <pixel_file> is required\n";
         return 2;
     }
 
@@ -235,40 +193,25 @@ int main(const int argc, char* argv[]) {
         }
     }
 
-    const fs::path input_path(input_dir);
-    const std::string pixel_hits_dir = (input_path / "pixelHits").string();
-
-    // Output paths are only used when --output is supplied; otherwise the run
-    // prints summary counts and writes nothing.
-    std::string photons_dir;
-    std::string logs_dir;
+    // Sidecar photon_pixels and summary paths derive from the output file: same
+    // directory, output basename with a suffix. Only used when --output is set.
+    std::string pixels_output_file;
     std::string summary_path;
     if (have_output) {
-        const fs::path output_path(output_dir);
-        photons_dir = (output_path / "photons").string();
-        logs_dir = (output_path / "logs").string();
+        const fs::path output_path(output_file);
+        const fs::path parent = output_path.parent_path();
+        const std::string stem = output_path.stem().string();
+        pixels_output_file =
+            (parent / (stem + "-photon-pixels.parquet")).string();
         summary_path =
-            (fs::path(logs_dir) /
-             (base_file_name + "-reconstruction-summary.json"))
-                .string();
+            (parent / (stem + "-reconstruction-summary.json")).string();
     }
 
     const auto total_start = Clock::now();
 
-    // Discover the pixel_data files for this base name, grouped and ordered per
-    // chip.
-    auto groups = hermes_photon_clusterer::discoverPixelFiles(pixel_hits_dir,
-                                                              base_file_name);
-    if (!groups.errors.empty()) {
-        for (const auto& error : groups.errors) {
-            std::cerr << "Error: " << error << "\n";
-        }
-        return 1;
-    }
-
-    // Shared photon-file metadata; chip_index is filled in per chip.
+    // Photon-file metadata; provenance lives here, not in the summary.
     hermes_photon_clusterer::PhotonFileMetadata metadata;
-    metadata.raw_file_stem = base_file_name;
+    metadata.raw_file_stem = fs::path(input_file).stem().string();
     metadata.canonical_tick_seconds = kCanonicalTickSeconds;
     metadata.clustering_algorithm = "connected_components";
     metadata.clustering_settings_json = settingsToJson(settings).dump();
@@ -286,141 +229,54 @@ int main(const int argc, char* argv[]) {
     }
     metadata.save_photon_pixels = settings.save_photon_pixels;
 
-    // Accumulate the whole-stem summary across all chips.
     hermes_photon_clusterer::ReconstructionSummaryContent summary;
-    summary.algorithm = "connected_components";
-    summary.settings = summarySettings(settings);
-    summary.photon_timing.estimator = settings.photon_time_estimator;
-    summary.photon_timing.correction_model =
-        has_correction ? correctionModelName(correction) : "none";
-    if (has_correction) {
-        summary.photon_timing.calibration_file =
-            settings.timewalk_calibration_file;
-        summary.photon_timing.parameters = correctionParameters(correction);
-        summary.photon_timing.has_high_tot_anchor = true;
-        summary.photon_timing.high_tot_anchor = correction.high_tot_anchor;
-    }
-    summary.photon_pixels_requested = settings.save_photon_pixels;
-
-    double reading_seconds = 0.0;
-    double clustering_seconds = 0.0;
-    double writing_seconds = 0.0;
 
     const hermes_photon_clusterer::TimewalkCorrection* correction_ptr =
         has_correction ? &correction : nullptr;
 
-    // Reconstruct each chip independently and accumulate counts and output.
-    for (const auto& [chip, files] : groups.files_by_chip) {
-        // Record the input files relative to the input directory.
-        for (const auto& file : files) {
-            summary.input_pixel_data_files.push_back(
-                fs::relative(file, input_path).string());
+    // Read the one input file into memory in its stored (time-sorted) order.
+    std::vector<hermes_photon_clusterer::PixelHit> hits;
+    const auto read_start = Clock::now();
+    std::vector<std::string> read_errors;
+    const bool read_ok = hermes_photon_clusterer::readPixelHits(
+        {input_file},
+        [&](const hermes_photon_clusterer::PixelHit& hit) {
+            hits.push_back(hit);
+        },
+        read_errors);
+    summary.parquet_reading_seconds = secondsSince(read_start);
+    if (!read_ok) {
+        for (const auto& error : read_errors) {
+            std::cerr << "Error: " << error << "\n";
         }
-
-        // Read the chip's ordered pixel_data into memory in timestamp order.
-        std::vector<hermes_photon_clusterer::PixelHit> hits;
-        const auto read_start = Clock::now();
-        std::vector<std::string> read_errors;
-        const bool read_ok = hermes_photon_clusterer::readPixelHits(
-            files,
-            [&](const hermes_photon_clusterer::PixelHit& hit) {
-                hits.push_back(hit);
-            },
-            read_errors);
-        reading_seconds += secondsSince(read_start);
-        if (!read_ok) {
-            for (const auto& error : read_errors) {
-                std::cerr << "Error: " << error << "\n";
-            }
-            return 1;
-        }
-
-        // Cluster, filter, and build photons for this chip.
-        std::size_t cursor = 0;
-        auto next_hit = [&](hermes_photon_clusterer::PixelHit& out) {
-            if (cursor >= hits.size()) {
-                return false;
-            }
-            out = hits[cursor++];
-            return true;
-        };
-        const auto cluster_start = Clock::now();
-        auto result = hermes_photon_clusterer::reconstructPhotons(
-            next_hit, settings, correction_ptr, settings.save_photon_pixels);
-        clustering_seconds += secondsSince(cluster_start);
-
-        // Accumulate counts.
-        summary.pixel_rows_read += result.counts.pixel_rows_read;
-        summary.pixel_rows_below_min_tot +=
-            result.counts.pixel_rows_below_min_tot;
-        summary.components_formed += result.counts.components_formed;
-        summary.photon_count += result.counts.photon_count;
-        summary.rejected_component_count +=
-            result.counts.rejected_component_count;
-        summary.rejection_counts.below_min_cluster_size +=
-            result.counts.rejection_counts.below_min_cluster_size;
-        summary.rejection_counts.above_max_cluster_size +=
-            result.counts.rejection_counts.above_max_cluster_size;
-        summary.rejection_counts.below_min_cluster_tot +=
-            result.counts.rejection_counts.below_min_cluster_tot;
-        summary.rejection_counts.above_max_cluster_tot +=
-            result.counts.rejection_counts.above_max_cluster_tot;
-        summary.rejection_counts.above_max_aspect_ratio +=
-            result.counts.rejection_counts.above_max_aspect_ratio;
-        summary.rejection_counts.below_min_filled_fraction +=
-            result.counts.rejection_counts.below_min_filled_fraction;
-        summary.saturated_pixel_count += result.counts.saturated_pixel_count;
-        summary.bridged_components_count +=
-            result.counts.bridged_components_count;
-
-        // Write this chip's photon output only when --output was supplied.
-        if (!have_output) {
-            continue;
-        }
-        metadata.chip_index = chip;
-        const auto write_start = Clock::now();
-        std::vector<std::string> write_errors;
-        auto events_result = hermes_photon_clusterer::writePhotonEventsParquet(
-            result.photons, photons_dir, metadata, kRowsPerPart, overwrite,
-            write_errors);
-        if (!write_errors.empty()) {
-            for (const auto& error : write_errors) {
-                std::cerr << "Error: " << error << "\n";
-            }
-            return 1;
-        }
-        summary.photon_events_row_count += events_result.row_count;
-        for (const auto& file : events_result.files) {
-            summary.photon_events_files.push_back("photons/" + file);
-        }
-
-        if (settings.save_photon_pixels) {
-            auto pixels_result =
-                hermes_photon_clusterer::writePhotonPixelsParquet(
-                    result.photon_pixels, photons_dir, metadata, kRowsPerPart,
-                    overwrite, write_errors);
-            if (!write_errors.empty()) {
-                for (const auto& error : write_errors) {
-                    std::cerr << "Error: " << error << "\n";
-                }
-                return 1;
-            }
-            summary.photon_pixels_row_count += pixels_result.row_count;
-            for (const auto& file : pixels_result.files) {
-                summary.photon_pixels_files.push_back("photons/" + file);
-            }
-        }
-        writing_seconds += secondsSince(write_start);
+        return 1;
     }
 
-    summary.parquet_reading_seconds = reading_seconds;
-    summary.clustering_and_filtering_seconds = clustering_seconds;
-    summary.parquet_writing_seconds = writing_seconds;
-    summary.total_seconds = secondsSince(total_start);
+    // Cluster, filter, and build photons for this file.
+    std::size_t cursor = 0;
+    auto next_hit = [&](hermes_photon_clusterer::PixelHit& out) {
+        if (cursor >= hits.size()) {
+            return false;
+        }
+        out = hits[cursor++];
+        return true;
+    };
+    const auto cluster_start = Clock::now();
+    auto result = hermes_photon_clusterer::reconstructPhotons(
+        next_hit, settings, correction_ptr, settings.save_photon_pixels);
+    summary.clustering_and_filtering_seconds = secondsSince(cluster_start);
+
+    summary.pixel_rows_read = result.counts.pixel_rows_read;
+    summary.pixel_rows_below_min_tot = result.counts.pixel_rows_below_min_tot;
+    summary.components_formed = result.counts.components_formed;
+    summary.photon_count = result.counts.photon_count;
+    summary.rejected_component_count = result.counts.rejected_component_count;
+    summary.rejection_counts = result.counts.rejection_counts;
+    summary.saturated_pixel_count = result.counts.saturated_pixel_count;
+    summary.bridged_components_count = result.counts.bridged_components_count;
 
     std::cout << "Reconstructed " << summary.photon_count << " photons from "
-              << summary.pixel_rows_read << " pixel rows across "
-              << groups.files_by_chip.size() << " chip(s).\n";
+              << summary.pixel_rows_read << " pixel rows.\n";
 
     // Without --output, print the summary counts and write no files.
     if (!have_output) {
@@ -429,14 +285,31 @@ int main(const int argc, char* argv[]) {
         return 0;
     }
 
-    // Write the whole-base-name reconstruction summary under logs/.
-    std::error_code ec;
-    fs::create_directories(logs_dir, ec);
-    if (ec) {
-        std::cerr << "Error: failed to create logs directory " << logs_dir
-                  << ": " << ec.message() << "\n";
+    // Write the single photon file, plus a photon_pixels sidecar when enabled.
+    const auto write_start = Clock::now();
+    std::vector<std::string> write_errors;
+    hermes_photon_clusterer::writePhotonEventsParquet(
+        result.photons, output_file, metadata, overwrite, write_errors);
+    if (!write_errors.empty()) {
+        for (const auto& error : write_errors) {
+            std::cerr << "Error: " << error << "\n";
+        }
         return 1;
     }
+    if (settings.save_photon_pixels) {
+        hermes_photon_clusterer::writePhotonPixelsParquet(
+            result.photon_pixels, pixels_output_file, metadata, overwrite,
+            write_errors);
+        if (!write_errors.empty()) {
+            for (const auto& error : write_errors) {
+                std::cerr << "Error: " << error << "\n";
+            }
+            return 1;
+        }
+    }
+    summary.parquet_writing_seconds = secondsSince(write_start);
+    summary.total_seconds = secondsSince(total_start);
+
     try {
         hermes_photon_clusterer::writeReconstructionSummaryJson(
             summary_path, summary, overwrite);
@@ -445,6 +318,7 @@ int main(const int argc, char* argv[]) {
         return 1;
     }
 
+    std::cout << "Wrote: " << output_file << "\n";
     std::cout << "Summary: " << summary_path << "\n";
     return 0;
 }

--- a/backends/reconstruction/photons/cpp/src/photon_writer.cpp
+++ b/backends/reconstruction/photons/cpp/src/photon_writer.cpp
@@ -16,21 +16,6 @@
 
 namespace hermes_photon_clusterer {
 
-namespace {
-
-// "<stem>-chip-<chip>-<group>-part-<00000>.parquet".
-std::string makePhotonFileName(const std::string& stem,
-                               int chip_index,
-                               const std::string& group,
-                               std::uint64_t part) {
-    std::ostringstream name;
-    name << stem << "-chip-" << chip_index << "-" << group << "-part-"
-         << std::setw(5) << std::setfill('0') << part << ".parquet";
-    return name.str();
-}
-
-}  // namespace
-
 #ifdef HERMES_HAS_ARROW_PARQUET
 
 namespace {
@@ -79,26 +64,30 @@ std::shared_ptr<arrow::KeyValueMetadata> buildFileMetadata(
     return std::make_shared<arrow::KeyValueMetadata>(keys, values);
 }
 
-bool ensureDirectory(const std::string& path, std::vector<std::string>& errors) {
+// Creates the parent directory of output_file_path if it has one.
+bool ensureParentDirectory(const std::string& output_file_path,
+                           std::vector<std::string>& errors) {
+    const std::filesystem::path parent =
+        std::filesystem::path(output_file_path).parent_path();
+    if (parent.empty()) {
+        return true;
+    }
     std::error_code ec;
-    std::filesystem::create_directories(path, ec);
+    std::filesystem::create_directories(parent, ec);
     if (ec) {
-        errors.push_back("Failed to create photon output directory " + path +
-                         ": " + ec.message());
+        errors.push_back("Failed to create photon output directory " +
+                         parent.string() + ": " + ec.message());
         return false;
     }
     return true;
 }
 
-// Writes one Arrow table to a Parquet part file. When overwrite is false,
+// Writes one Arrow table to a single Parquet file. When overwrite is false,
 // refuses to replace an existing file; when true, replaces it.
-bool writeTablePart(const std::shared_ptr<arrow::Table>& table,
-                    const std::string& directory,
-                    const std::string& filename,
-                    std::uint64_t rows_per_part,
-                    bool overwrite,
-                    std::vector<std::string>& errors) {
-    const std::string full_path = directory + "/" + filename;
+bool writeTable(const std::shared_ptr<arrow::Table>& table,
+                const std::string& full_path,
+                bool overwrite,
+                std::vector<std::string>& errors) {
     if (!overwrite && std::filesystem::exists(full_path)) {
         errors.push_back("Refusing to overwrite existing photon file " +
                          full_path);
@@ -114,35 +103,15 @@ bool writeTablePart(const std::shared_ptr<arrow::Table>& table,
     // metadata, so a reader recovers it; WriteTable drops it otherwise.
     auto arrow_properties =
         parquet::ArrowWriterProperties::Builder().store_schema()->build();
+    const std::int64_t chunk_size =
+        std::max<std::int64_t>(table->num_rows(), 1);
     auto status = parquet::arrow::WriteTable(
-        *table, arrow::default_memory_pool(), *out_result, rows_per_part,
+        *table, arrow::default_memory_pool(), *out_result, chunk_size,
         parquet::default_writer_properties(), arrow_properties);
     if (!status.ok()) {
         errors.push_back("Failed to write photon file " + full_path + ": " +
                          status.ToString());
         return false;
-    }
-    return true;
-}
-
-// Refuses the whole write up front if any expected part file already exists, so
-// a refused overwrite never leaves some parts written and others not. Only used
-// when overwrite is false. Returns false and appends an error on the first
-// existing part.
-bool ensureNoExistingParts(const std::string& directory,
-                           const std::string& stem,
-                           int chip_index,
-                           const std::string& group,
-                           std::uint64_t parts,
-                           std::vector<std::string>& errors) {
-    for (std::uint64_t part = 0; part < parts; ++part) {
-        const std::string full_path =
-            directory + "/" + makePhotonFileName(stem, chip_index, group, part);
-        if (std::filesystem::exists(full_path)) {
-            errors.push_back("Refusing to overwrite existing photon file " +
-                             full_path);
-            return false;
-        }
     }
     return true;
 }
@@ -241,81 +210,49 @@ std::shared_ptr<arrow::Table> buildPixelsTable(
 
 PhotonWriteResult writePhotonEventsParquet(
     const std::vector<Photon>& photons,
-    const std::string& photon_output_directory,
+    const std::string& output_file_path,
     const PhotonFileMetadata& metadata,
-    std::uint64_t rows_per_part,
     bool overwrite,
     std::vector<std::string>& errors) {
     PhotonWriteResult result;
     if (photons.empty()) {
         return result;
     }
-    if (!ensureDirectory(photon_output_directory, errors)) {
+    if (!ensureParentDirectory(output_file_path, errors)) {
         return {};
     }
 
     const auto kv = buildFileMetadata(metadata, kPhotonEventsSchemaName);
-    const std::uint64_t total = photons.size();
-    const std::uint64_t parts = (total + rows_per_part - 1) / rows_per_part;
-    if (!overwrite &&
-        !ensureNoExistingParts(photon_output_directory, metadata.raw_file_stem,
-                               metadata.chip_index, "photon-events", parts,
-                               errors)) {
+    auto table = buildEventsTable(photons, 0, photons.size(), kv);
+    if (!writeTable(table, output_file_path, overwrite, errors)) {
         return {};
     }
-    for (std::uint64_t part = 0; part < parts; ++part) {
-        const std::uint64_t start = part * rows_per_part;
-        const std::uint64_t count = std::min(rows_per_part, total - start);
-        auto table = buildEventsTable(photons, start, count, kv);
-        const std::string filename = makePhotonFileName(
-            metadata.raw_file_stem, metadata.chip_index, "photon-events", part);
-        if (!writeTablePart(table, photon_output_directory, filename,
-                            rows_per_part, overwrite, errors)) {
-            return {};
-        }
-        result.files.push_back(filename);
-    }
-    result.row_count = total;
+    result.file = output_file_path;
+    result.row_count = photons.size();
     return result;
 }
 
 PhotonWriteResult writePhotonPixelsParquet(
     const std::vector<PhotonPixelRow>& rows,
-    const std::string& photon_output_directory,
+    const std::string& output_file_path,
     const PhotonFileMetadata& metadata,
-    std::uint64_t rows_per_part,
     bool overwrite,
     std::vector<std::string>& errors) {
     PhotonWriteResult result;
     if (rows.empty()) {
         return result;
     }
-    if (!ensureDirectory(photon_output_directory, errors)) {
+    if (!ensureParentDirectory(output_file_path, errors)) {
         return {};
     }
 
     const auto kv = buildFileMetadata(metadata, kPhotonPixelsSchemaName);
-    const std::uint64_t total = rows.size();
-    const std::uint64_t parts = (total + rows_per_part - 1) / rows_per_part;
-    if (!overwrite &&
-        !ensureNoExistingParts(photon_output_directory, metadata.raw_file_stem,
-                               metadata.chip_index, "photon-pixels", parts,
-                               errors)) {
+    auto table = buildPixelsTable(rows, 0, rows.size(), kv);
+    if (!writeTable(table, output_file_path, overwrite, errors)) {
         return {};
     }
-    for (std::uint64_t part = 0; part < parts; ++part) {
-        const std::uint64_t start = part * rows_per_part;
-        const std::uint64_t count = std::min(rows_per_part, total - start);
-        auto table = buildPixelsTable(rows, start, count, kv);
-        const std::string filename = makePhotonFileName(
-            metadata.raw_file_stem, metadata.chip_index, "photon-pixels", part);
-        if (!writeTablePart(table, photon_output_directory, filename,
-                            rows_per_part, overwrite, errors)) {
-            return {};
-        }
-        result.files.push_back(filename);
-    }
-    result.row_count = total;
+    result.file = output_file_path;
+    result.row_count = rows.size();
     return result;
 }
 
@@ -323,9 +260,8 @@ PhotonWriteResult writePhotonPixelsParquet(
 
 PhotonWriteResult writePhotonEventsParquet(
     const std::vector<Photon>& /*photons*/,
-    const std::string& /*photon_output_directory*/,
+    const std::string& /*output_file_path*/,
     const PhotonFileMetadata& /*metadata*/,
-    std::uint64_t /*rows_per_part*/,
     bool /*overwrite*/,
     std::vector<std::string>& errors) {
     errors.push_back("photon_events writing requires Arrow/Parquet support");
@@ -334,9 +270,8 @@ PhotonWriteResult writePhotonEventsParquet(
 
 PhotonWriteResult writePhotonPixelsParquet(
     const std::vector<PhotonPixelRow>& /*rows*/,
-    const std::string& /*photon_output_directory*/,
+    const std::string& /*output_file_path*/,
     const PhotonFileMetadata& /*metadata*/,
-    std::uint64_t /*rows_per_part*/,
     bool /*overwrite*/,
     std::vector<std::string>& errors) {
     errors.push_back("photon_pixels writing requires Arrow/Parquet support");

--- a/backends/reconstruction/photons/cpp/src/pixel_reader.cpp
+++ b/backends/reconstruction/photons/cpp/src/pixel_reader.cpp
@@ -1,9 +1,5 @@
 #include "pixel_reader.h"
 
-#include <algorithm>
-#include <filesystem>
-#include <regex>
-
 #ifdef HERMES_HAS_ARROW_PARQUET
 #include <arrow/array.h>
 #include <arrow/io/file.h>
@@ -13,72 +9,6 @@
 #endif
 
 namespace hermes_photon_clusterer {
-
-namespace {
-
-// Matches "<stem>-chip-<chip>-part-<00000>.parquet", the unpacker's pixel_data
-// filename convention.
-const std::regex& pixelFilePattern() {
-    static const std::regex pattern(
-        R"(^(.+)-chip-(\d+)-part-(\d{5})\.parquet$)");
-    return pattern;
-}
-
-}  // namespace
-
-PixelFileGroups discoverPixelFiles(const std::string& pixel_data_directory,
-                                   const std::string& raw_file_stem) {
-    PixelFileGroups groups;
-
-    // Collect (part_number, path) per chip, then verify contiguity and order.
-    std::map<int, std::vector<std::pair<int, std::string>>> parts_by_chip;
-    std::error_code ec;
-    std::filesystem::directory_iterator it(pixel_data_directory, ec);
-    if (ec) {
-        groups.errors.push_back("Failed to read pixel_data directory " +
-                                pixel_data_directory + ": " + ec.message());
-        return groups;
-    }
-
-    for (const auto& entry : it) {
-        if (!entry.is_regular_file()) {
-            continue;
-        }
-        const std::string name = entry.path().filename().string();
-        std::smatch match;
-        if (!std::regex_match(name, match, pixelFilePattern())) {
-            continue;
-        }
-        if (match[1].str() != raw_file_stem) {
-            continue;
-        }
-        const int chip = std::stoi(match[2].str());
-        const int part = std::stoi(match[3].str());
-        parts_by_chip[chip].emplace_back(part, entry.path().string());
-    }
-
-    if (parts_by_chip.empty()) {
-        groups.errors.push_back(
-            "No pixel_data Parquet files found for stem '" + raw_file_stem +
-            "' in " + pixel_data_directory);
-        return groups;
-    }
-
-    for (auto& [chip, parts] : parts_by_chip) {
-        std::sort(parts.begin(), parts.end());
-        for (std::size_t index = 0; index < parts.size(); ++index) {
-            if (parts[index].first != static_cast<int>(index)) {
-                groups.errors.push_back(
-                    "pixel_data parts are not contiguous for stem '" +
-                    raw_file_stem + "' chip " + std::to_string(chip));
-                break;
-            }
-            groups.files_by_chip[chip].push_back(parts[index].second);
-        }
-    }
-
-    return groups;
-}
 
 #ifdef HERMES_HAS_ARROW_PARQUET
 

--- a/backends/reconstruction/photons/cpp/src/summary_writer.cpp
+++ b/backends/reconstruction/photons/cpp/src/summary_writer.cpp
@@ -10,48 +10,6 @@ namespace hermes_photon_clusterer {
 
 using json = nlohmann::ordered_json;
 
-namespace {
-
-json settingsJson(const SummaryClusteringSettings& s) {
-    json j;
-    j["max_time_spread_ticks"] = s.max_time_spread_ticks;
-    j["min_cluster_size"] = s.min_cluster_size;
-    j["max_cluster_size"] = s.max_cluster_size;
-    j["min_pixel_tot_raw"] = s.min_pixel_tot_raw;
-    j["min_cluster_tot_raw"] = s.min_cluster_tot_raw;
-    j["max_cluster_tot_raw"] = s.max_cluster_tot_raw;
-    j["max_aspect_ratio"] = s.max_aspect_ratio;
-    j["min_filled_fraction"] = s.min_filled_fraction;
-    j["adjacency"] = s.adjacency;
-    j["position_averaging"] = s.position_averaging;
-    j["photon_time_estimator"] = s.photon_time_estimator;
-    if (s.timewalk_calibration_file.empty()) {
-        j["timewalk_calibration_file"] = nullptr;
-    } else {
-        j["timewalk_calibration_file"] = s.timewalk_calibration_file;
-    }
-    j["save_photon_pixels"] = s.save_photon_pixels;
-    return j;
-}
-
-json timingJson(const SummaryPhotonTiming& t) {
-    json j;
-    j["estimator"] = t.estimator;
-    j["correction_model"] = t.correction_model;
-    j["calibration_file"] =
-        t.calibration_file.empty() ? json(nullptr) : json(t.calibration_file);
-    json parameters = json::object();
-    for (const auto& [key, value] : t.parameters) {
-        parameters[key] = value;
-    }
-    j["parameters"] = parameters;
-    j["high_tot_anchor"] =
-        t.has_high_tot_anchor ? json(t.high_tot_anchor) : json(nullptr);
-    return j;
-}
-
-}  // namespace
-
 std::string generateReconstructionSummaryJson(
     const ReconstructionSummaryContent& content) {
     const double pixels_per_second =
@@ -95,28 +53,6 @@ std::string generateReconstructionSummaryJson(
          }},
         {"warnings", content.warnings},
         {"errors", content.errors},
-    };
-
-    j["clustering"] = {
-        {"algorithm", content.algorithm},
-        {"settings", settingsJson(content.settings)},
-    };
-
-    j["photon_timing"] = timingJson(content.photon_timing);
-
-    j["parquet"] = {
-        {"input_pixel_data_files", content.input_pixel_data_files},
-        {"photon_events",
-         {
-             {"row_count", content.photon_events_row_count},
-             {"files", content.photon_events_files},
-         }},
-        {"photon_pixels",
-         {
-             {"requested", content.photon_pixels_requested},
-             {"row_count", content.photon_pixels_row_count},
-             {"files", content.photon_pixels_files},
-         }},
     };
 
     j["processing_times_seconds"] = {

--- a/backends/reconstruction/photons/cpp/tests/photon_writer_tests.cpp
+++ b/backends/reconstruction/photons/cpp/tests/photon_writer_tests.cpp
@@ -81,45 +81,39 @@ int main() {
             Photon{7.0, 9.0, 500.0, 15, 0b11},
         };
         std::vector<std::string> errors;
-        const auto dir = (base / "events").string();
-        auto result = writePhotonEventsParquet(photons, dir,
-                                               sampleMetadata(), 1000, false,
-                                               errors);
+        const auto path = (base / "events.parquet").string();
+        auto result = writePhotonEventsParquet(photons, path, sampleMetadata(),
+                                               false, errors);
         test.expect(errors.empty(), "events write reports no errors");
         test.expectEqual(result.row_count, std::uint64_t{2}, "two events written");
-        test.expectEqual(result.files.size(), std::size_t{1}, "one events part");
+        test.expect(result.file == path, "events written to the given path");
 
-        if (result.files.size() == 1) {
-            test.expect(result.files[0] ==
-                            "raw-chip-0-photon-events-part-00000.parquet",
-                        "events filename follows convention");
-            auto table = readTable((std::filesystem::path(dir) / result.files[0]).string());
-            test.expectEqual(table->num_rows(), std::int64_t{2},
-                             "events file has two rows");
-            // Columns: photon_id, x, y, timestamp_canonical, tot, quality_flags.
-            test.expectEqual(uint64At(table, 0, 0), std::uint64_t{0},
-                             "photon_id is zero-based");
-            test.expect(nearlyEqual(doubleAt(table, 1, 0), 2.5), "x preserved");
-            test.expect(nearlyEqual(doubleAt(table, 3, 0), 1000.75),
-                        "fractional timestamp preserved as float64");
-            test.expectEqual(uint64At(table, 4, 0), std::uint64_t{100},
-                             "tot preserved");
+        auto table = readTable(path);
+        test.expectEqual(table->num_rows(), std::int64_t{2},
+                         "events file has two rows");
+        // Columns: photon_id, x, y, timestamp_canonical, tot, quality_flags.
+        test.expectEqual(uint64At(table, 0, 0), std::uint64_t{0},
+                         "photon_id is zero-based");
+        test.expect(nearlyEqual(doubleAt(table, 1, 0), 2.5), "x preserved");
+        test.expect(nearlyEqual(doubleAt(table, 3, 0), 1000.75),
+                    "fractional timestamp preserved as float64");
+        test.expectEqual(uint64At(table, 4, 0), std::uint64_t{100},
+                         "tot preserved");
 
-            // Schema metadata is attached.
-            auto metadata = table->schema()->metadata();
-            test.expect(metadata != nullptr, "events schema carries metadata");
-            if (metadata != nullptr) {
-                test.expect(
-                    metadata->Get("schema_name").ValueOr("") ==
-                        "hermes_tpx3_spidr_photon_events",
-                    "events schema_name metadata");
-                test.expect(metadata->Get("correction_model").ValueOr("") ==
-                                "inverse",
-                            "correction_model metadata");
-                test.expect(metadata->Get("photon_time_estimator").ValueOr("") ==
-                                "leading_edge",
-                            "photon_time_estimator metadata");
-            }
+        // Schema metadata is attached.
+        auto metadata = table->schema()->metadata();
+        test.expect(metadata != nullptr, "events schema carries metadata");
+        if (metadata != nullptr) {
+            test.expect(
+                metadata->Get("schema_name").ValueOr("") ==
+                    "hermes_tpx3_spidr_photon_events",
+                "events schema_name metadata");
+            test.expect(metadata->Get("correction_model").ValueOr("") ==
+                            "inverse",
+                        "correction_model metadata");
+            test.expect(metadata->Get("photon_time_estimator").ValueOr("") ==
+                            "leading_edge",
+                        "photon_time_estimator metadata");
         }
     }
 
@@ -131,65 +125,47 @@ int main() {
             PhotonPixelRow{1, 9, 7, 9, 15, 500},
         };
         std::vector<std::string> errors;
-        const auto dir = (base / "pixels").string();
-        auto result = writePhotonPixelsParquet(rows, dir,
-                                               sampleMetadata(), 1000, false,
-                                               errors);
+        const auto path = (base / "pixels.parquet").string();
+        auto result = writePhotonPixelsParquet(rows, path, sampleMetadata(),
+                                               false, errors);
         test.expect(errors.empty(), "pixels write reports no errors");
         test.expectEqual(result.row_count, std::uint64_t{3}, "three pixels");
-        if (result.files.size() == 1) {
-            test.expect(result.files[0] ==
-                            "raw-chip-0-photon-pixels-part-00000.parquet",
-                        "pixels filename follows convention");
-            auto table = readTable((std::filesystem::path(dir) / result.files[0]).string());
-            test.expectEqual(table->num_rows(), std::int64_t{3},
-                             "pixels file has three rows");
-            // Columns: photon_id, pixel_event_id, x, y, tot_raw, timestamp.
-            test.expectEqual(uint64At(table, 0, 2), std::uint64_t{1},
-                             "third pixel maps to photon 1");
-            test.expectEqual(uint64At(table, 1, 0), std::uint64_t{3},
-                             "pixel_event_id preserved");
-        }
+        test.expect(result.file == path, "pixels written to the given path");
+
+        auto table = readTable(path);
+        test.expectEqual(table->num_rows(), std::int64_t{3},
+                         "pixels file has three rows");
+        // Columns: photon_id, pixel_event_id, x, y, tot_raw, timestamp.
+        test.expectEqual(uint64At(table, 0, 2), std::uint64_t{1},
+                         "third pixel maps to photon 1");
+        test.expectEqual(uint64At(table, 1, 0), std::uint64_t{3},
+                         "pixel_event_id preserved");
     }
 
-    // Empty inputs write no files and report no errors.
+    // Empty inputs write no file and report no errors.
     {
         std::vector<std::string> errors;
-        auto result = writePhotonEventsParquet({}, (base / "empty").string(),
-                                               sampleMetadata(), 1000, false,
-                                               errors);
+        auto result = writePhotonEventsParquet({}, (base / "empty.parquet").string(),
+                                               sampleMetadata(), false, errors);
         test.expect(errors.empty(), "empty events write has no errors");
         test.expectEqual(result.row_count, std::uint64_t{0}, "no rows");
-        test.expect(result.files.empty(), "no files for empty events");
+        test.expect(result.file.empty(), "no file for empty events");
     }
 
-    // Multiple parts are produced when the row count exceeds rows_per_part.
+    // overwrite == false refuses an existing file; overwrite == true replaces it.
     {
-        std::vector<Photon> photons(5, Photon{1.0, 1.0, 1.0, 1, 0});
-        std::vector<std::string> errors;
-        auto result = writePhotonEventsParquet(photons, (base / "multi").string(),
-                                               sampleMetadata(), 2, false,
-                                               errors);
-        test.expect(errors.empty(), "multi-part write has no errors");
-        test.expectEqual(result.files.size(), std::size_t{3},
-                         "five rows at two per part yields three files");
-        test.expectEqual(result.row_count, std::uint64_t{5}, "row count is five");
-    }
-
-    // overwrite == false refuses an existing part; overwrite == true replaces it.
-    {
-        const auto dir = (base / "overwrite").string();
+        const auto path = (base / "overwrite.parquet").string();
         std::vector<Photon> first = {Photon{1.0, 1.0, 1.0, 1, 0}};
         std::vector<std::string> errors;
-        auto initial = writePhotonEventsParquet(first, dir, sampleMetadata(),
-                                                1000, false, errors);
+        auto initial = writePhotonEventsParquet(first, path, sampleMetadata(),
+                                                false, errors);
         test.expect(errors.empty() && initial.row_count == 1,
                     "initial events write succeeds");
 
         // A second write to the same file with overwrite == false must refuse.
         std::vector<std::string> refuse_errors;
-        auto refused = writePhotonEventsParquet(first, dir, sampleMetadata(),
-                                                1000, false, refuse_errors);
+        auto refused = writePhotonEventsParquet(first, path, sampleMetadata(),
+                                                false, refuse_errors);
         test.expect(!refuse_errors.empty() && refused.row_count == 0,
                     "overwrite == false refuses existing photon file");
 
@@ -199,16 +175,13 @@ int main() {
             Photon{3.0, 3.0, 3.0, 3, 0},
         };
         std::vector<std::string> replace_errors;
-        auto replaced = writePhotonEventsParquet(second, dir, sampleMetadata(),
-                                                 1000, true, replace_errors);
+        auto replaced = writePhotonEventsParquet(second, path, sampleMetadata(),
+                                                 true, replace_errors);
         test.expect(replace_errors.empty() && replaced.row_count == 2,
                     "overwrite == true replaces existing photon file");
-        if (replaced.files.size() == 1) {
-            auto table = readTable(
-                (std::filesystem::path(dir) / replaced.files[0]).string());
-            test.expectEqual(table->num_rows(), std::int64_t{2},
-                             "replaced file holds the new rows");
-        }
+        auto table = readTable(path);
+        test.expectEqual(table->num_rows(), std::int64_t{2},
+                         "replaced file holds the new rows");
     }
 
     std::filesystem::remove_all(base);

--- a/backends/reconstruction/photons/cpp/tests/photon_writer_tests.cpp
+++ b/backends/reconstruction/photons/cpp/tests/photon_writer_tests.cpp
@@ -28,9 +28,7 @@ std::shared_ptr<arrow::Table> readTable(const std::string& path) {
     auto input = arrow::io::ReadableFile::Open(path).ValueOrDie();
     auto reader =
         parquet::arrow::OpenFile(input, arrow::default_memory_pool()).ValueOrDie();
-    std::shared_ptr<arrow::Table> table;
-    (void)reader->ReadTable(&table);
-    return table;
+    return reader->ReadTable().ValueOrDie();
 }
 
 double doubleAt(const std::shared_ptr<arrow::Table>& table, int col, int row) {

--- a/backends/reconstruction/photons/cpp/tests/pixel_reader_tests.cpp
+++ b/backends/reconstruction/photons/cpp/tests/pixel_reader_tests.cpp
@@ -14,7 +14,6 @@
 
 namespace {
 
-using hermes_photon_clusterer::discoverPixelFiles;
 using hermes_photon_clusterer::PixelHit;
 using hermes_photon_clusterer::readPixelHits;
 using hermes_photon_clusterer::readPixelHitsFiltered;
@@ -77,25 +76,17 @@ int main() {
     std::filesystem::remove_all(base);
     std::filesystem::create_directories(base);
 
-    // Two contiguous parts for one chip, read back in part order.
-    writePixelFile((base / "raw-chip-0-part-00000.parquet").string(),
-                   {PixelHit{10, 20, 100, 1000}, PixelHit{11, 20, 90, 1005}});
-    writePixelFile((base / "raw-chip-0-part-00001.parquet").string(),
-                   {PixelHit{12, 20, 80, 1010}});
-    // A file for a different stem must be ignored.
-    writePixelFile((base / "other-chip-0-part-00000.parquet").string(),
-                   {PixelHit{0, 0, 1, 1}});
-
-    auto groups = discoverPixelFiles(base.string(), "raw");
-    test.expect(groups.errors.empty(), "discovery reports no errors");
-    test.expect(groups.files_by_chip.count(0) == 1, "chip 0 discovered");
-    test.expectEqual(groups.files_by_chip[0].size(), std::size_t{2},
-                     "two parts discovered for chip 0");
+    // A single pixel file is read back in row order.
+    const auto pixel_file =
+        (base / "raw-chip-0-part-00000.parquet").string();
+    writePixelFile(pixel_file,
+                   {PixelHit{10, 20, 100, 1000}, PixelHit{11, 20, 90, 1005},
+                    PixelHit{12, 20, 80, 1010}});
 
     std::vector<PixelHit> read_hits;
     std::vector<std::string> errors;
     const bool ok = readPixelHits(
-        groups.files_by_chip[0],
+        {pixel_file},
         [&](const PixelHit& hit) { read_hits.push_back(hit); }, errors);
     test.expect(ok, "reading succeeds");
     test.expectEqual(read_hits.size(), std::size_t{3}, "three rows read");
@@ -105,7 +96,11 @@ int main() {
         test.expectEqual(read_hits[0].timestamp_canonical,
                          std::uint64_t{1000}, "row 0 timestamp");
         test.expectEqual(read_hits[2].timestamp_canonical,
-                         std::uint64_t{1010}, "row 2 timestamp (part 1)");
+                         std::uint64_t{1010}, "row 2 timestamp");
+        test.expectEqual(read_hits[0].pixel_event_id, std::uint64_t{0},
+                         "row 0 pixel_event_id is zero-based");
+        test.expectEqual(read_hits[2].pixel_event_id, std::uint64_t{2},
+                         "row 2 pixel_event_id");
     }
 
     // The per-pixel min-ToT filter drops low-ToT noise rows as they are read.
@@ -113,7 +108,7 @@ int main() {
     std::uint64_t rejected = 0;
     std::vector<std::string> filter_errors;
     const bool filter_ok = readPixelHitsFiltered(
-        groups.files_by_chip[0], 90,
+        {pixel_file}, 90,
         [&](const PixelHit& hit) { kept_hits.push_back(hit); }, rejected,
         filter_errors);
     test.expect(filter_ok, "filtered reading succeeds");
@@ -123,17 +118,6 @@ int main() {
     for (const auto& hit : kept_hits) {
         test.expect(hit.tot_raw >= 90, "kept rows meet the ToT threshold");
     }
-
-    // A non-contiguous part set is rejected.
-    const auto gap = base / "gap";
-    std::filesystem::create_directories(gap);
-    writePixelFile((gap / "raw-chip-0-part-00000.parquet").string(),
-                   {PixelHit{0, 0, 1, 1}});
-    writePixelFile((gap / "raw-chip-0-part-00002.parquet").string(),
-                   {PixelHit{0, 0, 1, 2}});
-    auto gap_groups = discoverPixelFiles(gap.string(), "raw");
-    test.expect(!gap_groups.errors.empty(),
-                "non-contiguous parts report an error");
 
     std::filesystem::remove_all(base);
     return test.finish();

--- a/backends/reconstruction/photons/cpp/tests/summary_writer_tests.cpp
+++ b/backends/reconstruction/photons/cpp/tests/summary_writer_tests.cpp
@@ -38,22 +38,6 @@ ReconstructionSummaryContent consistentContent() {
     content.saturated_pixel_count = 5;
     content.bridged_components_count = 3;
 
-    content.settings.max_time_spread_ticks = 491520;
-    content.settings.min_cluster_size = 2;
-    content.settings.max_cluster_size = 64;
-    content.settings.min_pixel_tot_raw = 1;
-    content.settings.min_cluster_tot_raw = 2;
-    content.settings.max_cluster_tot_raw = 65472;
-    content.settings.max_aspect_ratio = 3.0;
-    content.settings.min_filled_fraction = 0.5;
-    content.settings.adjacency = 8;
-
-    content.input_pixel_data_files = {"pixelHits/raw-chip-0-part-00000.parquet"};
-    content.photon_events_row_count = 70;
-    content.photon_events_files = {
-        "photons/raw-chip-0-photon-events-part-00000.parquet"};
-    content.photon_pixels_requested = false;
-
     content.total_seconds = 2.0;
     content.parquet_reading_seconds = 0.5;
     content.clustering_and_filtering_seconds = 1.0;
@@ -66,10 +50,9 @@ ReconstructionSummaryContent consistentContent() {
 int main() {
     TestContext test;
 
-    // Uncorrected timing: correction_model "none" with no calibration details.
+    // Counts, rejection/quality tallies, and derived throughput render.
     {
         auto content = consistentContent();
-        content.photon_timing.correction_model = "none";
         const auto text = generateReconstructionSummaryJson(content);
         auto j = nlohmann::json::parse(text);
 
@@ -84,15 +67,12 @@ int main() {
             j["reconstruction"]["quality_flag_counts"]["saturated_pixel"]
                 .get<int>(),
             5, "quality flag count rendered");
-        test.expect(j["photon_timing"]["calibration_file"].is_null(),
-                    "no calibration file when uncorrected");
-        test.expect(j["photon_timing"]["high_tot_anchor"].is_null(),
-                    "no anchor when uncorrected");
-        test.expect(j["photon_timing"]["parameters"].empty(),
-                    "no parameters when uncorrected");
-        test.expect(j["clustering"]["settings"]["timewalk_calibration_file"]
-                        .is_null(),
-                    "settings calibration file null when uncorrected");
+        // The slimmed summary carries no settings echo or timing provenance.
+        test.expect(!j.contains("clustering"),
+                    "summary omits clustering settings echo");
+        test.expect(!j.contains("photon_timing"),
+                    "summary omits photon_timing block");
+        test.expect(!j.contains("parquet"), "summary omits parquet file lists");
         // Throughput derived from counts and total time.
         test.expect(j["processing_times_seconds"]["throughput"]
                             ["pixels_per_second"]
@@ -102,32 +82,6 @@ int main() {
                             ["photons_per_second"]
                         .get<double>() == 35.0,
                     "photons_per_second derived");
-    }
-
-    // Inverse correction: model, calibration file, parameters, and anchor set.
-    {
-        auto content = consistentContent();
-        content.photon_timing.correction_model = "inverse";
-        content.photon_timing.calibration_file =
-            "calibrations/tpx3/time-walk_example.json";
-        content.photon_timing.parameters = {{"a", 1254855.58}, {"b", 10.6986}};
-        content.photon_timing.has_high_tot_anchor = true;
-        content.photon_timing.high_tot_anchor = 23.0;
-        content.settings.timewalk_calibration_file =
-            "calibrations/tpx3/time-walk_example.json";
-
-        const auto text = generateReconstructionSummaryJson(content);
-        auto j = nlohmann::json::parse(text);
-        test.expect(j["photon_timing"]["correction_model"].get<std::string>() ==
-                        "inverse",
-                    "correction_model rendered");
-        test.expect(!j["photon_timing"]["calibration_file"].is_null(),
-                    "calibration file present when corrected");
-        test.expect(j["photon_timing"]["parameters"]["a"].get<double>() ==
-                        1254855.58,
-                    "correction parameter a rendered");
-        test.expect(j["photon_timing"]["high_tot_anchor"].get<double>() == 23.0,
-                    "anchor rendered when corrected");
     }
 
     // Zero total time yields zero throughput without dividing by zero.

--- a/backends/unpackers/tpx3-spidr/cpp/inc/unpacker.h
+++ b/backends/unpackers/tpx3-spidr/cpp/inc/unpacker.h
@@ -31,7 +31,8 @@ struct WorkflowResult {
 WorkflowResult runTwoPassWorkflow(std::istream& input,
                                   const std::string& source_file_path,
                                   const std::string& analysis_directory,
-                                  bool overwrite = false);
+                                  bool overwrite = false,
+                                  bool time_sort = true);
 
 }  // namespace hermes_tpx3_spidr
 

--- a/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
@@ -9,11 +9,16 @@ namespace {
 void printHelp(const char* program_name) {
     std::cout << "HERMES TPX3 SPIDR Unpacker v0.1.0\n\n";
     std::cout << "Usage: " << program_name
-              << " --input <input.tpx3> [--output <analysis_directory>] [--overwrite]\n\n";
+              << " --input <input.tpx3> [--output <analysis_directory>]"
+                 " [--overwrite] [--time-sort <true|false>]\n\n";
     std::cout << "Options:\n";
     std::cout << "  --input <input.tpx3>          Input TPX3 raw data file (required)\n";
     std::cout << "  --output <analysis_directory> Shared analysis directory (optional)\n";
     std::cout << "  --overwrite                   Overwrite existing summary and Parquet files\n";
+    std::cout << "  --time-sort <true|false>      Sort rows by timestamp (default: true).\n";
+    std::cout << "                                false leaves rows in source packet order\n";
+    std::cout << "                                (diagnostics only; downstream clustering\n";
+    std::cout << "                                assumes time-ordered data)\n";
     std::cout << "  -h, --help                    Show this help message\n";
     std::cout << "  -v, --version                 Show version information\n\n";
     std::cout << "Output Modes:\n";
@@ -42,6 +47,7 @@ void printVersion() {
 
 int main(const int argc, char* argv[]) {
     bool overwrite = false;
+    bool time_sort = true;
     std::string input_path;
     std::string output_dir;
     bool have_input = false;
@@ -59,6 +65,15 @@ int main(const int argc, char* argv[]) {
         }
         if (arg == "--overwrite") {
             overwrite = true;
+            continue;
+        }
+        if (arg == "--time-sort") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --time-sort requires true or false\n";
+                return 2;
+            }
+            // Defaults to true; only an explicit "false" disables sorting.
+            time_sort = std::string(argv[++i]) != "false";
             continue;
         }
         if (arg == "--input") {
@@ -104,7 +119,7 @@ int main(const int argc, char* argv[]) {
     }
 
     const auto result = hermes_tpx3_spidr::runTwoPassWorkflow(
-        input, input_path, output_dir, overwrite);
+        input, input_path, output_dir, overwrite, time_sort);
 
     if (!result.success) {
         std::cerr << "Workflow failed with errors:\n";

--- a/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
@@ -487,7 +487,8 @@ UnpackResult unpack(std::istream& input) {
 WorkflowResult runTwoPassWorkflow(std::istream& input,
                                   const std::string& source_file_path,
                                   const std::string& analysis_directory,
-                                  const bool overwrite) {
+                                  const bool overwrite,
+                                  const bool time_sort) {
     using Clock = std::chrono::high_resolution_clock;
     using Duration = std::chrono::duration<double>;
 
@@ -617,10 +618,14 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
     workflow_result.summary.timing_diagnostics.conversion_seconds =
         Duration(conversion_end - conversion_start).count();
 
-    // Sort the exact rows that will be split into Parquet part files.
+    // Sort the exact rows that will be split into Parquet part files. When
+    // time_sort is disabled (a diagnostics mode) the rows are left in the
+    // source packet order in which they were decoded.
     auto sort_start = Clock::now();
     SortingDiagnostics sort_diag;
-    sortAllOutputRows(output_rows, sort_diag);
+    if (time_sort) {
+        sortAllOutputRows(output_rows, sort_diag);
+    }
     auto sort_end = Clock::now();
     workflow_result.summary.timing_diagnostics.sorting_seconds =
         Duration(sort_end - sort_start).count();

--- a/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
+++ b/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
@@ -370,6 +370,24 @@ void testWorkflowErrorHandling(TestContext& test) {
     std::filesystem::remove_all(analysis_directory);
 }
 
+void testTimeSortDisabledStillWritesRows(TestContext& test) {
+    const auto analysis_directory = makeTestDirectory("no-time-sort");
+    const auto bytes = makePixelInput();
+
+    std::istringstream input(bytes);
+    const auto result = runTwoPassWorkflow(
+        input, "/tmp/no_time_sort.tpx3", analysis_directory.string(),
+        /*overwrite=*/false, /*time_sort=*/false);
+
+    printWorkflowErrors(result, "time-sort-disabled run");
+    test.expect(result.success, "workflow succeeded with time_sort disabled");
+    test.expectEqual(result.summary.writer_diagnostics.pixel_hits.row_count,
+                     std::uint64_t{1},
+                     "pixel row written with time_sort disabled");
+
+    std::filesystem::remove_all(analysis_directory);
+}
+
 }  // namespace
 
 int main() {
@@ -380,5 +398,6 @@ int main() {
     testSummaryJsonGeneration(test);
     testSummaryJsonStructure(test);
     testWorkflowErrorHandling(test);
+    testTimeSortDisabledStillWritesRows(test);
     return test.finish();
 }

--- a/examples/analysis/timewalk_calibration/timewalk_config.yaml
+++ b/examples/analysis/timewalk_calibration/timewalk_config.yaml
@@ -7,9 +7,10 @@ environment:
 
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
   analysis_directory: data/examples/analysis/timewalk_calibration/analysis
-  tpx3_files:
-    - path: tests/data/Example_1kHz_5frames.tpx3
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+    tpx3_files:
+      - path: tests/data/Example_1kHz_5frames.tpx3

--- a/examples/analysis/two_stage/run_two_stage.py
+++ b/examples/analysis/two_stage/run_two_stage.py
@@ -28,26 +28,34 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
     final_record = workflow.record
     final_analysis = final_record.analysis
     final_reconstruction = final_analysis.photon_reconstruction
-    reconstruction = final_analysis.results.reconstruction
+    reconstruction_results = final_reconstruction.results
     save_hermes_record_to_yaml(final_record, final_record_path)
 
     # Step 5: Display the unpacking and photon reconstruction results
-    print(f"Raw TPX3 files: {len(final_analysis.tpx3_files)}")
-    for raw_tpx3_file in final_analysis.tpx3_files:
+    raw_tpx3_files = final_analysis.unpacking.tpx3_files
+    print(f"Raw TPX3 files: {len(raw_tpx3_files)}")
+    for raw_tpx3_file in raw_tpx3_files:
         print(f"  - {raw_tpx3_file.path}")
     print(f"Unpacked this run: {len(unpacked_raw_files)}")
     print(
         "Skipped existing valid unpacking output: "
-        f"{len(final_analysis.tpx3_files) - len(unpacked_raw_files)}"
+        f"{len(raw_tpx3_files) - len(unpacked_raw_files)}"
     )
-    print(f"Photon reconstruction status: {reconstruction.status}")
-    print(f"Photons: {reconstruction.photon_count}")
-    print(f"Rejected clusters: {reconstruction.rejected_count}")
+    photon_count = sum(
+        result.counts.photon_count
+        for result in reconstruction_results
+        if result.counts is not None
+    )
+    rejected_count = sum(
+        result.counts.rejected_component_count
+        for result in reconstruction_results
+        if result.counts is not None
+    )
+    print(f"Reconstructed photon files: {len(reconstruction_results)}")
+    print(f"Photons: {photon_count}")
+    print(f"Rejected clusters: {rejected_count}")
     print(f"Analysis directory: {final_analysis.analysis_directory}")
-    print(
-        "Photon output directory: "
-        f"{final_reconstruction.photon_output_directory}"
-    )
+    print(f"Photon output directory: {final_reconstruction.output_directory}")
     print(f"HERMES state file: {final_record_path}")
 
 

--- a/examples/analysis/two_stage/two_stage_config.yaml
+++ b/examples/analysis/two_stage/two_stage_config.yaml
@@ -7,18 +7,18 @@ environment:
 
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
   analysis_directory: data/examples/analysis/two_stage/analysis
-  tpx3_files:
-    - path: tests/data/Example_1kHz_5frames.tpx3
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+    tpx3_files:
+      - path: tests/data/Example_1kHz_5frames.tpx3
   photon_reconstruction:
     program:
       name: photon-clusterer-cpp
       executable_path: build/backends/photon-clusterer/hermes-photon-clusterer
-    pixel_data_directory: data/examples/analysis/two_stage/analysis/pixelHits
-    photon_output_directory: data/examples/analysis/two_stage/analysis/photons
+    pixel_parquet_files: auto
     clustering_algorithm: connected_components
     settings:
       max_time_spread_ticks: 491520

--- a/examples/analysis/unpacking/README.md
+++ b/examples/analysis/unpacking/README.md
@@ -28,10 +28,9 @@ pixi run python examples/analysis/unpacking/run_unpacking.py \
   examples/analysis/unpacking/multiple_files.yaml
 ```
 
-For a self-contained demonstration, the script copies the checked-in TPX3 file
-five times with unique filename stems before loading this configuration.
-HERMES can then schedule the five raw files using the configured
-`resource_limit_percent`.
+Before loading this configuration, the script copies the checked-in TPX3 file
+five times, giving each copy a unique name. HERMES then schedules the five raw
+files using the configured `resource_limit_percent`.
 
 ## Use another configuration
 
@@ -58,8 +57,8 @@ tpx3_files:
 ```
 
 Each non-comment line in that text file names one raw TPX3 file. Relative
-entries are resolved from the text file's directory. Raw TPX3 filename stems
-must be unique because they are used in the Parquet and summary JSON filenames.
+entries are resolved from the text file's directory. Each raw TPX3 file name
+must be unique because it is reused in the Parquet and summary JSON file names.
 
 ## Output
 

--- a/examples/analysis/unpacking/multiple_files.yaml
+++ b/examples/analysis/unpacking/multiple_files.yaml
@@ -7,14 +7,15 @@ environment:
 
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
   analysis_directory: data/examples/analysis/unpacking/multiple_files/analysis
   resource_limit_percent: 90
-  tpx3_files:
-    - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0000.tpx3
-    - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0001.tpx3
-    - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0002.tpx3
-    - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0003.tpx3
-    - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0004.tpx3
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+    tpx3_files:
+      - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0000.tpx3
+      - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0001.tpx3
+      - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0002.tpx3
+      - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0003.tpx3
+      - path: data/examples/analysis/unpacking/multiple_files/input/Example_1kHz_5frames_0004.tpx3

--- a/examples/analysis/unpacking/run_unpacking.py
+++ b/examples/analysis/unpacking/run_unpacking.py
@@ -57,13 +57,14 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
     save_hermes_record_to_yaml(final_record, final_record_path)
 
     # Step 6: Display the unpacking results
-    print(f"Raw TPX3 files: {len(final_analysis.tpx3_files)}")
-    for raw_tpx3_file in final_analysis.tpx3_files:
+    raw_tpx3_files = final_analysis.unpacking.tpx3_files
+    print(f"Raw TPX3 files: {len(raw_tpx3_files)}")
+    for raw_tpx3_file in raw_tpx3_files:
         print(f"  - {raw_tpx3_file.path}")
     print(f"Unpacked this run: {len(unpacked_raw_files)}")
     print(
         "Skipped existing valid outputs: "
-        f"{len(final_analysis.tpx3_files) - len(unpacked_raw_files)}"
+        f"{len(raw_tpx3_files) - len(unpacked_raw_files)}"
     )
     print(f"Analysis directory: {final_analysis.analysis_directory}")
     print(f"HERMES state file: {final_record_path}")

--- a/examples/analysis/unpacking/single_file.yaml
+++ b/examples/analysis/unpacking/single_file.yaml
@@ -12,5 +12,7 @@ analysis:
     program:
       name: tpx3-spidr-cpp
       executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+    runtime_options:
+      overwrite: true
     tpx3_files:
       - path: tests/data/Example_1kHz_5frames.tpx3

--- a/examples/analysis/unpacking/single_file.yaml
+++ b/examples/analysis/unpacking/single_file.yaml
@@ -7,9 +7,10 @@ environment:
 
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
   analysis_directory: data/examples/analysis/unpacking/single_file/analysis
-  tpx3_files:
-    - path: tests/data/Example_1kHz_5frames.tpx3
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+    tpx3_files:
+      - path: tests/data/Example_1kHz_5frames.tpx3

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -1,30 +1,30 @@
 """Runs the C++ photon reconstruction binary over unpacked pixel data.
 
-The flow is: plan_reconstruction decides which raw files still need work,
-execute_reconstruction runs the binary on one file and checks its output, and
-the helpers below validate that the files it produced are complete and safe.
+Reconstruction is 1:1: each pixel Parquet file produces one photon file at the
+matching path (input basename kept). plan_reconstruction decides which files
+still need work, execute_reconstruction runs the binary on one file and reads
+its sidecar summary for the per-file counts.
 """
 
 from __future__ import annotations
 
 import json
-import re
 import subprocess
 import tempfile
 from pathlib import Path
 from time import perf_counter
 from typing import Literal, TypeAlias
 
-import pyarrow.parquet as pq
 from loguru import logger
 from pydantic import ValidationError
 
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
-    Tpx3PhotonReconstructionConfiguration,
+    HermesTpx3ReconstructionResult,
+    Tpx3PhotonReconstruction,
     Tpx3PhotonReconstructionSummary,
 )
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import FileReference, utc_now
 
 ContinuationAction: TypeAlias = Literal["run", "skip"]
 ReconstructionPlan: TypeAlias = list[tuple[FileReference, ContinuationAction]]
@@ -53,39 +53,56 @@ class HermesReconstructionOutputError(HermesReconstructionPreflightError):
     """Raised when reconstruction output is missing, unsafe, or inconsistent."""
 
 
-def derive_summary_path(
+def resolve_pixel_files(
     analysis: HermesTpx3AnalysisState,
-    raw_file: FileReference,
+) -> list[FileReference]:
+    """Return the pixel Parquet files reconstruction should run over.
+
+    ``pixel_parquet_files == "auto"`` gathers every ``*.parquet`` under the
+    unpacking stage's ``pixelHits`` directory; an explicit list is used as-is.
+    """
+    reconstruction = _require_reconstruction(analysis)
+    if reconstruction.pixel_parquet_files != "auto":
+        return list(reconstruction.pixel_parquet_files)
+
+    pixel_directory = analysis.analysis_directory / "pixelHits"
+    if not pixel_directory.is_dir():
+        return []
+    return [
+        FileReference(path=path)
+        for path in sorted(pixel_directory.glob("*.parquet"))
+    ]
+
+
+def derive_output_path(
+    reconstruction: Tpx3PhotonReconstruction,
+    input_file: FileReference,
 ) -> Path:
-    """Return the path of the summary JSON the binary writes for one raw file."""
-    # The file is named after the raw file (without its extension), under logs/.
-    return (
-        analysis.analysis_directory
-        / "logs"
-        / f"{raw_file.path.stem}-reconstruction-summary.json"
-    )
+    """Return the photon file path for one pixel file (input basename kept)."""
+    assert reconstruction.output_directory is not None  # derived on the state
+    return reconstruction.output_directory / f"{input_file.path.stem}.parquet"
+
+
+def derive_summary_path(output_file: Path) -> Path:
+    """Return the reconstruction-summary sidecar the binary writes."""
+    return output_file.parent / f"{output_file.stem}-reconstruction-summary.json"
 
 
 def derive_reconstruction_command(
-    reconstruction: Tpx3PhotonReconstructionConfiguration,
-    analysis_directory: Path,
-    raw_file_stem: str,
+    reconstruction: Tpx3PhotonReconstruction,
+    input_file: FileReference,
+    output_file: Path,
     settings_file: Path,
     *,
     overwrite: bool = False,
 ) -> list[str]:
     """Build the command line that launches the reconstruction binary."""
-    # Reads pixel data from and writes results to the same analysis directory.
-    # --overwrite lets it replace files from a previous run; without it the
-    # binary refuses and stops.
     command = [
         str(reconstruction.program.executable_path),
         "--input",
-        str(analysis_directory),
-        "--base-file-name",
-        raw_file_stem,
+        str(input_file.path),
         "--output",
-        str(analysis_directory),
+        str(output_file),
         "--settings",
         str(settings_file),
     ]
@@ -99,83 +116,49 @@ def plan_reconstruction(
     *,
     overwrite: bool = False,
 ) -> ReconstructionPlan:
-    """Decide, per raw file, whether to "run" reconstruction or "skip" it.
+    """Decide, per pixel file, whether to "run" reconstruction or "skip" it.
 
-    A file is skipped when valid results already exist. This runs before any
-    binary is launched, so problems are caught up front.
+    With overwrite every file runs. Otherwise a file is skipped only when its
+    photon output file already exists.
     """
     reconstruction = _require_reconstruction(analysis)
     _validate_program_and_algorithm(reconstruction)
 
-    # With overwrite, redo every file regardless of existing output.
-    if overwrite:
-        return [(raw_file, "run") for raw_file in analysis.tpx3_files]
-
     plan: ReconstructionPlan = []
-    for raw_file in analysis.tpx3_files:
-        summary_path = derive_summary_path(analysis, raw_file)
-        # Photon files already sitting in the output directory for this file.
-        matching_photon_files = _matching_photon_files(
-            reconstruction.photon_output_directory,
-            raw_file.path.stem,
-        )
-
-        # A summary exists: only skip if it matches the requested settings and
-        # its files check out. A mismatch means the existing results are stale.
-        if summary_path.exists():
-            summary = _load_summary(summary_path)
-            if (
-                summary.clustering.algorithm != reconstruction.clustering_algorithm
-                or summary.clustering.settings != reconstruction.settings
-            ):
-                raise HermesReconstructionOutputError(
-                    "reconstruction summary settings do not match the requested settings: "
-                    f"{summary_path}"
-                )
-            _validate_completed_files(
-                summary,
-                summary_path,
-                analysis.analysis_directory,
-                raw_file.path.stem,
-            )
-            plan.append((raw_file, "skip"))
-        # Photon files but no summary means a half-finished or corrupt run; stop
-        # rather than silently overwrite or trust them.
-        elif matching_photon_files:
-            raise HermesReconstructionPreflightError(
-                f"photon files exist without a valid summary for "
-                f"{raw_file.path}: {matching_photon_files[0]}"
-            )
-        # Nothing on disk yet: this file needs reconstruction.
+    for input_file in resolve_pixel_files(analysis):
+        if not overwrite and derive_output_path(
+            reconstruction, input_file
+        ).exists():
+            plan.append((input_file, "skip"))
         else:
-            plan.append((raw_file, "run"))
-
+            plan.append((input_file, "run"))
     return plan
 
 
 def execute_reconstruction(
     analysis: HermesTpx3AnalysisState,
-    raw_file: FileReference,
+    input_file: FileReference,
     *,
     overwrite: bool = False,
-) -> Tpx3PhotonReconstructionSummary:
-    """Run the binary on one raw file and return its validated summary.
+) -> HermesTpx3ReconstructionResult:
+    """Run the binary on one pixel file and return its per-file result.
 
     Raises a HermesReconstructionError if the binary fails to launch, exits with
-    an error, or produces output that does not pass validation.
+    an error, or leaves no readable summary.
     """
     reconstruction = _require_reconstruction(analysis)
-    summary_path = derive_summary_path(analysis, raw_file)
+    output_file = derive_output_path(reconstruction, input_file)
+    summary_path = derive_summary_path(output_file)
+    started_at = utc_now()
     started = perf_counter()
 
-    # HERMES delivers the complete clustering settings to the binary in a
-    # temporary JSON file and removes it after the process exits. The field
-    # names match the binary's settings keys.
+    # The complete clustering settings go to the binary in a temporary JSON
+    # file; the field names match the binary's settings keys.
     settings_json = reconstruction.settings.model_dump(mode="json")
     with tempfile.NamedTemporaryFile(
         mode="w",
         suffix=".json",
-        prefix=f"{raw_file.path.stem}-clustering-settings-",
+        prefix=f"{input_file.path.stem}-clustering-settings-",
         delete=False,
     ) as settings_stream:
         json.dump(settings_json, settings_stream)
@@ -183,17 +166,16 @@ def execute_reconstruction(
 
     command = derive_reconstruction_command(
         reconstruction,
-        analysis.analysis_directory,
-        raw_file.path.stem,
+        input_file,
+        output_file,
         settings_file,
         overwrite=overwrite,
     )
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_reconstruction.started",
         event_type="analysis.tpx3_reconstruction.started",
-        raw_tpx3_file=str(raw_file.path),
-        raw_file_stem=raw_file.path.stem,
-        analysis_directory=str(analysis.analysis_directory),
+        pixel_file=str(input_file.path),
+        output_file=str(output_file),
         summary_json_file=str(summary_path),
         executable_path=str(reconstruction.program.executable_path),
         executable_version=reconstruction.program.version,
@@ -202,8 +184,6 @@ def execute_reconstruction(
     )
 
     try:
-        # Launch the binary and wait for it. shell=False avoids shell parsing;
-        # check=False lets us inspect the exit code ourselves below.
         try:
             process = subprocess.run(
                 command,
@@ -215,13 +195,13 @@ def execute_reconstruction(
         except OSError as exc:
             elapsed_seconds = perf_counter() - started
             _log_process_failure(
-                raw_file,
+                input_file,
                 command,
                 elapsed_seconds,
                 error=str(exc),
             )
             raise HermesReconstructionExecutionError(
-                f"failed to launch clusterer for {raw_file.path}: {exc}"
+                f"failed to launch clusterer for {input_file.path}: {exc}"
             ) from exc
 
         elapsed_seconds = perf_counter() - started
@@ -229,7 +209,7 @@ def execute_reconstruction(
         stderr_excerpt = _bounded_text(process.stderr)
         if process.returncode != 0:
             _log_process_failure(
-                raw_file,
+                input_file,
                 command,
                 elapsed_seconds,
                 error=f"clusterer exited with code {process.returncode}",
@@ -239,53 +219,18 @@ def execute_reconstruction(
             )
             raise HermesReconstructionExecutionError(
                 f"clusterer exited with code {process.returncode} for "
-                f"{raw_file.path}"
+                f"{input_file.path}"
             )
 
-        # The binary exited cleanly; now confirm the output it left behind is
-        # complete and matches what we asked for before trusting it.
-        summary: Tpx3PhotonReconstructionSummary | None = None
-        try:
-            summary = _load_summary(summary_path)
-            if (
-                summary.clustering.algorithm != reconstruction.clustering_algorithm
-                or summary.clustering.settings != reconstruction.settings
-            ):
-                raise HermesReconstructionOutputError(
-                    "reconstruction summary settings do not match the requested settings: "
-                    f"{summary_path}"
-                )
-            _validate_completed_files(
-                summary,
-                summary_path,
-                analysis.analysis_directory,
-                raw_file.path.stem,
-            )
-        except HermesReconstructionError as exc:
-            _log_process_failure(
-                raw_file,
-                command,
-                elapsed_seconds,
-                error=str(exc),
-                exit_code=process.returncode,
-                stdout_excerpt=stdout_excerpt,
-                stderr_excerpt=stderr_excerpt,
-                summary=(
-                    summary.model_dump(mode="json")
-                    if summary is not None
-                    else None
-                ),
-            )
-            raise
+        summary = _load_summary(summary_path)
     finally:
-        # Always remove the temporary settings file, even if the run failed.
         settings_file.unlink(missing_ok=True)
 
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_reconstruction.completed",
         event_type="analysis.tpx3_reconstruction.completed",
-        raw_tpx3_file=str(raw_file.path),
-        analysis_directory=str(analysis.analysis_directory),
+        pixel_file=str(input_file.path),
+        output_file=str(output_file),
         summary_json_file=str(summary_path),
         command=command,
         exit_code=process.returncode,
@@ -295,37 +240,43 @@ def execute_reconstruction(
         photon_count=summary.reconstruction.photon_count,
         rejected_component_count=summary.reconstruction.rejected_component_count,
     )
-    return summary
+    return HermesTpx3ReconstructionResult(
+        input_file=input_file,
+        output_file=output_file,
+        status="completed",
+        started_at=started_at,
+        completed_at=utc_now(),
+        counts=summary.reconstruction,
+    )
 
 
 def log_skipped_input(
-    analysis: HermesTpx3AnalysisState,
-    raw_file: FileReference,
+    input_file: FileReference,
+    output_file: Path,
 ) -> None:
-    """Log that one raw file was skipped because valid results already exist."""
+    """Log that one pixel file was skipped because its photon file exists."""
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_reconstruction.skipped",
         event_type="analysis.tpx3_reconstruction.skipped",
-        raw_tpx3_file=str(raw_file.path),
-        analysis_directory=str(analysis.analysis_directory),
-        summary_json_file=str(derive_summary_path(analysis, raw_file)),
-        reason="valid summary and photon files already exist",
+        pixel_file=str(input_file.path),
+        output_file=str(output_file),
+        reason="photon output file already exists",
     )
 
 
 def log_overall_completion(
     *,
-    raw_file_count: int,
+    pixel_file_count: int,
     reconstructed_file_count: int,
 ) -> None:
-    """Log a summary line once every raw file has been handled."""
+    """Log a summary line once every pixel file has been handled."""
     _ANALYSIS_LOGGER.info(
         "analysis.tpx3_reconstruction.completed",
         event_type="analysis.tpx3_reconstruction.completed",
-        scope="all_raw_tpx3_files",
-        raw_file_count=raw_file_count,
+        scope="all_pixel_files",
+        pixel_file_count=pixel_file_count,
         reconstructed_file_count=reconstructed_file_count,
-        skipped_file_count=raw_file_count - reconstructed_file_count,
+        skipped_file_count=pixel_file_count - reconstructed_file_count,
     )
 
 
@@ -334,14 +285,14 @@ def log_overall_failure(error: Exception) -> None:
     _ANALYSIS_LOGGER.error(
         "analysis.tpx3_reconstruction.failed",
         event_type="analysis.tpx3_reconstruction.failed",
-        scope="all_raw_tpx3_files",
+        scope="all_pixel_files",
         error=str(error),
     )
 
 
 def _require_reconstruction(
     analysis: HermesTpx3AnalysisState,
-) -> Tpx3PhotonReconstructionConfiguration:
+) -> Tpx3PhotonReconstruction:
     """Return the reconstruction config, or raise if it is not set up."""
     reconstruction = analysis.photon_reconstruction
     if reconstruction is None:
@@ -352,7 +303,7 @@ def _require_reconstruction(
 
 
 def _validate_program_and_algorithm(
-    reconstruction: Tpx3PhotonReconstructionConfiguration,
+    reconstruction: Tpx3PhotonReconstruction,
 ) -> None:
     """Check the algorithm is supported and the binary exists before running."""
     if reconstruction.clustering_algorithm != "connected_components":
@@ -368,158 +319,23 @@ def _validate_program_and_algorithm(
 
 
 def _load_summary(summary_path: Path) -> Tpx3PhotonReconstructionSummary:
-    """Read and parse a summary JSON file into a validated model object."""
+    """Read and parse a reconstruction-summary sidecar into a model object."""
     if not summary_path.is_file():
-        raise HermesReconstructionPreflightError(
-            f"summary path is not a regular file: {summary_path}"
+        raise HermesReconstructionOutputError(
+            f"reconstruction summary is missing: {summary_path}"
         )
     try:
         return Tpx3PhotonReconstructionSummary.model_validate_json(
             summary_path.read_bytes()
         )
     except OSError as exc:
-        raise HermesReconstructionPreflightError(
+        raise HermesReconstructionOutputError(
             f"cannot read summary JSON file: {summary_path}"
         ) from exc
     except ValidationError as exc:
-        raise HermesReconstructionPreflightError(
+        raise HermesReconstructionOutputError(
             f"invalid summary JSON file: {summary_path}"
         ) from exc
-
-
-def _validate_completed_files(
-    summary: Tpx3PhotonReconstructionSummary,
-    summary_path: Path,
-    analysis_directory: Path,
-    raw_file_stem: str,
-) -> None:
-    """Confirm the files the summary claims to have produced are real and sane.
-
-    Guards against a summary that reports errors, lists files that are missing,
-    misnamed, duplicated, or point outside the analysis directory, has row
-    counts that disagree with the files, or leaves stray files on disk. Any of
-    these raises HermesReconstructionOutputError.
-    """
-    if summary.reconstruction.errors:
-        raise HermesReconstructionOutputError(
-            f"summary reports reconstruction errors: {summary_path}"
-        )
-
-    # Used below to make sure no listed file escapes the analysis directory.
-    analysis_root = analysis_directory.resolve()
-
-    # photon_events is always written; photon_pixels only when it was requested.
-    file_groups = [
-        ("photon-events", summary.parquet.photon_events, True),
-    ]
-    if summary.parquet.photon_pixels.requested:
-        file_groups.append(
-            ("photon-pixels", summary.parquet.photon_pixels, True)
-        )
-    elif (
-        summary.parquet.photon_pixels.files
-        or summary.parquet.photon_pixels.row_count
-    ):
-        raise HermesReconstructionOutputError(
-            f"summary lists photon_pixels output that was not requested: "
-            f"{summary_path}"
-        )
-
-    listed_files: set[Path] = set()
-    filename_pattern = re.compile(
-        rf"^{re.escape(raw_file_stem)}-chip-(\d+)-(photon-events|photon-pixels)"
-        rf"-part-(\d{{5}})\.parquet$"
-    )
-    # Check every file the summary lists: correct name, no duplicates, inside
-    # the directory, and actually present on disk.
-    for filename_marker, category, _always in file_groups:
-        parts_by_chip: dict[int, list[int]] = {}
-        for relative_path in category.files:
-            filename_match = filename_pattern.fullmatch(relative_path.name)
-            if (
-                len(relative_path.parts) != 2
-                or relative_path.parts[0] != "photons"
-                or filename_match is None
-                or filename_match.group(2) != filename_marker
-            ):
-                raise HermesReconstructionOutputError(
-                    f"unexpected photon filename for {raw_file_stem}: "
-                    f"{relative_path}"
-                )
-            if relative_path in listed_files:
-                raise HermesReconstructionOutputError(
-                    f"summary lists the same photon file more than once: "
-                    f"{relative_path}"
-                )
-
-            chip_index = int(filename_match.group(1))
-            part_index = int(filename_match.group(3))
-            parts_by_chip.setdefault(chip_index, []).append(part_index)
-
-            photon_path = analysis_directory / relative_path
-            resolved_path = photon_path.resolve()
-            if not resolved_path.is_relative_to(analysis_root):
-                raise HermesReconstructionOutputError(
-                    f"summary lists a photon file outside the analysis "
-                    f"directory: {relative_path}"
-                )
-            if not photon_path.is_file():
-                raise HermesReconstructionOutputError(
-                    f"summary lists a missing photon file: {photon_path}"
-                )
-            listed_files.add(relative_path)
-
-        # Each chip's parts must be numbered 0, 1, 2, ... with no gaps.
-        for chip_index, part_indexes in parts_by_chip.items():
-            if sorted(part_indexes) != list(range(len(part_indexes))):
-                raise HermesReconstructionOutputError(
-                    f"unexpected photon part numbers for {filename_marker} "
-                    f"chip {chip_index}: {sorted(part_indexes)}"
-                )
-
-    # The photon_events row count must equal the recorded photon count.
-    observed_events = 0
-    for relative_path in summary.parquet.photon_events.files:
-        photon_path = analysis_directory / relative_path
-        try:
-            observed_events += pq.read_metadata(photon_path).num_rows
-        except Exception as exc:
-            raise HermesReconstructionOutputError(
-                f"cannot read photon Parquet metadata: {photon_path}"
-            ) from exc
-    if observed_events != summary.parquet.photon_events.row_count:
-        raise HermesReconstructionOutputError(
-            f"photon_events row count mismatch: "
-            f"summary={summary.parquet.photon_events.row_count}, "
-            f"files={observed_events}"
-        )
-
-    # Every photon file on disk for this stem must be listed in the summary.
-    matching_files = {
-        path.relative_to(analysis_directory)
-        for path in _matching_photon_files(
-            analysis_directory / "photons",
-            raw_file_stem,
-        )
-    }
-    if matching_files != listed_files:
-        unexpected = sorted(str(path) for path in matching_files - listed_files)
-        missing = sorted(str(path) for path in listed_files - matching_files)
-        raise HermesReconstructionOutputError(
-            f"summary photon file list does not match files for "
-            f"{raw_file_stem}; unexpected={unexpected}, missing={missing}"
-        )
-
-
-def _matching_photon_files(
-    photon_output_directory: Path,
-    raw_file_stem: str,
-) -> list[Path]:
-    """List the photon files on disk that belong to one raw file."""
-    if not photon_output_directory.is_dir():
-        return []
-    pattern = f"{raw_file_stem}-*.parquet"
-    return sorted(photon_output_directory.glob(pattern))
 
 
 def _bounded_text(text: str) -> str:
@@ -528,7 +344,7 @@ def _bounded_text(text: str) -> str:
 
 
 def _log_process_failure(
-    raw_file: FileReference,
+    input_file: FileReference,
     command: list[str],
     elapsed_seconds: float,
     *,
@@ -536,18 +352,16 @@ def _log_process_failure(
     exit_code: int | None = None,
     stdout_excerpt: str = "",
     stderr_excerpt: str = "",
-    summary: dict[str, object] | None = None,
 ) -> None:
-    """Log a failure for one raw file with the command output for debugging."""
+    """Log a failure for one pixel file with the command output for debugging."""
     _ANALYSIS_LOGGER.error(
         "analysis.tpx3_reconstruction.failed",
         event_type="analysis.tpx3_reconstruction.failed",
-        raw_tpx3_file=str(raw_file.path),
+        pixel_file=str(input_file.path),
         command=command,
         exit_code=exit_code,
         elapsed_seconds=elapsed_seconds,
         stdout_excerpt=stdout_excerpt,
         stderr_excerpt=stderr_excerpt,
-        summary=summary,
         error=error,
     )

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -275,7 +275,7 @@ def _run_photon_reconstruction(
                     HermesTpx3ReconstructionResult(
                         input_file=input_file,
                         output_file=output_file,
-                        status="completed",
+                        status="skipped",
                     )
                 )
 

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -204,16 +204,16 @@ def run_hermes_analysis(
         unpacking_results = [
             HermesTpx3UnpackingResult(
                 input_file=raw_file,
-                status="completed",
-                started_at=started_at,
-                completed_at=completed_at,
+                status="completed" if action == "run" else "skipped",
+                started_at=started_at if action == "run" else None,
+                completed_at=completed_at if action == "run" else None,
             )
-            for raw_file, _ in unpacking_plan
+            for raw_file, action in unpacking_plan
         ]
         _apply_unpacking_results(
             state_manager,
             unpacking_results,
-            justification="every raw TPX3 file passed unpacking validation",
+            justification="unpacked new raw TPX3 files; revalidated existing outputs",
         )
         log_overall_completion(
             raw_file_count=len(unpacking_plan),

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from hermes.analysis.hermes.reconstruction import (
     HermesReconstructionError,
+    derive_output_path,
     execute_reconstruction,
     plan_reconstruction,
 )
@@ -30,7 +31,6 @@ from hermes.analysis.hermes.unpacker import (
 )
 from hermes.state.models.analysis.empir import EmpirAnalysisState
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
-    HermesTpx3AnalysisResults,
     HermesTpx3AnalysisState,
     HermesTpx3ReconstructionResult,
     HermesTpx3UnpackingResult,
@@ -109,30 +109,25 @@ def _calculate_worker_count(
     return worker_count
 
 
-def _run_parallel_unpacking(
-    analysis: HermesTpx3AnalysisState,
-    files_to_run: list[FileReference],
-    worker_count: int,
-    *,
-    overwrite: bool = False,
-) -> list[FileReference]:
-    """Run unpacker processes concurrently and return successfully unpacked files."""
+def _run_parallel(executor_fn, items, worker_count):
+    """Run ``executor_fn`` over ``items`` concurrently, stopping on first error.
+
+    Returns ``{index: result}`` for the items that completed successfully. On
+    the first failure the remaining not-started futures are cancelled and the
+    error is re-raised once in-flight work drains.
+    """
     first_error: Exception | None = None
-    completed_files: set[int] = set()
+    results: dict[int, object] = {}
 
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
         future_to_index = {
-            executor.submit(
-                execute_unpacker, analysis, raw_file, overwrite=overwrite
-            ): i
-            for i, raw_file in enumerate(files_to_run)
+            executor.submit(executor_fn, item): i
+            for i, item in enumerate(items)
         }
-
         for future in as_completed(future_to_index):
-            file_index = future_to_index[future]
+            index = future_to_index[future]
             try:
-                future.result()
-                completed_files.add(file_index)
+                results[index] = future.result()
             except Exception as exc:
                 if first_error is None:
                     first_error = exc
@@ -143,7 +138,7 @@ def _run_parallel_unpacking(
     if first_error is not None:
         raise first_error
 
-    return [files_to_run[i] for i in sorted(completed_files)]
+    return results
 
 
 def run_hermes_analysis(
@@ -178,51 +173,46 @@ def run_hermes_analysis(
         )
         raise HermesAnalysisError(error)
 
+    unpack_overwrite = overwrite or analysis.unpacking.runtime_options.overwrite
     try:
-        unpacking_plan = plan_unpacking(analysis, overwrite=overwrite)
+        unpacking_plan = plan_unpacking(analysis, overwrite=unpack_overwrite)
         files_to_run = [
             raw_file
             for raw_file, action in unpacking_plan
             if action == "run"
         ]
 
-        if files_to_run:
-            _apply_unpacking_result(
-                state_manager,
-                analysis,
-                HermesTpx3UnpackingResult(
-                    status="running",
-                    started_at=utc_now(),
-                ),
-                justification="TPX3 SPIDR unpacking is ready to start",
-            )
-
         for raw_file, action in unpacking_plan:
             if action == "skip":
                 log_skipped_input(analysis, raw_file)
 
+        started_at = utc_now()
         if files_to_run:
             worker_count = _calculate_worker_count(analysis, files_to_run)
-            unpacked_files = _run_parallel_unpacking(
-                analysis,
+            completed = _run_parallel(
+                lambda raw_file: execute_unpacker(
+                    analysis, raw_file, overwrite=unpack_overwrite
+                ),
                 files_to_run,
                 worker_count,
-                overwrite=overwrite,
             )
+            unpacked_files = [files_to_run[i] for i in sorted(completed)]
         else:
             unpacked_files = []
 
-        current_analysis = state_manager.get_state().analysis
-        if not isinstance(current_analysis, HermesTpx3AnalysisState):
-            raise HermesAnalysisError("the saved analysis mode changed during unpacking")
-        _apply_unpacking_result(
-            state_manager,
-            current_analysis,
+        completed_at = utc_now()
+        unpacking_results = [
             HermesTpx3UnpackingResult(
+                input_file=raw_file,
                 status="completed",
-                started_at=current_analysis.results.unpacking.started_at,
-                completed_at=utc_now(),
-            ),
+                started_at=started_at,
+                completed_at=completed_at,
+            )
+            for raw_file, _ in unpacking_plan
+        ]
+        _apply_unpacking_results(
+            state_manager,
+            unpacking_results,
             justification="every raw TPX3 file passed unpacking validation",
         )
         log_overall_completion(
@@ -230,6 +220,7 @@ def run_hermes_analysis(
             unpacked_file_count=len(files_to_run),
         )
 
+        current_analysis = _current_hermes_analysis(state_manager)
         if current_analysis.photon_reconstruction is not None:
             _run_photon_reconstruction(
                 state_manager, current_analysis, overwrite=overwrite
@@ -239,39 +230,20 @@ def run_hermes_analysis(
     except HermesTpx3Error as exc:
         current_analysis = state_manager.get_state().analysis
         if isinstance(current_analysis, HermesTpx3AnalysisState):
-            _apply_unpacking_result(
+            _apply_unpacking_results(
                 state_manager,
-                current_analysis,
-                HermesTpx3UnpackingResult(
-                    status="failed",
-                    started_at=current_analysis.results.unpacking.started_at,
-                    completed_at=utc_now(),
-                ),
+                [
+                    HermesTpx3UnpackingResult(
+                        input_file=raw_file,
+                        status="failed",
+                        completed_at=utc_now(),
+                    )
+                    for raw_file in current_analysis.unpacking.tpx3_files
+                ],
                 justification=f"TPX3 SPIDR unpacking failed: {exc}",
             )
         log_overall_failure(exc)
         raise
-
-
-def _apply_unpacking_result(
-    state_manager: StateManager,
-    analysis: HermesTpx3AnalysisState,
-    unpacking_result: HermesTpx3UnpackingResult,
-    *,
-    justification: str,
-) -> None:
-    results = HermesTpx3AnalysisResults(
-        unpacking=unpacking_result,
-        reconstruction=analysis.results.reconstruction,
-    )
-    change = state_manager.propose_change(
-        "analysis.results",
-        results,
-        origin="trusted_workflow",
-        proposer="tpx3_spidr_unpacking",
-        justification=justification,
-    )
-    state_manager.apply_change(change.change_id)
 
 
 def _run_photon_reconstruction(
@@ -280,93 +252,120 @@ def _run_photon_reconstruction(
     *,
     overwrite: bool = False,
 ) -> None:
-    """Reconstruct photons for every raw stem, applying status on the main thread."""
+    """Reconstruct photons file-by-file in parallel, recording per-file results."""
+    reconstruction = analysis.photon_reconstruction
+    assert reconstruction is not None
+    recon_overwrite = overwrite or reconstruction.runtime_options.overwrite
     try:
-        reconstruction_plan = plan_reconstruction(analysis, overwrite=overwrite)
+        reconstruction_plan = plan_reconstruction(
+            analysis, overwrite=recon_overwrite
+        )
         files_to_run = [
-            raw_file
-            for raw_file, action in reconstruction_plan
+            input_file
+            for input_file, action in reconstruction_plan
             if action == "run"
         ]
 
-        started_at = None
-        if files_to_run:
-            started_at = utc_now()
-            _apply_reconstruction_result(
-                state_manager,
-                HermesTpx3ReconstructionResult(
-                    status="running",
-                    started_at=started_at,
-                ),
-                justification="photon reconstruction is ready to start",
-            )
-
-        photon_count = 0
-        rejected_count = 0
-        for raw_file, action in reconstruction_plan:
+        skipped_results: list[HermesTpx3ReconstructionResult] = []
+        for input_file, action in reconstruction_plan:
             if action == "skip":
-                log_reconstruction_skipped(analysis, raw_file)
-                continue
-            summary = execute_reconstruction(
-                analysis, raw_file, overwrite=overwrite
-            )
-            photon_count += summary.reconstruction.photon_count
-            rejected_count += summary.reconstruction.rejected_component_count
+                output_file = derive_output_path(reconstruction, input_file)
+                log_reconstruction_skipped(input_file, output_file)
+                skipped_results.append(
+                    HermesTpx3ReconstructionResult(
+                        input_file=input_file,
+                        output_file=output_file,
+                        status="completed",
+                    )
+                )
 
-        _apply_reconstruction_result(
+        if files_to_run:
+            worker_count = _calculate_worker_count(analysis, files_to_run)
+            completed = _run_parallel(
+                lambda input_file: execute_reconstruction(
+                    analysis, input_file, overwrite=recon_overwrite
+                ),
+                files_to_run,
+                worker_count,
+            )
+            run_results = [completed[i] for i in sorted(completed)]
+        else:
+            run_results = []
+
+        _apply_reconstruction_results(
             state_manager,
-            HermesTpx3ReconstructionResult(
-                status="completed",
-                started_at=started_at,
-                completed_at=utc_now(),
-                photon_count=photon_count,
-                rejected_count=rejected_count,
-            ),
-            justification="every raw TPX3 file passed photon reconstruction",
+            skipped_results + run_results,
+            justification="every pixel file passed photon reconstruction",
         )
         log_reconstruction_completion(
-            raw_file_count=len(reconstruction_plan),
+            pixel_file_count=len(reconstruction_plan),
             reconstructed_file_count=len(files_to_run),
         )
     except HermesReconstructionError as exc:
-        current_analysis = state_manager.get_state().analysis
-        started_at = None
-        if (
-            isinstance(current_analysis, HermesTpx3AnalysisState)
-            and current_analysis.results.reconstruction is not None
-        ):
-            started_at = current_analysis.results.reconstruction.started_at
-        _apply_reconstruction_result(
+        _apply_reconstruction_results(
             state_manager,
-            HermesTpx3ReconstructionResult(
-                status="failed",
-                started_at=started_at,
-                completed_at=utc_now(),
-                errors=[str(exc)],
-            ),
+            [
+                HermesTpx3ReconstructionResult(
+                    input_file=input_file,
+                    output_file=derive_output_path(reconstruction, input_file),
+                    status="failed",
+                    completed_at=utc_now(),
+                )
+                for input_file in _reconstruction_inputs(analysis)
+            ],
             justification=f"photon reconstruction failed: {exc}",
         )
         log_reconstruction_failure(exc)
         raise
 
 
-def _apply_reconstruction_result(
+def _reconstruction_inputs(
+    analysis: HermesTpx3AnalysisState,
+) -> list[FileReference]:
+    """Best-effort pixel-file list for failure reporting (never raises)."""
+    from hermes.analysis.hermes.reconstruction import resolve_pixel_files
+
+    try:
+        return resolve_pixel_files(analysis)
+    except Exception:
+        return []
+
+
+def _current_hermes_analysis(
     state_manager: StateManager,
-    reconstruction_result: HermesTpx3ReconstructionResult,
-    *,
-    justification: str,
-) -> None:
+) -> HermesTpx3AnalysisState:
     current_analysis = state_manager.get_state().analysis
     if not isinstance(current_analysis, HermesTpx3AnalysisState):
         raise HermesAnalysisError(
-            "the saved analysis mode changed during reconstruction"
+            "the saved analysis mode changed during analysis"
         )
-    results = HermesTpx3AnalysisResults(
-        unpacking=current_analysis.results.unpacking,
-        reconstruction=reconstruction_result,
-    )
+    return current_analysis
+
+
+def _apply_unpacking_results(
+    state_manager: StateManager,
+    results: list[HermesTpx3UnpackingResult],
+    *,
+    justification: str,
+) -> None:
     change = state_manager.propose_change(
-        "analysis.results",
+        "analysis.unpacking.results",
+        results,
+        origin="trusted_workflow",
+        proposer="tpx3_spidr_unpacking",
+        justification=justification,
+    )
+    state_manager.apply_change(change.change_id)
+
+
+def _apply_reconstruction_results(
+    state_manager: StateManager,
+    results: list[HermesTpx3ReconstructionResult],
+    *,
+    justification: str,
+) -> None:
+    change = state_manager.propose_change(
+        "analysis.photon_reconstruction.results",
         results,
         origin="trusted_workflow",
         proposer="tpx3_spidr_reconstruction",

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -228,7 +228,7 @@ def log_skipped_input(
     analysis: HermesTpx3AnalysisState,
     raw_file: FileReference,
 ) -> None:
-    _ANALYSIS_LOGGER.info(
+    _ANALYSIS_LOGGER.warning(
         "analysis.tpx3_unpacking.skipped",
         event_type="analysis.tpx3_unpacking.skipped",
         raw_tpx3_file=str(raw_file.path),

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -69,14 +69,16 @@ def derive_unpacker_command(
     overwrite: bool = False,
 ) -> list[str]:
     command = [
-        str(analysis.unpacker_program.executable_path),
+        str(analysis.unpacking.program.executable_path),
         "--input",
         str(raw_file.path),
         "--output",
-        str(analysis.analysis_directory),
+        str(analysis.unpacking.output_directory),
     ]
     if overwrite:
         command.append("--overwrite")
+    if not analysis.unpacking.runtime_options.time_sort:
+        command.extend(["--time-sort", "false"])
     return command
 
 
@@ -88,10 +90,10 @@ def plan_unpacking(
     _validate_program_and_inputs(analysis)
 
     if overwrite:
-        return [(raw_file, "run") for raw_file in analysis.tpx3_files]
+        return [(raw_file, "run") for raw_file in analysis.unpacking.tpx3_files]
 
     plan: UnpackingPlan = []
-    for raw_file in analysis.tpx3_files:
+    for raw_file in analysis.unpacking.tpx3_files:
         summary_path = derive_summary_path(analysis, raw_file)
         matching_parquet_files = _matching_parquet_files(
             analysis.analysis_directory,
@@ -127,7 +129,7 @@ def execute_unpacker(
     command = derive_unpacker_command(analysis, raw_file, overwrite=overwrite)
     summary_path = derive_summary_path(analysis, raw_file)
     resolved_executable_path = (
-        analysis.unpacker_program.executable_path.resolve()
+        analysis.unpacking.program.executable_path.resolve()
     )
     started = perf_counter()
     _ANALYSIS_LOGGER.info(
@@ -137,9 +139,9 @@ def execute_unpacker(
         raw_tpx3_size_bytes=raw_file.path.stat().st_size,
         analysis_directory=str(analysis.analysis_directory),
         summary_json_file=str(summary_path),
-        executable_path=str(analysis.unpacker_program.executable_path),
+        executable_path=str(analysis.unpacking.program.executable_path),
         resolved_executable_path=str(resolved_executable_path),
-        executable_version=analysis.unpacker_program.version,
+        executable_version=analysis.unpacking.program.version,
         command=command,
     )
 
@@ -261,20 +263,20 @@ def log_overall_failure(error: Exception) -> None:
 
 
 def _validate_program_and_inputs(analysis: HermesTpx3AnalysisState) -> None:
-    executable = analysis.unpacker_program.executable_path
+    executable = analysis.unpacking.program.executable_path
     if not executable.is_file():
         raise HermesTpx3PreflightError(
             f"unpacker executable does not exist: {executable}; build the "
-            "binary (e.g. via pixi) and set unpacker_program.executable_path"
+            "binary (e.g. via pixi) and set unpacking.program.executable_path"
         )
 
-    for raw_file in analysis.tpx3_files:
+    for raw_file in analysis.unpacking.tpx3_files:
         if not raw_file.path.is_file():
             raise HermesTpx3PreflightError(
                 f"raw TPX3 file does not exist: {raw_file.path}"
             )
 
-    stems = [raw_file.path.stem for raw_file in analysis.tpx3_files]
+    stems = [raw_file.path.stem for raw_file in analysis.unpacking.tpx3_files]
     if len(stems) != len(set(stems)):
         raise HermesTpx3PreflightError(
             "raw TPX3 filename stems must be unique"

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -6,7 +6,11 @@ from typing import Literal
 
 from pydantic import Field, model_validator
 
-from hermes.state.models.shared_models import FileReference, StrictBaseModel
+from hermes.state.models.shared_models import (
+    BinaryProgram,
+    FileReference,
+    StrictBaseModel,
+)
 
 EmpirRunStatus = Literal["planned", "running", "completed", "failed"]
 EmpirExternalTriggerMode = Literal["ignore", "reference", "frameSync"]
@@ -40,7 +44,7 @@ class EmpirPixelToPhotonRun(StrictBaseModel):
 
 
 class EmpirPixelToPhotonState(StrictBaseModel):
-    executable_path: Path
+    program: BinaryProgram
     settings: EmpirPixelToPhotonSettings
     runs: list[EmpirPixelToPhotonRun] = Field(min_length=1)
 
@@ -71,7 +75,7 @@ class EmpirPhotonToEventRun(StrictBaseModel):
 
 
 class EmpirPhotonToEventState(StrictBaseModel):
-    executable_path: Path
+    program: BinaryProgram
     settings: EmpirPhotonToEventSettings
     runs: list[EmpirPhotonToEventRun] = Field(min_length=1)
 
@@ -125,7 +129,7 @@ class EmpirEventToImageResult(StrictBaseModel):
 
 
 class EmpirEventToImageState(StrictBaseModel):
-    executable_path: Path
+    program: BinaryProgram
     settings: EmpirEventToImageSettings
     input_event_files: list[FileReference] = Field(min_length=1)
     requested_tiff_file: Path

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -6,7 +6,11 @@ from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
 
-from hermes.state.models.shared_models import FileReference, StrictBaseModel
+from hermes.state.models.shared_models import (
+    BinaryProgram,
+    FileReference,
+    StrictBaseModel,
+)
 
 HermesTpx3RunStatus = Literal["planned", "running", "completed", "failed"]
 SortingStrategy = Literal["in_memory", "external_merge"]
@@ -17,25 +21,45 @@ PhotonTimeEstimator = Literal[
     "mean",
     "tot_weighted",
 ]
-PhotonCorrectionModel = Literal["none", "linear", "inverse"]
 
 
-class Tpx3SpidrUnpackerProgram(StrictBaseModel):
-    name: str = Field(min_length=1)
-    executable_path: Path
-    version: str | None = None
+def _expand_file_list(value: object) -> object:
+    """Expand a ``{"file_list": path}`` mapping into a list of file entries.
 
+    Each non-empty, non-comment line of the referenced text file becomes one
+    ``{"path": ...}`` entry. Relative lines resolve against the list's own
+    directory. Any other value passes through unchanged.
+    """
+    if not isinstance(value, dict) or "file_list" not in value:
+        return value
 
-class HermesTpx3UnpackingResult(StrictBaseModel):
-    status: HermesTpx3RunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    if set(value) != {"file_list"}:
+        raise ValueError("the file-list form must contain only file_list")
 
+    file_list_value = value["file_list"]
+    if not isinstance(file_list_value, str | Path):
+        raise ValueError("file_list must be a file path")
 
-class PhotonReconstructorProgram(StrictBaseModel):
-    name: str = Field(min_length=1)
-    executable_path: Path
-    version: str | None = None
+    file_list_path = Path(file_list_value).expanduser().resolve(strict=False)
+    try:
+        lines = file_list_path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise ValueError(f"cannot read file list: {file_list_path}") from exc
+
+    files: list[dict[str, Path]] = []
+    for line in lines:
+        entry = line.strip()
+        if not entry or entry.startswith("#"):
+            continue
+        path = Path(entry).expanduser()
+        if not path.is_absolute():
+            path = file_list_path.parent / path
+        files.append({"path": path.resolve(strict=False)})
+
+    if not files:
+        raise ValueError(f"file list contains no file paths: {file_list_path}")
+
+    return files
 
 
 class Tpx3PhotonClusteringSettings(StrictBaseModel):
@@ -79,110 +103,9 @@ class Tpx3PhotonClusteringSettings(StrictBaseModel):
         return self
 
 
-class Tpx3PhotonReconstructionConfiguration(StrictBaseModel):
-    program: PhotonReconstructorProgram
-    pixel_data_directory: Path
-    photon_output_directory: Path
-    settings: Tpx3PhotonClusteringSettings
-    clustering_algorithm: ClusteringAlgorithm = "connected_components"
-
-
-class HermesTpx3ReconstructionResult(StrictBaseModel):
-    status: HermesTpx3RunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
-    photon_count: int = Field(default=0, ge=0)
-    rejected_count: int = Field(default=0, ge=0)
-    warnings: list[str] = Field(default_factory=list)
-    errors: list[str] = Field(default_factory=list)
-
-
-class HermesTpx3AnalysisResults(StrictBaseModel):
-    unpacking: HermesTpx3UnpackingResult = Field(
-        default_factory=HermesTpx3UnpackingResult
-    )
-    reconstruction: HermesTpx3ReconstructionResult | None = None
-
-
-class HermesTpx3AnalysisState(StrictBaseModel):
-    mode: Literal["hermes"] = "hermes"
-    unpacker_program: Tpx3SpidrUnpackerProgram
-    analysis_directory: Path
-    tpx3_files: list[FileReference] = Field(min_length=1)
-    resource_limit_percent: int = Field(default=90, ge=1, le=100)
-    photon_reconstruction: Tpx3PhotonReconstructionConfiguration | None = None
-    results: HermesTpx3AnalysisResults = Field(
-        default_factory=HermesTpx3AnalysisResults
-    )
-
-    @field_validator("tpx3_files", mode="before")
-    @classmethod
-    def expand_tpx3_file_list(cls, value: object) -> object:
-        if not isinstance(value, dict) or "file_list" not in value:
-            return value
-
-        if set(value) != {"file_list"}:
-            raise ValueError(
-                "the tpx3_files file-list form must contain only file_list"
-            )
-
-        file_list_value = value["file_list"]
-        if not isinstance(file_list_value, str | Path):
-            raise ValueError("tpx3_files.file_list must be a file path")
-
-        file_list_path = Path(file_list_value).expanduser().resolve(strict=False)
-        try:
-            lines = file_list_path.read_text(encoding="utf-8").splitlines()
-        except (OSError, UnicodeError) as exc:
-            raise ValueError(
-                f"cannot read raw TPX3 file list: {file_list_path}"
-            ) from exc
-
-        raw_tpx3_files: list[dict[str, Path]] = []
-        for line in lines:
-            entry = line.strip()
-            if not entry or entry.startswith("#"):
-                continue
-
-            raw_tpx3_path = Path(entry).expanduser()
-            if not raw_tpx3_path.is_absolute():
-                raw_tpx3_path = file_list_path.parent / raw_tpx3_path
-            raw_tpx3_files.append(
-                {"path": raw_tpx3_path.resolve(strict=False)}
-            )
-
-        if not raw_tpx3_files:
-            raise ValueError(
-                f"raw TPX3 file list contains no file paths: {file_list_path}"
-            )
-
-        return raw_tpx3_files
-
-    @model_validator(mode="after")
-    def validate_analysis_paths_and_inputs(self) -> HermesTpx3AnalysisState:
-        stems = [raw_file.path.stem for raw_file in self.tpx3_files]
-        duplicate_stems = sorted(
-            stem for stem in set(stems) if stems.count(stem) > 1
-        )
-        if duplicate_stems:
-            duplicates = ", ".join(duplicate_stems)
-            raise ValueError(f"raw TPX3 filename stems must be unique: {duplicates}")
-
-        reconstruction = self.photon_reconstruction
-        if reconstruction is not None:
-            expected_pixel_directory = self.analysis_directory / "pixelHits"
-            if reconstruction.pixel_data_directory != expected_pixel_directory:
-                raise ValueError(
-                    "photon reconstruction pixel_data_directory must equal "
-                    "analysis_directory / 'pixelHits'"
-                )
-            expected_photon_directory = self.analysis_directory / "photons"
-            if reconstruction.photon_output_directory != expected_photon_directory:
-                raise ValueError(
-                    "photon reconstruction photon_output_directory must equal "
-                    "analysis_directory / 'photons'"
-                )
-        return self
+# ---------------------------------------------------------------------------
+# Unpacker summary (parsed from the unpacker binary's sidecar JSON)
+# ---------------------------------------------------------------------------
 
 
 class Tpx3SpidrUnpackingSummary(StrictBaseModel):
@@ -297,6 +220,11 @@ class Tpx3SpidrSummary(StrictBaseModel):
     processing_times_seconds: Tpx3SpidrProcessingTimesSummary
 
 
+# ---------------------------------------------------------------------------
+# Reconstruction summary (parsed from the clusterer binary's sidecar JSON)
+# ---------------------------------------------------------------------------
+
+
 class Tpx3PhotonRejectionCountsSummary(StrictBaseModel):
     below_min_cluster_size: int = Field(ge=0)
     above_max_cluster_size: int = Field(ge=0)
@@ -346,108 +274,6 @@ class Tpx3PhotonReconstructionCountsSummary(StrictBaseModel):
         return self
 
 
-class Tpx3PhotonClusteringSummary(StrictBaseModel):
-    algorithm: ClusteringAlgorithm
-    settings: Tpx3PhotonClusteringSettings
-
-
-class Tpx3PhotonTimingSummary(StrictBaseModel):
-    estimator: Literal["leading_edge"]
-    correction_model: PhotonCorrectionModel
-    calibration_file: Path | None
-    parameters: dict[str, float]
-    high_tot_anchor: float | None = Field(ge=0, le=1023)
-
-    @model_validator(mode="after")
-    def require_correction_details(self) -> Tpx3PhotonTimingSummary:
-        if self.correction_model == "none":
-            if (
-                self.calibration_file is not None
-                or self.parameters
-                or self.high_tot_anchor is not None
-            ):
-                raise ValueError(
-                    "correction_model='none' cannot include calibration details"
-                )
-        elif (
-            self.calibration_file is None
-            or not self.parameters
-            or self.high_tot_anchor is None
-        ):
-            raise ValueError(
-                "a fitted correction requires a calibration file, parameters, "
-                "and high_tot_anchor"
-            )
-        return self
-
-
-class Tpx3PhotonParquetFilesSummary(StrictBaseModel):
-    row_count: int = Field(ge=0)
-    files: list[Path]
-
-    @model_validator(mode="after")
-    def require_files_for_saved_rows(self) -> Tpx3PhotonParquetFilesSummary:
-        if self.row_count == 0 and self.files:
-            raise ValueError("a file group with zero rows cannot list Parquet files")
-        if self.row_count > 0 and not self.files:
-            raise ValueError("a file group with saved rows must list a Parquet file")
-        return self
-
-
-class Tpx3PhotonPixelsParquetSummary(Tpx3PhotonParquetFilesSummary):
-    requested: bool
-
-    @model_validator(mode="after")
-    def require_no_unrequested_membership_files(
-        self,
-    ) -> Tpx3PhotonPixelsParquetSummary:
-        if not self.requested and (self.row_count != 0 or self.files):
-            raise ValueError(
-                "unrequested photon_pixels must have zero rows and no files"
-            )
-        return self
-
-
-class Tpx3PhotonParquetSummary(StrictBaseModel):
-    input_pixel_data_files: list[Path] = Field(min_length=1)
-    photon_events: Tpx3PhotonParquetFilesSummary
-    photon_pixels: Tpx3PhotonPixelsParquetSummary
-
-    @model_validator(mode="after")
-    def require_relative_category_paths(self) -> Tpx3PhotonParquetSummary:
-        for input_path in self.input_pixel_data_files:
-            if (
-                input_path.is_absolute()
-                or ".." in input_path.parts
-                or len(input_path.parts) != 2
-                or input_path.parts[0] != "pixelHits"
-            ):
-                raise ValueError(
-                    "input pixel_data paths must be relative and begin with "
-                    "pixelHits/"
-                )
-
-        file_groups = (
-            ("photon-events", self.photon_events.files),
-            ("photon-pixels", self.photon_pixels.files),
-        )
-        for filename_marker, files in file_groups:
-            for file_path in files:
-                if (
-                    file_path.is_absolute()
-                    or ".." in file_path.parts
-                    or len(file_path.parts) != 2
-                    or file_path.parts[0] != "photons"
-                    or filename_marker not in file_path.name
-                    or file_path.suffix != ".parquet"
-                ):
-                    raise ValueError(
-                        f"{filename_marker} paths must be relative Parquet "
-                        "paths beginning with photons/"
-                    )
-        return self
-
-
 class Tpx3PhotonThroughputSummary(StrictBaseModel):
     pixels_per_second: float = Field(ge=0)
     photons_per_second: float = Field(ge=0)
@@ -464,36 +290,117 @@ class Tpx3PhotonProcessingTimesSummary(StrictBaseModel):
 class Tpx3PhotonReconstructionSummary(StrictBaseModel):
     schema_version: Literal[1] = 1
     reconstruction: Tpx3PhotonReconstructionCountsSummary
-    clustering: Tpx3PhotonClusteringSummary
-    photon_timing: Tpx3PhotonTimingSummary
-    parquet: Tpx3PhotonParquetSummary
     processing_times_seconds: Tpx3PhotonProcessingTimesSummary
 
+
+# ---------------------------------------------------------------------------
+# Per-file results
+# ---------------------------------------------------------------------------
+
+
+class HermesTpx3UnpackingResult(StrictBaseModel):
+    input_file: FileReference
+    status: HermesTpx3RunStatus = "planned"
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+class HermesTpx3ReconstructionResult(StrictBaseModel):
+    input_file: FileReference
+    output_file: Path
+    status: HermesTpx3RunStatus = "planned"
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    counts: Tpx3PhotonReconstructionCountsSummary | None = None
+
+
+# ---------------------------------------------------------------------------
+# Stage containers
+# ---------------------------------------------------------------------------
+
+
+class Tpx3UnpackingRuntimeOptions(StrictBaseModel):
+    overwrite: bool = False
+    time_sort: bool = True
+
+
+class Tpx3Unpacking(StrictBaseModel):
+    program: BinaryProgram
+    tpx3_files: list[FileReference] = Field(min_length=1)
+    output_directory: Path | None = None
+    runtime_options: Tpx3UnpackingRuntimeOptions = Field(
+        default_factory=Tpx3UnpackingRuntimeOptions
+    )
+    results: list[HermesTpx3UnpackingResult] = Field(default_factory=list)
+
+    @field_validator("tpx3_files", mode="before")
+    @classmethod
+    def expand_tpx3_file_list(cls, value: object) -> object:
+        return _expand_file_list(value)
+
     @model_validator(mode="after")
-    def require_matching_settings_and_counts(
-        self,
-    ) -> Tpx3PhotonReconstructionSummary:
-        settings = self.clustering.settings
-        if settings.photon_time_estimator != self.photon_timing.estimator:
+    def require_unique_stems(self) -> Tpx3Unpacking:
+        stems = [raw_file.path.stem for raw_file in self.tpx3_files]
+        duplicate_stems = sorted(
+            stem for stem in set(stems) if stems.count(stem) > 1
+        )
+        if duplicate_stems:
             raise ValueError(
-                "photon timing estimator must match the clustering settings"
+                "raw TPX3 filename stems must be unique: "
+                + ", ".join(duplicate_stems)
             )
-        if settings.save_photon_pixels != self.parquet.photon_pixels.requested:
+        return self
+
+
+class Tpx3PhotonReconstructionRuntimeOptions(StrictBaseModel):
+    overwrite: bool = False
+
+
+class Tpx3PhotonReconstruction(StrictBaseModel):
+    program: BinaryProgram
+    # "auto" gathers pixel files from the unpacking stage's output; a list names
+    # specific pixelHits Parquet files to reconstruct.
+    pixel_parquet_files: Literal["auto"] | list[FileReference] = "auto"
+    output_directory: Path | None = None
+    clustering_algorithm: ClusteringAlgorithm = "connected_components"
+    settings: Tpx3PhotonClusteringSettings
+    runtime_options: Tpx3PhotonReconstructionRuntimeOptions = Field(
+        default_factory=Tpx3PhotonReconstructionRuntimeOptions
+    )
+    results: list[HermesTpx3ReconstructionResult] = Field(default_factory=list)
+
+    @field_validator("pixel_parquet_files", mode="before")
+    @classmethod
+    def expand_pixel_file_list(cls, value: object) -> object:
+        return _expand_file_list(value)
+
+    @field_validator("pixel_parquet_files", mode="after")
+    @classmethod
+    def require_non_empty_file_list(cls, value: object) -> object:
+        if isinstance(value, list) and not value:
             raise ValueError(
-                "photon_pixels requested value must match save_photon_pixels"
+                "pixel_parquet_files must be 'auto' or a non-empty file list"
             )
-        if (
-            settings.timewalk_calibration_file
-            != self.photon_timing.calibration_file
-        ):
-            raise ValueError(
-                "photon timing calibration file must match clustering settings"
-            )
-        if (
-            self.reconstruction.photon_count
-            != self.parquet.photon_events.row_count
-        ):
-            raise ValueError(
-                "photon_events row_count must match reconstruction photon_count"
-            )
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Analysis state
+# ---------------------------------------------------------------------------
+
+
+class HermesTpx3AnalysisState(StrictBaseModel):
+    mode: Literal["hermes"] = "hermes"
+    analysis_directory: Path
+    resource_limit_percent: int = Field(default=90, ge=1, le=100)
+    unpacking: Tpx3Unpacking
+    photon_reconstruction: Tpx3PhotonReconstruction | None = None
+
+    @model_validator(mode="after")
+    def derive_output_directories(self) -> HermesTpx3AnalysisState:
+        if self.unpacking.output_directory is None:
+            self.unpacking.output_directory = self.analysis_directory
+        reconstruction = self.photon_reconstruction
+        if reconstruction is not None and reconstruction.output_directory is None:
+            reconstruction.output_directory = self.analysis_directory / "photons"
         return self

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -12,7 +12,9 @@ from hermes.state.models.shared_models import (
     StrictBaseModel,
 )
 
-HermesTpx3RunStatus = Literal["planned", "running", "completed", "failed"]
+HermesTpx3RunStatus = Literal[
+    "planned", "running", "completed", "skipped", "failed"
+]
 SortingStrategy = Literal["in_memory", "external_merge"]
 ClusteringAlgorithm = Literal["connected_components", "dbscan"]
 PhotonTimeEstimator = Literal[

--- a/src/hermes/state/models/shared_models.py
+++ b/src/hermes/state/models/shared_models.py
@@ -30,7 +30,10 @@ class FileReference(StrictBaseModel):
 
     path: Path
     media_type: str | None = Field(default=None, min_length=1)
-    sha256: str | None = Field(default=None, pattern=r"^[A-Fa-f0-9]{64}$")
-    size_bytes: int | None = Field(default=None, ge=0)
     created_at: datetime | None = None
     description: str | None = None
+
+class BinaryProgram(StrictBaseModel):
+    name: str = Field(min_length=1)
+    executable_path: Path
+    version: str | None = None

--- a/tests/unit/examples/analysis/test_timewalk_calibration_example.py
+++ b/tests/unit/examples/analysis/test_timewalk_calibration_example.py
@@ -43,7 +43,7 @@ def test_checked_in_yaml_configures_unpacking_and_clustering(
     assert initial_record.analysis.analysis_directory == Path(
         "data/examples/analysis/timewalk_calibration/analysis"
     )
-    assert initial_record.analysis.tpx3_files == [
+    assert initial_record.analysis.unpacking.tpx3_files == [
         FileReference(path=Path("tests/data/Example_1kHz_5frames.tpx3"))
     ]
     assert initial_record.analysis.photon_reconstruction is None
@@ -89,12 +89,13 @@ environment:
   working_dir: {working_directory}
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: {unpacker_executable}
   analysis_directory: {analysis_directory}
-  tpx3_files:
-    - path: {raw_tpx3_file}
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: {unpacker_executable}
+    tpx3_files:
+      - path: {raw_tpx3_file}
 """,
         encoding="utf-8",
     )
@@ -109,7 +110,7 @@ analysis:
         def run_analysis(self) -> list[FileReference]:
             analysis = self.record.analysis
             assert isinstance(analysis, HermesTpx3AnalysisState)
-            return analysis.tpx3_files
+            return analysis.unpacking.tpx3_files
 
     calibration_calls: list[dict[str, object]] = []
 

--- a/tests/unit/examples/analysis/test_two_stage.py
+++ b/tests/unit/examples/analysis/test_two_stage.py
@@ -7,10 +7,12 @@ from types import ModuleType
 import pytest
 
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
-    HermesTpx3AnalysisResults,
     HermesTpx3AnalysisState,
     HermesTpx3ReconstructionResult,
     HermesTpx3UnpackingResult,
+    Tpx3PhotonQualityFlagCountsSummary,
+    Tpx3PhotonRejectionCountsSummary,
+    Tpx3PhotonReconstructionCountsSummary,
 )
 from hermes.state.models.shared_models import FileReference
 from hermes.state.state import HermesRecord
@@ -42,14 +44,14 @@ def test_checked_in_yaml_configures_both_analysis_stages(
     assert isinstance(initial_record.analysis, HermesTpx3AnalysisState)
 
     analysis = initial_record.analysis
-    assert analysis.unpacker_program.name == "tpx3-spidr-cpp"
-    assert analysis.unpacker_program.executable_path == Path(
+    assert analysis.unpacking.program.name == "tpx3-spidr-cpp"
+    assert analysis.unpacking.program.executable_path == Path(
         "build/backends/tpx3-spidr/hermes-tpx3-spidr"
     )
     assert analysis.analysis_directory == Path(
         "data/examples/analysis/two_stage/analysis"
     )
-    assert analysis.tpx3_files == [
+    assert analysis.unpacking.tpx3_files == [
         FileReference(path=Path("tests/data/Example_1kHz_5frames.tpx3"))
     ]
 
@@ -60,10 +62,8 @@ def test_checked_in_yaml_configures_both_analysis_stages(
         "build/backends/photon-clusterer/hermes-photon-clusterer"
     )
     assert reconstruction.clustering_algorithm == "connected_components"
-    assert reconstruction.pixel_data_directory == (
-        analysis.analysis_directory / "pixelHits"
-    )
-    assert reconstruction.photon_output_directory == (
+    assert reconstruction.pixel_parquet_files == "auto"
+    assert reconstruction.output_directory == (
         analysis.analysis_directory / "photons"
     )
     assert reconstruction.settings.timewalk_calibration_file == Path(
@@ -95,19 +95,19 @@ environment:
   working_dir: {working_directory}
 analysis:
   mode: hermes
-  unpacker_program:
-    name: test-unpacker
-    executable_path: {tmp_path / "test-unpacker"}
   analysis_directory: {analysis_directory}
-  tpx3_files:
-    - path: {first_raw_file}
-    - path: {second_raw_file}
+  unpacking:
+    program:
+      name: test-unpacker
+      executable_path: {tmp_path / "test-unpacker"}
+    tpx3_files:
+      - path: {first_raw_file}
+      - path: {second_raw_file}
   photon_reconstruction:
     program:
       name: test-clusterer
       executable_path: {tmp_path / "test-clusterer"}
-    pixel_data_directory: {analysis_directory / "pixelHits"}
-    photon_output_directory: {photon_directory}
+    pixel_parquet_files: auto
     settings:
       max_time_spread_ticks: 100
       min_cluster_size: 2
@@ -128,16 +128,59 @@ analysis:
             received_records.append(record.model_copy(deep=True))
             analysis = record.analysis
             assert isinstance(analysis, HermesTpx3AnalysisState)
+            tpx3_files = analysis.unpacking.tpx3_files
+            counts = Tpx3PhotonReconstructionCountsSummary(
+                pixel_rows_read=10,
+                pixel_rows_below_min_tot=0,
+                components_formed=5,
+                photon_count=3,
+                rejected_component_count=2,
+                rejection_counts=Tpx3PhotonRejectionCountsSummary(
+                    below_min_cluster_size=0,
+                    above_max_cluster_size=0,
+                    below_min_cluster_tot=0,
+                    above_max_cluster_tot=0,
+                    above_max_aspect_ratio=0,
+                    below_min_filled_fraction=0,
+                ),
+                quality_flag_counts=Tpx3PhotonQualityFlagCountsSummary(
+                    saturated_pixel=0,
+                    bridged_components=0,
+                ),
+                warnings=[],
+                errors=[],
+            )
+            completed_unpacking = analysis.unpacking.model_copy(
+                update={
+                    "results": [
+                        HermesTpx3UnpackingResult(
+                            input_file=raw_file,
+                            status="completed",
+                        )
+                        for raw_file in tpx3_files
+                    ]
+                }
+            )
+            assert analysis.photon_reconstruction is not None
+            completed_reconstruction = analysis.photon_reconstruction.model_copy(
+                update={
+                    "results": [
+                        HermesTpx3ReconstructionResult(
+                            input_file=tpx3_files[0],
+                            output_file=(
+                                analysis.photon_reconstruction.output_directory
+                                / "photons.parquet"
+                            ),
+                            status="completed",
+                            counts=counts,
+                        )
+                    ]
+                }
+            )
             completed_analysis = analysis.model_copy(
                 update={
-                    "results": HermesTpx3AnalysisResults(
-                        unpacking=HermesTpx3UnpackingResult(status="completed"),
-                        reconstruction=HermesTpx3ReconstructionResult(
-                            status="completed",
-                            photon_count=3,
-                            rejected_count=2,
-                        ),
-                    )
+                    "unpacking": completed_unpacking,
+                    "photon_reconstruction": completed_reconstruction,
                 }
             )
             self.record = record.model_copy(
@@ -147,7 +190,7 @@ analysis:
         def run_analysis(self) -> list[FileReference]:
             analysis = self.record.analysis
             assert isinstance(analysis, HermesTpx3AnalysisState)
-            return analysis.tpx3_files
+            return analysis.unpacking.tpx3_files
 
     monkeypatch.setattr(run_two_stage_module, "Workflow", CompletedWorkflow)
 
@@ -162,28 +205,30 @@ analysis:
     assert len(received_records) == 1
     received_analysis = received_records[0].analysis
     assert isinstance(received_analysis, HermesTpx3AnalysisState)
-    assert [raw_file.path for raw_file in received_analysis.tpx3_files] == [
+    assert [
+        raw_file.path for raw_file in received_analysis.unpacking.tpx3_files
+    ] == [
         first_raw_file,
         second_raw_file,
     ]
     assert received_analysis.photon_reconstruction is not None
 
     assert isinstance(saved_final_record.analysis, HermesTpx3AnalysisState)
-    assert saved_final_record.analysis.results.unpacking.status == "completed"
-    assert (
-        saved_final_record.analysis.results.reconstruction is not None
-    )
-    assert (
-        saved_final_record.analysis.results.reconstruction.status
-        == "completed"
-    )
+    unpacking_results = saved_final_record.analysis.unpacking.results
+    assert [result.status for result in unpacking_results] == [
+        "completed",
+        "completed",
+    ]
+    reconstruction = saved_final_record.analysis.photon_reconstruction
+    assert reconstruction is not None
+    assert reconstruction.results[0].status == "completed"
 
     assert str(first_raw_file) in console_output
     assert str(second_raw_file) in console_output
     assert "Raw TPX3 files: 2" in console_output
     assert "Unpacked this run: 2" in console_output
     assert "Skipped existing valid unpacking output: 0" in console_output
-    assert "Photon reconstruction status: completed" in console_output
+    assert "Reconstructed photon files: 1" in console_output
     assert "Photons: 3" in console_output
     assert "Rejected clusters: 2" in console_output
     assert str(analysis_directory) in console_output

--- a/tests/unit/examples/analysis/test_unpacker_single_file.py
+++ b/tests/unit/examples/analysis/test_unpacker_single_file.py
@@ -38,25 +38,22 @@ def test_checked_in_partial_yaml_loads_with_expected_defaults(
     )
     assert initial_record.acquisition is None
     assert isinstance(initial_record.analysis, HermesTpx3AnalysisState)
-    assert initial_record.analysis.unpacker_program.executable_path == Path(
+    assert initial_record.analysis.unpacking.program.executable_path == Path(
         "build/backends/tpx3-spidr/hermes-tpx3-spidr"
     )
     assert initial_record.analysis.analysis_directory == Path(
         "data/examples/analysis/unpacking/single_file/analysis"
     )
-    assert initial_record.analysis.tpx3_files[0].path == Path(
+    assert initial_record.analysis.unpacking.tpx3_files[0].path == Path(
         "tests/data/Example_1kHz_5frames.tpx3"
     )
     assert initial_record.analysis.resource_limit_percent == 90
-    assert initial_record.analysis.unpacker_program.version is None
+    assert initial_record.analysis.unpacking.program.version is None
     assert initial_record.analysis.photon_reconstruction is None
-    assert initial_record.analysis.results.unpacking.status == "planned"
-    assert initial_record.analysis.results.reconstruction is None
+    assert initial_record.analysis.unpacking.results == []
 
-    raw_tpx3_file = initial_record.analysis.tpx3_files[0]
+    raw_tpx3_file = initial_record.analysis.unpacking.tpx3_files[0]
     assert raw_tpx3_file.media_type is None
-    assert raw_tpx3_file.sha256 is None
-    assert raw_tpx3_file.size_bytes is None
     assert raw_tpx3_file.created_at is None
     assert raw_tpx3_file.description is None
 
@@ -103,12 +100,13 @@ environment:
   working_dir: {working_directory}
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: {unpacker_executable}
   analysis_directory: {analysis_directory}
-  tpx3_files:
-    - path: {raw_tpx3_file}
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: {unpacker_executable}
+    tpx3_files:
+      - path: {raw_tpx3_file}
 """,
         encoding="utf-8",
     )
@@ -122,7 +120,7 @@ analysis:
         assert overwrite is False
         current_record = state_manager.get_state()
         assert isinstance(current_record.analysis, HermesTpx3AnalysisState)
-        return current_record.analysis.tpx3_files
+        return current_record.analysis.unpacking.tpx3_files
 
     monkeypatch.setattr(
         "hermes.workflows.workflow.run_hermes_analysis",

--- a/tests/unit/hermes/analysis/hermes/test_reconstruction.py
+++ b/tests/unit/hermes/analysis/hermes/test_reconstruction.py
@@ -8,29 +8,28 @@ import textwrap
 from pathlib import Path
 from typing import Any
 
-import pyarrow as pa
-import pyarrow.parquet as pq
 import pytest
 
 from hermes.analysis.hermes.reconstruction import (
     HermesReconstructionExecutionError,
+    HermesReconstructionOutputError,
     HermesReconstructionPreflightError,
+    derive_output_path,
     derive_reconstruction_command,
     derive_summary_path,
     execute_reconstruction,
     plan_reconstruction,
 )
+from hermes.analysis.hermes.run import run_hermes_analysis
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
-    PhotonReconstructorProgram,
     Tpx3PhotonClusteringSettings,
-    Tpx3PhotonReconstructionConfiguration,
-    Tpx3SpidrUnpackerProgram,
+    Tpx3PhotonReconstruction,
+    Tpx3Unpacking,
 )
-from hermes.analysis.hermes.run import run_hermes_analysis
 from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import BinaryProgram, FileReference
 from hermes.state.state import HermesRecord
 from hermes.state_service.shared_types import StateServiceConfig
 from hermes.state_service.state_manager import StateManager
@@ -53,7 +52,7 @@ def _settings(**overrides: Any) -> Tpx3PhotonClusteringSettings:
 
 def _analysis(
     tmp_path: Path,
-    *raw_names: str,
+    *pixel_names: str,
     settings: Tpx3PhotonClusteringSettings | None = None,
     clustering_algorithm: str = "connected_components",
     with_reconstruction: bool = True,
@@ -65,83 +64,52 @@ def _analysis(
     clusterer_exe = tmp_path / "bin/hermes-photon-clusterer"
     clusterer_exe.touch()
 
-    raw_files: list[FileReference] = []
-    for raw_name in raw_names:
-        raw_path = tmp_path / "rawTpx3" / raw_name
-        raw_path.parent.mkdir(parents=True, exist_ok=True)
-        raw_path.touch()
-        raw_files.append(FileReference(path=raw_path))
-
     analysis_directory = tmp_path / "analysis"
+
+    # A raw TPX3 file is required to build the unpacking stage; the
+    # reconstruction stage reads pixel Parquet files it creates below.
+    raw_path = tmp_path / "rawTpx3" / "run_000000.tpx3"
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    raw_path.touch()
+
+    # Pixel Parquet inputs for reconstruction live under pixelHits/.
+    pixel_directory = analysis_directory / "pixelHits"
+    for pixel_name in pixel_names:
+        pixel_path = pixel_directory / pixel_name
+        pixel_path.parent.mkdir(parents=True, exist_ok=True)
+        pixel_path.touch()
+
     reconstruction = None
     if with_reconstruction:
-        reconstruction = Tpx3PhotonReconstructionConfiguration(
-            program=PhotonReconstructorProgram(
+        reconstruction = Tpx3PhotonReconstruction(
+            program=BinaryProgram(
                 name="photon-clusterer-cpp",
                 executable_path=clusterer_exe,
                 version="0.1.0",
             ),
-            pixel_data_directory=analysis_directory / "pixelHits",
-            photon_output_directory=analysis_directory / "photons",
             settings=settings or _settings(),
             clustering_algorithm=clustering_algorithm,
         )
 
     return HermesTpx3AnalysisState(
-        unpacker_program=Tpx3SpidrUnpackerProgram(
-            name="tpx3-spidr-cpp",
-            executable_path=unpacker_exe,
-            version="0.1.0",
-        ),
         analysis_directory=analysis_directory,
-        tpx3_files=raw_files,
+        unpacking=Tpx3Unpacking(
+            program=BinaryProgram(
+                name="tpx3-spidr-cpp",
+                executable_path=unpacker_exe,
+                version="0.1.0",
+            ),
+            tpx3_files=[FileReference(path=raw_path)],
+        ),
         photon_reconstruction=reconstruction,
     )
 
 
 def _summary_dict(
-    raw_stem: str,
     *,
     photon_count: int = 3,
     rejected: int = 1,
-    save_photon_pixels: bool = False,
-    corrected: bool = False,
 ) -> dict[str, Any]:
-    events_files = [
-        f"photons/{raw_stem}-chip-0-photon-events-part-00000.parquet"
-    ]
-    if save_photon_pixels:
-        pixels = {
-            "requested": True,
-            "row_count": 7,
-            "files": [
-                f"photons/{raw_stem}-chip-0-photon-pixels-part-00000.parquet"
-            ],
-        }
-    else:
-        pixels = {"requested": False, "row_count": 0, "files": []}
-
-    if corrected:
-        timing = {
-            "estimator": "leading_edge",
-            "correction_model": "inverse",
-            "calibration_file": "calibrations/tpx3/time-walk_example.json",
-            "parameters": {"a": 1254855.58, "b": 10.6986},
-            "high_tot_anchor": 23.0,
-        }
-        calibration_file: str | None = (
-            "calibrations/tpx3/time-walk_example.json"
-        )
-    else:
-        timing = {
-            "estimator": "leading_edge",
-            "correction_model": "none",
-            "calibration_file": None,
-            "parameters": {},
-            "high_tot_anchor": None,
-        }
-        calibration_file = None
-
     return {
         "schema_version": 1,
         "reconstruction": {
@@ -165,35 +133,6 @@ def _summary_dict(
             "warnings": [],
             "errors": [],
         },
-        "clustering": {
-            "algorithm": "connected_components",
-            "settings": {
-                "max_time_spread_ticks": 491520,
-                "min_cluster_size": 2,
-                "max_cluster_size": 64,
-                "min_pixel_tot_raw": 1,
-                "min_cluster_tot_raw": 2,
-                "max_cluster_tot_raw": 65472,
-                "max_aspect_ratio": 3.0,
-                "min_filled_fraction": 0.5,
-                "adjacency": 8,
-                "position_averaging": "arithmetic",
-                "photon_time_estimator": "leading_edge",
-                "timewalk_calibration_file": calibration_file,
-                "save_photon_pixels": save_photon_pixels,
-            },
-        },
-        "photon_timing": timing,
-        "parquet": {
-            "input_pixel_data_files": [
-                f"pixelHits/{raw_stem}-chip-0-part-00000.parquet"
-            ],
-            "photon_events": {
-                "row_count": photon_count,
-                "files": events_files,
-            },
-            "photon_pixels": pixels,
-        },
         "processing_times_seconds": {
             "parquet_reading": 0.1,
             "clustering_and_filtering": 0.2,
@@ -207,36 +146,6 @@ def _summary_dict(
     }
 
 
-def _save_completed_files(
-    analysis: HermesTpx3AnalysisState,
-    raw_file: FileReference,
-    *,
-    photon_count: int = 3,
-    save_photon_pixels: bool = False,
-) -> None:
-    stem = raw_file.path.stem
-    summary = _summary_dict(
-        stem,
-        photon_count=photon_count,
-        save_photon_pixels=save_photon_pixels,
-    )
-    photons_dir = analysis.analysis_directory / "photons"
-    photons_dir.mkdir(parents=True, exist_ok=True)
-    # photon_events file with a matching row count.
-    pq.write_table(
-        pa.table({"photon_id": list(range(photon_count))}),
-        photons_dir / f"{stem}-chip-0-photon-events-part-00000.parquet",
-    )
-    if save_photon_pixels:
-        pq.write_table(
-            pa.table({"photon_id": [0]}),
-            photons_dir / f"{stem}-chip-0-photon-pixels-part-00000.parquet",
-        )
-    summary_path = derive_summary_path(analysis, raw_file)
-    summary_path.parent.mkdir(parents=True, exist_ok=True)
-    summary_path.write_text(json.dumps(summary), encoding="utf-8")
-
-
 def _write_fake_clusterer(
     executable: Path,
     *,
@@ -244,18 +153,14 @@ def _write_fake_clusterer(
     exit_code: int = 0,
     write_summary: bool = True,
 ) -> None:
-    summary_literal = json.dumps(
-        _summary_dict("PLACEHOLDER", photon_count=photon_count)
-    )
+    """Write a fake clusterer that creates the photon file and sidecar summary."""
+    summary_literal = json.dumps(_summary_dict(photon_count=photon_count))
     script = textwrap.dedent(
         f"""\
         #!{sys.executable}
         import json
         import sys
         from pathlib import Path
-
-        import pyarrow as pa
-        import pyarrow.parquet as pq
 
         args = sys.argv[1:]
         values = {{}}
@@ -269,37 +174,21 @@ def _write_fake_clusterer(
             values[flag] = args[i + 1]
             i += 2
 
-        # --output is where files go; --input holds pixelHits/ (same dir here).
-        analysis_dir = Path(values["--output"])
-        stem = values["--base-file-name"]
-        # settings arrive via --settings <file>; read to prove it is passed.
-        settings = json.loads(Path(values["--settings"]).read_text())
+        output_file = Path(values["--output"])
+        # Prove the settings file is passed and readable.
+        json.loads(Path(values["--settings"]).read_text())
 
-        exit_code = {exit_code}
         write_summary = {write_summary}
-        photon_count = {photon_count}
-
         if write_summary:
-            photons = analysis_dir / "photons"
-            photons.mkdir(parents=True, exist_ok=True)
-            pq.write_table(
-                pa.table({{"photon_id": list(range(photon_count))}}),
-                photons / (stem + "-chip-0-photon-events-part-00000.parquet"),
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_bytes(b"")
+            summary_path = (
+                output_file.parent
+                / (output_file.stem + "-reconstruction-summary.json")
             )
-            summary = json.loads({summary_literal!r})
-            summary["parquet"]["input_pixel_data_files"] = [
-                "pixelHits/" + stem + "-chip-0-part-00000.parquet"
-            ]
-            summary["parquet"]["photon_events"]["files"] = [
-                "photons/" + stem + "-chip-0-photon-events-part-00000.parquet"
-            ]
-            logs = analysis_dir / "logs"
-            logs.mkdir(parents=True, exist_ok=True)
-            (logs / (stem + "-reconstruction-summary.json")).write_text(
-                json.dumps(summary)
-            )
+            summary_path.write_text({summary_literal!r})
 
-        sys.exit(exit_code)
+        sys.exit({exit_code})
         """
     )
     executable.write_text(script, encoding="utf-8")
@@ -310,53 +199,55 @@ def _write_fake_clusterer(
 
 
 def test_plan_runs_when_no_output_exists(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     plan = plan_reconstruction(analysis)
     assert [action for _, action in plan] == ["run"]
 
 
-def test_plan_skips_when_valid_summary_exists(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
-    _save_completed_files(analysis, analysis.tpx3_files[0])
+def test_plan_skips_when_output_exists(tmp_path: Path) -> None:
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    reconstruction = analysis.photon_reconstruction
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
+    output_file = derive_output_path(reconstruction, input_file)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.touch()
+
     plan = plan_reconstruction(analysis)
     assert [action for _, action in plan] == ["skip"]
 
 
-def test_plan_rejects_summary_with_mismatched_settings(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
-    _save_completed_files(analysis, analysis.tpx3_files[0])
-
-    requested = _analysis(
-        tmp_path,
-        "run_000000.tpx3",
-        settings=_settings(save_photon_pixels=True),
+def test_plan_runs_all_when_overwrite(tmp_path: Path) -> None:
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    reconstruction = analysis.photon_reconstruction
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
     )
+    output_file = derive_output_path(reconstruction, input_file)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.touch()
 
-    with pytest.raises(HermesReconstructionPreflightError, match="settings"):
-        plan_reconstruction(requested)
-
-def test_plan_rejects_orphan_photon_files(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
-    photons_dir = analysis.analysis_directory / "photons"
-    photons_dir.mkdir(parents=True, exist_ok=True)
-    pq.write_table(
-        pa.table({"photon_id": [0]}),
-        photons_dir / "run_000000-chip-0-photon-events-part-00000.parquet",
-    )
-    with pytest.raises(HermesReconstructionPreflightError, match="without a valid"):
-        plan_reconstruction(analysis)
+    plan = plan_reconstruction(analysis, overwrite=True)
+    assert [action for _, action in plan] == ["run"]
 
 
 def test_plan_rejects_dbscan(tmp_path: Path) -> None:
     analysis = _analysis(
-        tmp_path, "run_000000.tpx3", clustering_algorithm="dbscan"
+        tmp_path,
+        "run_000000-chip-0-part-00000.parquet",
+        clustering_algorithm="dbscan",
     )
     with pytest.raises(HermesReconstructionPreflightError, match="not implemented"):
         plan_reconstruction(analysis)
 
 
 def test_plan_rejects_missing_executable(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     analysis.photon_reconstruction.program.executable_path.unlink()
     with pytest.raises(
         HermesReconstructionPreflightError, match="executable does not exist"
@@ -366,7 +257,9 @@ def test_plan_rejects_missing_executable(tmp_path: Path) -> None:
 
 def test_plan_requires_reconstruction_config(tmp_path: Path) -> None:
     analysis = _analysis(
-        tmp_path, "run_000000.tpx3", with_reconstruction=False
+        tmp_path,
+        "run_000000-chip-0-part-00000.parquet",
+        with_reconstruction=False,
     )
     with pytest.raises(
         HermesReconstructionPreflightError, match="not configured"
@@ -374,58 +267,29 @@ def test_plan_requires_reconstruction_config(tmp_path: Path) -> None:
         plan_reconstruction(analysis)
 
 
-def test_plan_skips_when_pixels_requested_and_present(tmp_path: Path) -> None:
-    analysis = _analysis(
-        tmp_path,
-        "run_000000.tpx3",
-        settings=_settings(save_photon_pixels=True),
-    )
-    _save_completed_files(
-        analysis, analysis.tpx3_files[0], save_photon_pixels=True
-    )
-    plan = plan_reconstruction(analysis)
-    assert [action for _, action in plan] == ["skip"]
-
-
-def test_plan_rejects_summary_requesting_missing_pixels(tmp_path: Path) -> None:
-    # The summary records photon_pixels output, but the pixels file is absent.
-    analysis = _analysis(
-        tmp_path,
-        "run_000000.tpx3",
-        settings=_settings(save_photon_pixels=True),
-    )
-    _save_completed_files(
-        analysis, analysis.tpx3_files[0], save_photon_pixels=True
-    )
-    stem = analysis.tpx3_files[0].path.stem
-    (
-        analysis.analysis_directory
-        / "photons"
-        / f"{stem}-chip-0-photon-pixels-part-00000.parquet"
-    ).unlink()
-    with pytest.raises(HermesReconstructionPreflightError):
-        plan_reconstruction(analysis)
-
-
 # ---- derive_reconstruction_command --------------------------------------
 
 
 def test_command_passes_named_flags_and_settings(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     reconstruction = analysis.photon_reconstruction
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
+    output_file = derive_output_path(reconstruction, input_file)
     command = derive_reconstruction_command(
         reconstruction,
-        analysis.analysis_directory,
-        "run_000000",
+        input_file,
+        output_file,
         tmp_path / "settings.json",
     )
     assert command[1:] == [
         "--input",
-        str(analysis.analysis_directory),
-        "--base-file-name",
-        "run_000000",
+        str(input_file.path),
         "--output",
-        str(analysis.analysis_directory),
+        str(output_file),
         "--settings",
         str(tmp_path / "settings.json"),
     ]
@@ -433,11 +297,17 @@ def test_command_passes_named_flags_and_settings(tmp_path: Path) -> None:
 
 
 def test_command_appends_overwrite_when_requested(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    reconstruction = analysis.photon_reconstruction
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
     command = derive_reconstruction_command(
-        analysis.photon_reconstruction,
-        analysis.analysis_directory,
-        "run_000000",
+        reconstruction,
+        input_file,
+        derive_output_path(reconstruction, input_file),
         tmp_path / "settings.json",
         overwrite=True,
     )
@@ -448,44 +318,70 @@ def test_command_appends_overwrite_when_requested(tmp_path: Path) -> None:
 
 
 def test_execute_success_returns_summary(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     _write_fake_clusterer(
         analysis.photon_reconstruction.program.executable_path,
         photon_count=5,
     )
-    summary = execute_reconstruction(analysis, analysis.tpx3_files[0])
-    assert summary.reconstruction.photon_count == 5
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
+    result = execute_reconstruction(analysis, input_file)
+    assert result.status == "completed"
+    assert result.counts is not None
+    assert result.counts.photon_count == 5
 
 
 def test_execute_removes_temp_settings_file(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     _write_fake_clusterer(analysis.photon_reconstruction.program.executable_path)
-    execute_reconstruction(analysis, analysis.tpx3_files[0])
-    leftover = list(Path(tempfile.gettempdir()).glob(
-        "run_000000-clustering-settings-*.json"
-    ))
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
+    execute_reconstruction(analysis, input_file)
+    leftover = list(
+        Path(tempfile.gettempdir()).glob(
+            "run_000000-chip-0-part-00000-clustering-settings-*.json"
+        )
+    )
     assert leftover == []
 
 
 def test_execute_raises_on_nonzero_exit(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     _write_fake_clusterer(
         analysis.photon_reconstruction.program.executable_path,
         exit_code=1,
         write_summary=False,
     )
-    with pytest.raises(HermesReconstructionExecutionError, match="exited with code"):
-        execute_reconstruction(analysis, analysis.tpx3_files[0])
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
+    with pytest.raises(
+        HermesReconstructionExecutionError, match="exited with code"
+    ):
+        execute_reconstruction(analysis, input_file)
 
 
 def test_execute_raises_on_missing_summary(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     _write_fake_clusterer(
         analysis.photon_reconstruction.program.executable_path,
         write_summary=False,
     )
-    with pytest.raises(HermesReconstructionPreflightError):
-        execute_reconstruction(analysis, analysis.tpx3_files[0])
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
+    with pytest.raises(HermesReconstructionOutputError):
+        execute_reconstruction(analysis, input_file)
 
 
 # ---- status flow through run_hermes_analysis ----------------------------
@@ -586,8 +482,8 @@ def _manager(analysis: HermesTpx3AnalysisState, tmp_path: Path) -> StateManager:
 
 
 def test_run_hermes_analysis_completes_reconstruction(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
+    analysis = _analysis(tmp_path)
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
     _write_fake_clusterer(
         analysis.photon_reconstruction.program.executable_path,
         photon_count=4,
@@ -596,18 +492,19 @@ def test_run_hermes_analysis_completes_reconstruction(tmp_path: Path) -> None:
 
     run_hermes_analysis(manager)
 
-    results = manager.get_state().analysis.results
-    assert results.unpacking.status == "completed"
-    assert results.reconstruction is not None
-    assert results.reconstruction.status == "completed"
-    assert results.reconstruction.started_at is not None
-    assert results.reconstruction.completed_at is not None
-    assert results.reconstruction.photon_count == 4
+    result_analysis = manager.get_state().analysis
+    assert result_analysis.unpacking.results[0].status == "completed"
+    reconstruction_results = result_analysis.photon_reconstruction.results
+    assert len(reconstruction_results) == 1
+    assert reconstruction_results[0].status == "completed"
+    assert reconstruction_results[0].started_at is not None
+    assert reconstruction_results[0].completed_at is not None
+    assert reconstruction_results[0].counts.photon_count == 4
 
 
 def test_run_hermes_analysis_marks_reconstruction_failed(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
+    analysis = _analysis(tmp_path)
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
     _write_fake_clusterer(
         analysis.photon_reconstruction.program.executable_path,
         exit_code=1,
@@ -618,24 +515,22 @@ def test_run_hermes_analysis_marks_reconstruction_failed(tmp_path: Path) -> None
     with pytest.raises(HermesReconstructionExecutionError):
         run_hermes_analysis(manager)
 
-    results = manager.get_state().analysis.results
-    assert results.unpacking.status == "completed"
-    assert results.reconstruction is not None
-    assert results.reconstruction.status == "failed"
-    assert results.reconstruction.errors
+    result_analysis = manager.get_state().analysis
+    assert result_analysis.unpacking.results[0].status == "completed"
+    reconstruction_results = result_analysis.photon_reconstruction.results
+    assert reconstruction_results
+    assert reconstruction_results[0].status == "failed"
 
 
 def test_run_hermes_analysis_without_reconstruction_leaves_result_none(
     tmp_path: Path,
 ) -> None:
-    analysis = _analysis(
-        tmp_path, "run_000000.tpx3", with_reconstruction=False
-    )
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
+    analysis = _analysis(tmp_path, with_reconstruction=False)
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
     manager = _manager(analysis, tmp_path)
 
     run_hermes_analysis(manager)
 
-    results = manager.get_state().analysis.results
-    assert results.unpacking.status == "completed"
-    assert results.reconstruction is None
+    result_analysis = manager.get_state().analysis
+    assert result_analysis.unpacking.results[0].status == "completed"
+    assert result_analysis.photon_reconstruction is None

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -490,9 +490,9 @@ def test_run_with_only_completed_files_does_not_mark_running(
     assert run_hermes_analysis(manager) == []
     results = manager.get_state().analysis.unpacking.results
     assert len(results) == 1
-    assert results[0].status == "completed"
-    assert results[0].started_at is not None
-    assert results[0].completed_at is not None
+    assert results[0].status == "skipped"
+    assert results[0].started_at is None
+    assert results[0].completed_at is None
 
 
 def test_run_rejects_empir_analysis(tmp_path: Path) -> None:

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -24,11 +23,11 @@ from hermes.state.models.analysis.empir import EmpirAnalysisState
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
     Tpx3SpidrSummary,
-    Tpx3SpidrUnpackerProgram,
+    Tpx3Unpacking,
 )
 from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import BinaryProgram, FileReference
 from hermes.state.state import HermesRecord
 from hermes.state_service.change_requests import ChangeRequest
 from hermes.state_service.shared_types import (
@@ -73,13 +72,15 @@ def _analysis(tmp_path: Path, *raw_names: str) -> HermesTpx3AnalysisState:
         raw_files.append(FileReference(path=raw_path))
 
     return HermesTpx3AnalysisState(
-        unpacker_program=Tpx3SpidrUnpackerProgram(
-            name="tpx3-spidr-cpp",
-            executable_path=executable,
-            version="0.1.0",
-        ),
         analysis_directory=tmp_path / "analysis",
-        tpx3_files=raw_files,
+        unpacking=Tpx3Unpacking(
+            program=BinaryProgram(
+                name="tpx3-spidr-cpp",
+                executable_path=executable,
+                version="0.1.0",
+            ),
+            tpx3_files=raw_files,
+        ),
     )
 
 
@@ -322,18 +323,36 @@ def _write_fake_unpacker(executable: Path) -> None:
 
 def test_derives_command_and_input_specific_summary_path(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "first.tpx3")
-    raw_file = analysis.tpx3_files[0]
+    raw_file = analysis.unpacking.tpx3_files[0]
 
     assert derive_unpacker_command(analysis, raw_file) == [
-        str(analysis.unpacker_program.executable_path),
+        str(analysis.unpacking.program.executable_path),
         "--input",
         str(raw_file.path),
         "--output",
-        str(analysis.analysis_directory),
+        str(analysis.unpacking.output_directory),
     ]
     assert derive_summary_path(analysis, raw_file) == (
         analysis.analysis_directory / "logs/first-unpacker-summary.json"
     )
+
+
+def test_command_includes_time_sort_false_when_time_sort_disabled(
+    tmp_path: Path,
+) -> None:
+    analysis = _analysis(tmp_path, "first.tpx3")
+    analysis.unpacking.runtime_options.time_sort = False
+    raw_file = analysis.unpacking.tpx3_files[0]
+
+    assert derive_unpacker_command(analysis, raw_file) == [
+        str(analysis.unpacking.program.executable_path),
+        "--input",
+        str(raw_file.path),
+        "--output",
+        str(analysis.unpacking.output_directory),
+        "--time-sort",
+        "false",
+    ]
 
 
 def test_plan_preserves_multiple_raw_file_order(tmp_path: Path) -> None:
@@ -349,7 +368,7 @@ def test_plan_preserves_multiple_raw_file_order(tmp_path: Path) -> None:
 
 def test_plan_skips_valid_completed_files(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "completed.tpx3")
-    raw_file = analysis.tpx3_files[0]
+    raw_file = analysis.unpacking.tpx3_files[0]
     _save_completed_files(analysis, raw_file, pixel_rows=1)
 
     assert plan_unpacking(analysis) == [(raw_file, "skip")]
@@ -362,9 +381,9 @@ def test_plan_rejects_missing_required_files(
 ) -> None:
     analysis = _analysis(tmp_path, "missing.tpx3")
     path = (
-        analysis.unpacker_program.executable_path
+        analysis.unpacking.program.executable_path
         if missing_file == "executable"
-        else analysis.tpx3_files[0].path
+        else analysis.unpacking.tpx3_files[0].path
     )
     path.unlink()
 
@@ -379,7 +398,7 @@ def test_plan_rejects_invalid_or_partial_existing_output(
 ) -> None:
     analysis = _analysis(tmp_path, "broken.tpx3")
     if invalid_existing_output == "invalid_summary":
-        summary_path = derive_summary_path(analysis, analysis.tpx3_files[0])
+        summary_path = derive_summary_path(analysis, analysis.unpacking.tpx3_files[0])
         summary_path.parent.mkdir(parents=True)
         summary_path.write_text("not JSON", encoding="utf-8")
     else:
@@ -396,7 +415,7 @@ def test_plan_rejects_invalid_or_partial_existing_output(
 
 def test_plan_rejects_summary_with_missing_parquet_file(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "incomplete.tpx3")
-    raw_file = analysis.tpx3_files[0]
+    raw_file = analysis.unpacking.tpx3_files[0]
     summary_path = derive_summary_path(analysis, raw_file)
     summary_path.parent.mkdir(parents=True)
     summary_path.write_text(
@@ -413,17 +432,12 @@ def test_plan_rejects_duplicate_raw_filename_stems(tmp_path: Path) -> None:
     duplicate = tmp_path / "other/first.tpx3"
     duplicate.parent.mkdir()
     duplicate.touch()
-    analysis = analysis.model_copy(
-        update={
-            "tpx3_files": [
-                analysis.tpx3_files[0],
-                FileReference(path=duplicate),
-            ]
-        }
-    )
 
-    with pytest.raises(HermesTpx3PreflightError, match="stems must be unique"):
-        plan_unpacking(analysis)
+    with pytest.raises(ValueError, match="stems must be unique"):
+        analysis.unpacking.tpx3_files = [
+            analysis.unpacking.tpx3_files[0],
+            FileReference(path=duplicate),
+        ]
 
 
 def test_run_marks_analysis_only_state_running_through_state_manager(
@@ -448,11 +462,15 @@ def test_run_marks_analysis_only_state_running_through_state_manager(
         "first.tpx3",
         "second.tpx3",
     ]
-    result = manager.get_state().analysis.results.unpacking
-    assert result.status == "completed"
-    assert result.started_at is not None
-    assert result.completed_at is not None
-    assert state_logger.changes[-1].path == "analysis.results"
+    results = manager.get_state().analysis.unpacking.results
+    assert [result.input_file.path.name for result in results] == [
+        "first.tpx3",
+        "second.tpx3",
+    ]
+    assert all(result.status == "completed" for result in results)
+    assert all(result.started_at is not None for result in results)
+    assert all(result.completed_at is not None for result in results)
+    assert state_logger.changes[-1].path == "analysis.unpacking.results"
     assert state_logger.changes[-1].origin == "trusted_workflow"
     assert state_logger.changes[-1].proposer == "tpx3_spidr_unpacking"
     assert state_logger.changes[-1].status == "applied"
@@ -462,7 +480,7 @@ def test_run_with_only_completed_files_does_not_mark_running(
     tmp_path: Path,
 ) -> None:
     analysis = _analysis(tmp_path, "completed.tpx3")
-    _save_completed_files(analysis, analysis.tpx3_files[0])
+    _save_completed_files(analysis, analysis.unpacking.tpx3_files[0])
     manager = StateManager(
         _record(tmp_path, analysis),
         config=StateServiceConfig(allow_trusted_workflow_bypass=True),
@@ -470,10 +488,11 @@ def test_run_with_only_completed_files_does_not_mark_running(
     )
 
     assert run_hermes_analysis(manager) == []
-    result = manager.get_state().analysis.results.unpacking
-    assert result.status == "completed"
-    assert result.started_at is None
-    assert result.completed_at is not None
+    results = manager.get_state().analysis.unpacking.results
+    assert len(results) == 1
+    assert results[0].status == "completed"
+    assert results[0].started_at is not None
+    assert results[0].completed_at is not None
 
 
 def test_run_rejects_empir_analysis(tmp_path: Path) -> None:
@@ -527,32 +546,25 @@ def test_run_rejects_missing_analysis(tmp_path: Path) -> None:
     assert invalid_mode["extra"]["actual_analysis_mode"] is None
 
 
-def test_disabled_bypass_leaves_pending_change_before_process_execution(
+def test_disabled_bypass_leaves_results_change_pending(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     analysis = _analysis(tmp_path, "first.tpx3")
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
+    analysis.unpacking.tpx3_files[0].path.write_text("success", encoding="utf-8")
     state_logger = CapturingStateLogger()
     manager = StateManager(
         _record(tmp_path, analysis),
         state_logger=state_logger,
     )
-    process_called = False
-
-    def unexpected_process(*args: object, **kwargs: object) -> None:
-        nonlocal process_called
-        process_called = True
-
-    monkeypatch.setattr(subprocess, "run", unexpected_process)
 
     with pytest.raises(ChangeApprovalError, match="requires approval"):
         run_hermes_analysis(manager)
 
-    assert process_called is False
-    assert manager.get_state().analysis.results.unpacking.status == "planned"
+    assert manager.get_state().analysis.unpacking.results == []
     pending = manager.list_pending_changes()
     assert len(pending) == 1
-    assert pending[0].path == "analysis.results"
+    assert pending[0].path == "analysis.unpacking.results"
     assert pending[0].origin == "trusted_workflow"
     assert pending[0].proposer == "tpx3_spidr_unpacking"
 
@@ -561,7 +573,7 @@ def test_run_executes_fake_unpacker_logs_details_and_round_trips_yaml(
     tmp_path: Path,
 ) -> None:
     analysis = _analysis(tmp_path, "success.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
     state_logger = CapturingStateLogger()
     manager = StateManager(
         _record(tmp_path, analysis),
@@ -578,11 +590,12 @@ def test_run_executes_fake_unpacker_logs_details_and_round_trips_yaml(
     finally:
         logger.remove(sink_id)
 
-    assert files_run == analysis.tpx3_files
-    result = manager.get_state().analysis.results.unpacking
-    assert result.status == "completed"
-    assert result.started_at is not None
-    assert result.completed_at is not None
+    assert files_run == analysis.unpacking.tpx3_files
+    results = manager.get_state().analysis.unpacking.results
+    assert len(results) == 1
+    assert results[0].status == "completed"
+    assert results[0].started_at is not None
+    assert results[0].completed_at is not None
 
     started = next(
         record
@@ -592,7 +605,7 @@ def test_run_executes_fake_unpacker_logs_details_and_round_trips_yaml(
     )
     assert started["extra"]["command"] == derive_unpacker_command(
         analysis,
-        analysis.tpx3_files[0],
+        analysis.unpacking.tpx3_files[0],
     )
     completed = next(
         record
@@ -618,15 +631,15 @@ def test_run_processes_multiple_inputs_and_then_skips_them(
     tmp_path: Path,
 ) -> None:
     analysis = _analysis(tmp_path, "first.tpx3", "second.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
     manager = StateManager(
         _record(tmp_path, analysis),
         config=StateServiceConfig(allow_trusted_workflow_bypass=True),
         state_logger=CapturingStateLogger(),
     )
 
-    assert run_hermes_analysis(manager) == analysis.tpx3_files
-    for raw_file in analysis.tpx3_files:
+    assert run_hermes_analysis(manager) == analysis.unpacking.tpx3_files
+    for raw_file in analysis.unpacking.tpx3_files:
         assert (
             analysis.analysis_directory
             / "pixelHits"
@@ -678,8 +691,8 @@ def test_run_saves_failed_state_before_raising_for_output_failures(
     message: str,
 ) -> None:
     analysis = _analysis(tmp_path, f"{mode}.tpx3")
-    analysis.tpx3_files[0].path.write_text(mode, encoding="utf-8")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
+    analysis.unpacking.tpx3_files[0].path.write_text(mode, encoding="utf-8")
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
     manager = StateManager(
         _record(tmp_path, analysis),
         config=StateServiceConfig(allow_trusted_workflow_bypass=True),
@@ -697,10 +710,10 @@ def test_run_saves_failed_state_before_raising_for_output_failures(
     finally:
         logger.remove(sink_id)
 
-    result = manager.get_state().analysis.results.unpacking
-    assert result.status == "failed"
-    assert result.started_at is not None
-    assert result.completed_at is not None
+    results = manager.get_state().analysis.unpacking.results
+    assert results
+    assert all(result.status == "failed" for result in results)
+    assert all(result.completed_at is not None for result in results)
     failures = [
         record
         for record in records
@@ -725,7 +738,7 @@ def test_run_saves_failed_state_before_raising_for_output_failures(
 
 def test_run_saves_failed_state_for_preflight_failure(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "invalid-existing.tpx3")
-    summary_path = derive_summary_path(analysis, analysis.tpx3_files[0])
+    summary_path = derive_summary_path(analysis, analysis.unpacking.tpx3_files[0])
     summary_path.parent.mkdir(parents=True)
     summary_path.write_text("not JSON", encoding="utf-8")
     manager = StateManager(
@@ -737,10 +750,10 @@ def test_run_saves_failed_state_for_preflight_failure(tmp_path: Path) -> None:
     with pytest.raises(HermesTpx3PreflightError, match="invalid summary"):
         run_hermes_analysis(manager)
 
-    result = manager.get_state().analysis.results.unpacking
-    assert result.status == "failed"
-    assert result.started_at is None
-    assert result.completed_at is not None
+    results = manager.get_state().analysis.unpacking.results
+    assert results
+    assert all(result.status == "failed" for result in results)
+    assert all(result.completed_at is not None for result in results)
 
 
 def test_resource_limit_percent_field_defaults_to_90(tmp_path: Path) -> None:
@@ -757,13 +770,15 @@ def test_resource_limit_percent_accepts_integers_from_1_to_100(tmp_path: Path) -
 
     for percent in [1, 50, 90, 100]:
         analysis = HermesTpx3AnalysisState(
-            unpacker_program=Tpx3SpidrUnpackerProgram(
-                name="test",
-                executable_path=executable,
-            ),
             analysis_directory=tmp_path / "analysis",
-            tpx3_files=[FileReference(path=raw_file)],
             resource_limit_percent=percent,
+            unpacking=Tpx3Unpacking(
+                program=BinaryProgram(
+                    name="test",
+                    executable_path=executable,
+                ),
+                tpx3_files=[FileReference(path=raw_file)],
+            ),
         )
         assert analysis.resource_limit_percent == percent
 
@@ -778,20 +793,22 @@ def test_resource_limit_percent_rejects_zero_and_above_100(tmp_path: Path) -> No
     for invalid_percent in [0, 101, 200, -1]:
         with pytest.raises(Exception):
             HermesTpx3AnalysisState(
-                unpacker_program=Tpx3SpidrUnpackerProgram(
-                    name="test",
-                    executable_path=executable,
-                ),
                 analysis_directory=tmp_path / "analysis",
-                tpx3_files=[FileReference(path=raw_file)],
                 resource_limit_percent=invalid_percent,
+                unpacking=Tpx3Unpacking(
+                    program=BinaryProgram(
+                        name="test",
+                        executable_path=executable,
+                    ),
+                    tpx3_files=[FileReference(path=raw_file)],
+                ),
             )
 
 
 def test_parallel_unpacking_returns_files_in_input_order(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "c.tpx3", "a.tpx3", "b.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
-    for raw_file in analysis.tpx3_files:
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
+    for raw_file in analysis.unpacking.tpx3_files:
         raw_file.path.write_text("success", encoding="utf-8")
 
     records: list[dict[str, Any]] = []
@@ -815,8 +832,8 @@ def test_parallel_unpacking_returns_files_in_input_order(tmp_path: Path) -> None
 
 def test_parallel_unpacking_logs_resource_calculation(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "a.tpx3", "b.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
-    for raw_file in analysis.tpx3_files:
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
+    for raw_file in analysis.unpacking.tpx3_files:
         raw_file.path.write_text("success", encoding="utf-8")
 
     records: list[dict[str, Any]] = []
@@ -851,11 +868,11 @@ def test_parallel_unpacking_logs_resource_calculation(tmp_path: Path) -> None:
 def test_parallel_unpacking_one_failure_stops_remaining_work(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "a.tpx3", "failing.tpx3", "c.tpx3", "d.tpx3")
     analysis.resource_limit_percent = 1
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
-    analysis.tpx3_files[0].path.write_text("success", encoding="utf-8")
-    analysis.tpx3_files[1].path.write_text("nonzero", encoding="utf-8")
-    analysis.tpx3_files[2].path.write_text("success", encoding="utf-8")
-    analysis.tpx3_files[3].path.write_text("success", encoding="utf-8")
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
+    analysis.unpacking.tpx3_files[0].path.write_text("success", encoding="utf-8")
+    analysis.unpacking.tpx3_files[1].path.write_text("nonzero", encoding="utf-8")
+    analysis.unpacking.tpx3_files[2].path.write_text("success", encoding="utf-8")
+    analysis.unpacking.tpx3_files[3].path.write_text("success", encoding="utf-8")
 
     manager = StateManager(
         _record(tmp_path, analysis),
@@ -866,8 +883,9 @@ def test_parallel_unpacking_one_failure_stops_remaining_work(tmp_path: Path) -> 
     with pytest.raises(HermesTpx3ExecutionError, match="exited with code 7"):
         run_hermes_analysis(manager)
 
-    result = manager.get_state().analysis.results.unpacking
-    assert result.status == "failed"
+    results = manager.get_state().analysis.unpacking.results
+    assert results
+    assert all(result.status == "failed" for result in results)
 
     summary_files = list((analysis.analysis_directory / "logs").glob("*.json"))
     completed_count = len(summary_files)
@@ -876,9 +894,9 @@ def test_parallel_unpacking_one_failure_stops_remaining_work(tmp_path: Path) -> 
 
 def test_parallel_unpacking_skips_valid_files(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "skip-me.tpx3", "run-me.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
-    _save_completed_files(analysis, analysis.tpx3_files[0], pixel_rows=1)
-    analysis.tpx3_files[1].path.write_text("success", encoding="utf-8")
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
+    _save_completed_files(analysis, analysis.unpacking.tpx3_files[0], pixel_rows=1)
+    analysis.unpacking.tpx3_files[1].path.write_text("success", encoding="utf-8")
 
     records: list[dict[str, Any]] = []
     sink_id = logger.add(lambda msg: records.append(msg.record))
@@ -907,14 +925,14 @@ def test_parallel_unpacking_skips_valid_files(tmp_path: Path) -> None:
 
 def test_resource_calculation_uses_only_pending_files(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "large-skip.tpx3", "small-run.tpx3")
-    _write_fake_unpacker(analysis.unpacker_program.executable_path)
+    _write_fake_unpacker(analysis.unpacking.program.executable_path)
 
     # Make the first file large but already completed (will be skipped)
-    analysis.tpx3_files[0].path.write_bytes(b"x" * (100 * 1024 * 1024))
-    _save_completed_files(analysis, analysis.tpx3_files[0], pixel_rows=1)
+    analysis.unpacking.tpx3_files[0].path.write_bytes(b"x" * (100 * 1024 * 1024))
+    _save_completed_files(analysis, analysis.unpacking.tpx3_files[0], pixel_rows=1)
 
     # Make the second file small (will be run)
-    analysis.tpx3_files[1].path.write_text("success", encoding="utf-8")
+    analysis.unpacking.tpx3_files[1].path.write_text("success", encoding="utf-8")
 
     records: list[dict[str, Any]] = []
     sink_id = logger.add(lambda msg: records.append(msg.record))

--- a/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
@@ -211,7 +211,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     ]
     assert skipped_inputs == ["example-first.tpx3", "example-second.tpx3"]
     final_results = manager.get_state().analysis.unpacking.results
-    assert all(result.status == "completed" for result in final_results)
+    assert all(result.status == "skipped" for result in final_results)
 
 
 def _contains_key(value: object, keys: set[str]) -> bool:

--- a/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker_integration.py
@@ -11,11 +11,11 @@ from hermes.analysis.hermes.unpacker import derive_summary_path
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
     Tpx3SpidrSummary,
-    Tpx3SpidrUnpackerProgram,
+    Tpx3Unpacking,
 )
 from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import BinaryProgram, FileReference
 from hermes.state.state import HermesRecord
 from hermes.state_service.shared_types import StateServiceConfig
 from hermes.state_service.state_manager import StateManager
@@ -51,13 +51,15 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
         shutil.copyfile(_TPX3_FIXTURE, raw_path)
 
     analysis = HermesTpx3AnalysisState(
-        unpacker_program=Tpx3SpidrUnpackerProgram(
-            name="tpx3-spidr-cpp",
-            executable_path=_UNPACKER_EXECUTABLE,
-            version="0.1.0",
-        ),
         analysis_directory=tmp_path / "analysis",
-        tpx3_files=[FileReference(path=raw_path) for raw_path in raw_paths],
+        unpacking=Tpx3Unpacking(
+            program=BinaryProgram(
+                name="tpx3-spidr-cpp",
+                executable_path=_UNPACKER_EXECUTABLE,
+                version="0.1.0",
+            ),
+            tpx3_files=[FileReference(path=raw_path) for raw_path in raw_paths],
+        ),
     )
     manager = StateManager(
         HermesRecord(
@@ -85,13 +87,15 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     assert [raw_file.path for raw_file in first_run] == raw_paths
     completed_state = manager.get_state()
     assert completed_state.acquisition is None
-    assert completed_state.analysis.results.unpacking.status == "completed"
-    assert completed_state.analysis.results.unpacking.started_at is not None
-    assert completed_state.analysis.results.unpacking.completed_at is not None
+    unpacking_results = completed_state.analysis.unpacking.results
+    assert [result.input_file.path for result in unpacking_results] == raw_paths
+    assert all(result.status == "completed" for result in unpacking_results)
+    assert all(result.started_at is not None for result in unpacking_results)
+    assert all(result.completed_at is not None for result in unpacking_results)
 
     summaries: list[Tpx3SpidrSummary] = []
     generated_paths: set[Path] = set()
-    for raw_file in analysis.tpx3_files:
+    for raw_file in analysis.unpacking.tpx3_files:
         summary_path = derive_summary_path(analysis, raw_file)
         assert summary_path.is_file()
         summary = Tpx3SpidrSummary.model_validate_json(summary_path.read_bytes())
@@ -129,19 +133,26 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     saved_analysis = completed_state.analysis.model_dump(mode="json")
     assert set(saved_analysis) == {
         "mode",
-        "unpacker_program",
         "analysis_directory",
-        "tpx3_files",
         "resource_limit_percent",
+        "unpacking",
         "photon_reconstruction",
-        "results",
     }
     assert saved_analysis["photon_reconstruction"] is None
-    assert set(saved_analysis["results"]["unpacking"]) == {
-        "status",
-        "started_at",
-        "completed_at",
+    assert set(saved_analysis["unpacking"]) == {
+        "program",
+        "tpx3_files",
+        "output_directory",
+        "runtime_options",
+        "results",
     }
+    for saved_result in saved_analysis["unpacking"]["results"]:
+        assert set(saved_result) == {
+            "input_file",
+            "status",
+            "started_at",
+            "completed_at",
+        }
     assert not _contains_key(
         saved_analysis,
         {
@@ -167,7 +178,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
 
     saved_files = [
         derive_summary_path(analysis, raw_file)
-        for raw_file in analysis.tpx3_files
+        for raw_file in analysis.unpacking.tpx3_files
     ] + [
         analysis.analysis_directory / relative_path
         for relative_path in generated_paths
@@ -199,7 +210,8 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
         == "analysis.tpx3_unpacking.skipped"
     ]
     assert skipped_inputs == ["example-first.tpx3", "example-second.tpx3"]
-    assert manager.get_state().analysis.results.unpacking.status == "completed"
+    final_results = manager.get_state().analysis.unpacking.results
+    assert all(result.status == "completed" for result in final_results)
 
 
 def _contains_key(value: object, keys: set[str]) -> bool:

--- a/tests/unit/hermes/state/models/test_empir.py
+++ b/tests/unit/hermes/state/models/test_empir.py
@@ -16,7 +16,7 @@ from hermes.state.models.analysis.empir import (
     EmpirPixelToPhotonSettings,
     EmpirPixelToPhotonState,
 )
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import BinaryProgram, FileReference
 
 
 def test_empir_analysis_state_serializes_direct_binary_pipeline(
@@ -31,7 +31,10 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
         save_photon_files=False,
         save_event_files=True,
         pixel_to_photon=EmpirPixelToPhotonState(
-            executable_path=tmp_path / "bin/empir_pixel2photon_tpx3spidr",
+            program=BinaryProgram(
+                name="empir-pixel2photon",
+                executable_path=tmp_path / "bin/empir_pixel2photon_tpx3spidr",
+            ),
             settings=EmpirPixelToPhotonSettings(
                 spatial_distance_pixels=5,
                 time_distance_seconds=500e-9,
@@ -47,7 +50,10 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
             ],
         ),
         photon_to_event=EmpirPhotonToEventState(
-            executable_path=tmp_path / "bin/empir_photon2event",
+            program=BinaryProgram(
+                name="empir-photon2event",
+                executable_path=tmp_path / "bin/empir_photon2event",
+            ),
             settings=EmpirPhotonToEventSettings(
                 spatial_distance_pixels=4,
                 time_distance_seconds=100e-6,
@@ -62,7 +68,10 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
             ],
         ),
         event_to_image=EmpirEventToImageState(
-            executable_path=tmp_path / "bin/empir_event2image",
+            program=BinaryProgram(
+                name="empir-event2image",
+                executable_path=tmp_path / "bin/empir_event2image",
+            ),
             settings=EmpirEventToImageSettings(
                 image_width_pixels=2048,
                 image_height_pixels=2048,
@@ -121,7 +130,10 @@ def test_event_to_image_settings_reject_invalid_combinations(
 def test_empir_stage_requires_at_least_one_file(tmp_path: Path) -> None:
     with pytest.raises(ValidationError, match="at least 1 item"):
         EmpirPixelToPhotonState(
-            executable_path=tmp_path / "empir_pixel2photon_tpx3spidr",
+            program=BinaryProgram(
+                name="empir-pixel2photon",
+                executable_path=tmp_path / "empir_pixel2photon_tpx3spidr",
+            ),
             settings=EmpirPixelToPhotonSettings(
                 spatial_distance_pixels=5,
                 time_distance_seconds=500e-9,

--- a/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
+++ b/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
@@ -7,38 +7,40 @@ import pytest
 from pydantic import ValidationError
 
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
-    HermesTpx3AnalysisResults,
     HermesTpx3AnalysisState,
     HermesTpx3ReconstructionResult,
     HermesTpx3UnpackingResult,
-    PhotonReconstructorProgram,
     Tpx3PhotonClusteringSettings,
-    Tpx3PhotonReconstructionConfiguration,
+    Tpx3PhotonReconstruction,
     Tpx3PhotonReconstructionSummary,
     Tpx3SpidrSummary,
-    Tpx3SpidrUnpackerProgram,
+    Tpx3Unpacking,
 )
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import BinaryProgram, FileReference
 
 
 def _analysis_state(tmp_path: Path, *raw_names: str) -> HermesTpx3AnalysisState:
     return HermesTpx3AnalysisState(
-        unpacker_program=Tpx3SpidrUnpackerProgram(
-            name="tpx3-spidr-cpp",
-            executable_path=tmp_path / "bin/hermes-tpx3-spidr",
-            version="0.1.0",
-        ),
         analysis_directory=tmp_path / "analysis",
-        tpx3_files=[
-            FileReference(path=tmp_path / "rawTpx3" / raw_name)
-            for raw_name in raw_names
-        ],
-        results=HermesTpx3AnalysisResults(
-            unpacking=HermesTpx3UnpackingResult(
-                status="completed",
-                started_at=datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc),
-                completed_at=datetime(2026, 7, 23, 12, 1, tzinfo=timezone.utc),
-            )
+        unpacking=Tpx3Unpacking(
+            program=BinaryProgram(
+                name="tpx3-spidr-cpp",
+                executable_path=tmp_path / "bin/hermes-tpx3-spidr",
+                version="0.1.0",
+            ),
+            tpx3_files=[
+                FileReference(path=tmp_path / "rawTpx3" / raw_name)
+                for raw_name in raw_names
+            ],
+            results=[
+                HermesTpx3UnpackingResult(
+                    input_file=FileReference(path=tmp_path / "rawTpx3" / raw_name),
+                    status="completed",
+                    started_at=datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc),
+                    completed_at=datetime(2026, 7, 23, 12, 1, tzinfo=timezone.utc),
+                )
+                for raw_name in raw_names
+            ],
         ),
     )
 
@@ -146,33 +148,6 @@ def _photon_summary_data() -> dict[str, object]:
             "warnings": [],
             "errors": [],
         },
-        "clustering": {
-            "algorithm": "connected_components",
-            "settings": _clustering_settings_data(),
-        },
-        "photon_timing": {
-            "estimator": "leading_edge",
-            "correction_model": "none",
-            "calibration_file": None,
-            "parameters": {},
-            "high_tot_anchor": None,
-        },
-        "parquet": {
-            "input_pixel_data_files": [
-                "pixelHits/raw-chip-0-part-00000.parquet",
-            ],
-            "photon_events": {
-                "row_count": 2,
-                "files": [
-                    "photons/raw-chip-0-photon-events-part-00000.parquet",
-                ],
-            },
-            "photon_pixels": {
-                "requested": False,
-                "row_count": 0,
-                "files": [],
-            },
-        },
         "processing_times_seconds": {
             "parquet_reading": 0.1,
             "clustering_and_filtering": 0.2,
@@ -200,25 +175,13 @@ def test_hermes_analysis_state_serializes_batch_fields(
     dumped = _analysis_state(tmp_path, *raw_names).model_dump(mode="json")
 
     assert dumped["mode"] == "hermes"
-    assert dumped["unpacker_program"]["name"] == "tpx3-spidr-cpp"
+    assert dumped["unpacking"]["program"]["name"] == "tpx3-spidr-cpp"
     assert dumped["analysis_directory"].endswith("analysis")
-    assert [Path(file["path"]).name for file in dumped["tpx3_files"]] == list(
-        raw_names
-    )
-    assert dumped["results"]["unpacking"]["status"] == "completed"
-    assert dumped["results"]["reconstruction"] is None
-
-    duplicated_fields = {
-        "unpacking_runs",
-        "command_args",
-        "summary_json_file",
-        "pixel_hit_count",
-        "warnings",
-        "errors",
-        "exit_code",
-    }
-    assert duplicated_fields.isdisjoint(dumped)
-    assert duplicated_fields.isdisjoint(dumped["results"]["unpacking"])
+    assert [
+        Path(file["path"]).name for file in dumped["unpacking"]["tpx3_files"]
+    ] == list(raw_names)
+    assert dumped["unpacking"]["results"][0]["status"] == "completed"
+    assert dumped["photon_reconstruction"] is None
 
 
 def test_hermes_analysis_state_requires_a_raw_tpx3_file(tmp_path: Path) -> None:
@@ -231,15 +194,17 @@ def test_hermes_analysis_state_rejects_duplicate_raw_filename_stems(
 ) -> None:
     with pytest.raises(ValidationError, match="filename stems must be unique"):
         HermesTpx3AnalysisState(
-            unpacker_program=Tpx3SpidrUnpackerProgram(
-                name="tpx3-spidr-cpp",
-                executable_path=tmp_path / "hermes-tpx3-spidr",
-            ),
             analysis_directory=tmp_path / "analysis",
-            tpx3_files=[
-                FileReference(path=tmp_path / "first/raw.tpx3"),
-                FileReference(path=tmp_path / "second/raw.tpx3"),
-            ],
+            unpacking=Tpx3Unpacking(
+                program=BinaryProgram(
+                    name="tpx3-spidr-cpp",
+                    executable_path=tmp_path / "hermes-tpx3-spidr",
+                ),
+                tpx3_files=[
+                    FileReference(path=tmp_path / "first/raw.tpx3"),
+                    FileReference(path=tmp_path / "second/raw.tpx3"),
+                ],
+            ),
         )
 
 
@@ -261,26 +226,28 @@ def test_hermes_analysis_state_expands_raw_tpx3_file_list(
 
     analysis = HermesTpx3AnalysisState.model_validate(
         {
-            "unpacker_program": {
-                "name": "tpx3-spidr-cpp",
-                "executable_path": tmp_path / "hermes-tpx3-spidr",
-            },
             "analysis_directory": tmp_path / "analysis",
-            "tpx3_files": {"file_list": file_list_path},
+            "unpacking": {
+                "program": {
+                    "name": "tpx3-spidr-cpp",
+                    "executable_path": tmp_path / "hermes-tpx3-spidr",
+                },
+                "tpx3_files": {"file_list": file_list_path},
+            },
         }
     )
 
-    assert [raw_file.path for raw_file in analysis.tpx3_files] == [
+    assert [raw_file.path for raw_file in analysis.unpacking.tpx3_files] == [
         (file_list_path.parent / "../raw/first.tpx3").resolve(),
         absolute_raw_tpx3_path.resolve(),
     ]
-    assert isinstance(analysis.tpx3_files[0], FileReference)
+    assert isinstance(analysis.unpacking.tpx3_files[0], FileReference)
 
 
 @pytest.mark.parametrize(
     ("file_contents", "error"),
     [
-        (None, "cannot read raw TPX3 file list"),
+        (None, "cannot read file list"),
         ("", "contains no file paths"),
         ("\n# no paths\n\n", "contains no file paths"),
     ],
@@ -297,12 +264,14 @@ def test_hermes_analysis_state_rejects_invalid_raw_tpx3_file_list(
     with pytest.raises(ValidationError, match=error):
         HermesTpx3AnalysisState.model_validate(
             {
-                "unpacker_program": {
-                    "name": "tpx3-spidr-cpp",
-                    "executable_path": tmp_path / "hermes-tpx3-spidr",
-                },
                 "analysis_directory": tmp_path / "analysis",
-                "tpx3_files": {"file_list": file_list_path},
+                "unpacking": {
+                    "program": {
+                        "name": "tpx3-spidr-cpp",
+                        "executable_path": tmp_path / "hermes-tpx3-spidr",
+                    },
+                    "tpx3_files": {"file_list": file_list_path},
+                },
             }
         )
 
@@ -319,29 +288,37 @@ def test_hermes_analysis_state_checks_duplicate_stems_from_file_list(
     with pytest.raises(ValidationError, match="filename stems must be unique"):
         HermesTpx3AnalysisState.model_validate(
             {
-                "unpacker_program": {
-                    "name": "tpx3-spidr-cpp",
-                    "executable_path": tmp_path / "hermes-tpx3-spidr",
-                },
                 "analysis_directory": tmp_path / "analysis",
-                "tpx3_files": {"file_list": file_list_path},
+                "unpacking": {
+                    "program": {
+                        "name": "tpx3-spidr-cpp",
+                        "executable_path": tmp_path / "hermes-tpx3-spidr",
+                    },
+                    "tpx3_files": {"file_list": file_list_path},
+                },
             }
         )
 
 
-def test_reconstruction_result_defaults_and_rejects_undefined_fields() -> None:
-    result = HermesTpx3ReconstructionResult()
+def test_reconstruction_result_defaults_and_rejects_undefined_fields(
+    tmp_path: Path,
+) -> None:
+    result = HermesTpx3ReconstructionResult(
+        input_file=FileReference(path=tmp_path / "pixelHits/raw.parquet"),
+        output_file=tmp_path / "photons/raw.parquet",
+    )
 
     assert result.status == "planned"
     assert result.started_at is None
     assert result.completed_at is None
-    assert result.photon_count == 0
-    assert result.rejected_count == 0
-    assert result.warnings == []
-    assert result.errors == []
+    assert result.counts is None
 
     with pytest.raises(ValidationError, match="extra_forbidden"):
-        HermesTpx3ReconstructionResult(settings={})
+        HermesTpx3ReconstructionResult(
+            input_file=FileReference(path=tmp_path / "pixelHits/raw.parquet"),
+            output_file=tmp_path / "photons/raw.parquet",
+            settings={},
+        )
 
 
 def test_photon_clustering_settings_use_structural_defaults() -> None:
@@ -418,19 +395,19 @@ def test_hermes_analysis_state_accepts_photon_reconstruction(
 ) -> None:
     analysis_directory = tmp_path / "analysis"
     state = HermesTpx3AnalysisState(
-        unpacker_program=Tpx3SpidrUnpackerProgram(
-            name="tpx3-spidr-cpp",
-            executable_path=tmp_path / "bin/hermes-tpx3-spidr",
-        ),
         analysis_directory=analysis_directory,
-        tpx3_files=[FileReference(path=tmp_path / "rawTpx3/raw.tpx3")],
-        photon_reconstruction=Tpx3PhotonReconstructionConfiguration(
-            program=PhotonReconstructorProgram(
+        unpacking=Tpx3Unpacking(
+            program=BinaryProgram(
+                name="tpx3-spidr-cpp",
+                executable_path=tmp_path / "bin/hermes-tpx3-spidr",
+            ),
+            tpx3_files=[FileReference(path=tmp_path / "rawTpx3/raw.tpx3")],
+        ),
+        photon_reconstruction=Tpx3PhotonReconstruction(
+            program=BinaryProgram(
                 name="connected-components-cpp",
                 executable_path=tmp_path / "bin/hermes-photon-clusterer",
             ),
-            pixel_data_directory=analysis_directory / "pixelHits",
-            photon_output_directory=analysis_directory / "photons",
             settings=Tpx3PhotonClusteringSettings.model_validate(
                 _clustering_settings_data()
             ),
@@ -442,42 +419,38 @@ def test_hermes_analysis_state_accepts_photon_reconstruction(
         "connected_components"
     )
     assert state.photon_reconstruction.settings.adjacency == 8
+    assert state.photon_reconstruction.pixel_parquet_files == "auto"
 
 
-@pytest.mark.parametrize(
-    ("directory_field", "directory_name"),
-    [
-        ("pixel_data_directory", "wrong-pixel-data"),
-        ("photon_output_directory", "wrong-photons"),
-    ],
-)
-def test_hermes_analysis_state_rejects_reconstruction_directory_mismatch(
+def test_hermes_analysis_state_derives_output_directories(
     tmp_path: Path,
-    directory_field: str,
-    directory_name: str,
 ) -> None:
     analysis_directory = tmp_path / "analysis"
-    reconstruction_data: dict[str, object] = {
-        "program": {
-            "name": "connected-components-cpp",
-            "executable_path": tmp_path / "bin/hermes-photon-clusterer",
-        },
-        "pixel_data_directory": analysis_directory / "pixelHits",
-        "photon_output_directory": analysis_directory / "photons",
-        "settings": _clustering_settings_data(),
-    }
-    reconstruction_data[directory_field] = analysis_directory / directory_name
-
-    with pytest.raises(ValidationError, match=directory_field):
-        HermesTpx3AnalysisState(
-            unpacker_program=Tpx3SpidrUnpackerProgram(
+    state = HermesTpx3AnalysisState(
+        analysis_directory=analysis_directory,
+        unpacking=Tpx3Unpacking(
+            program=BinaryProgram(
                 name="tpx3-spidr-cpp",
                 executable_path=tmp_path / "bin/hermes-tpx3-spidr",
             ),
-            analysis_directory=analysis_directory,
             tpx3_files=[FileReference(path=tmp_path / "rawTpx3/raw.tpx3")],
-            photon_reconstruction=reconstruction_data,
-        )
+        ),
+        photon_reconstruction=Tpx3PhotonReconstruction(
+            program=BinaryProgram(
+                name="connected-components-cpp",
+                executable_path=tmp_path / "bin/hermes-photon-clusterer",
+            ),
+            settings=Tpx3PhotonClusteringSettings.model_validate(
+                _clustering_settings_data()
+            ),
+        ),
+    )
+
+    assert state.unpacking.output_directory == analysis_directory
+    assert (
+        state.photon_reconstruction.output_directory
+        == analysis_directory / "photons"
+    )
 
 
 def test_summary_validates_every_section() -> None:
@@ -577,94 +550,43 @@ def test_photon_reconstruction_summary_validates_every_section() -> None:
 
     assert summary.schema_version == 1
     assert summary.reconstruction.photon_count == 2
-    assert summary.clustering.algorithm == "connected_components"
-    assert summary.clustering.settings.adjacency == 8
-    assert summary.photon_timing.correction_model == "none"
-    assert summary.parquet.photon_events.row_count == 2
-    assert summary.parquet.photon_pixels.requested is False
+    assert summary.reconstruction.components_formed == 3
+    assert summary.reconstruction.rejection_counts.below_min_cluster_size == 1
+    assert summary.reconstruction.quality_flag_counts.saturated_pixel == 1
     assert summary.processing_times_seconds.total == 0.4
+    assert summary.processing_times_seconds.throughput.photons_per_second == 5.0
 
 
 @pytest.mark.parametrize(
-    ("section", "field", "value", "error"),
+    ("field", "value", "error"),
     [
-        ("reconstruction", "components_formed", 4, "components_formed"),
-        ("reconstruction", "pixel_rows_below_min_tot", 13, "cannot exceed"),
-        ("photon_timing", "high_tot_anchor", 1024, "less than or equal"),
+        ("components_formed", 4, "components_formed"),
+        ("pixel_rows_below_min_tot", 13, "cannot exceed"),
     ],
 )
 def test_photon_reconstruction_summary_rejects_inconsistent_values(
-    section: str,
     field: str,
     value: object,
     error: str,
 ) -> None:
     summary_data = _photon_summary_data()
-    section_data = summary_data[section]
-    assert isinstance(section_data, dict)
-    section_data[field] = value
+    reconstruction = summary_data["reconstruction"]
+    assert isinstance(reconstruction, dict)
+    reconstruction[field] = value
 
     with pytest.raises(ValidationError, match=error):
         Tpx3PhotonReconstructionSummary.model_validate(summary_data)
 
 
-def test_photon_reconstruction_summary_requires_fitted_correction_details() -> None:
+def test_photon_reconstruction_summary_rejects_quality_flags_over_photons() -> (
+    None
+):
     summary_data = _photon_summary_data()
-    photon_timing = summary_data["photon_timing"]
-    assert isinstance(photon_timing, dict)
-    photon_timing["correction_model"] = "linear"
+    reconstruction = summary_data["reconstruction"]
+    assert isinstance(reconstruction, dict)
+    quality_flag_counts = reconstruction["quality_flag_counts"]
+    assert isinstance(quality_flag_counts, dict)
+    quality_flag_counts["bridged_components"] = 99
 
-    with pytest.raises(ValidationError, match="fitted correction requires"):
-        Tpx3PhotonReconstructionSummary.model_validate(summary_data)
-
-
-def test_photon_reconstruction_summary_accepts_fitted_correction() -> None:
-    summary_data = _photon_summary_data()
-    clustering = summary_data["clustering"]
-    assert isinstance(clustering, dict)
-    settings = clustering["settings"]
-    assert isinstance(settings, dict)
-    settings["timewalk_calibration_file"] = "logs/timewalk-calibration.json"
-
-    photon_timing = summary_data["photon_timing"]
-    assert isinstance(photon_timing, dict)
-    photon_timing.update(
-        {
-            "correction_model": "linear",
-            "calibration_file": "logs/timewalk-calibration.json",
-            "parameters": {"m": -2.5},
-            "high_tot_anchor": 900.0,
-        }
-    )
-
-    summary = Tpx3PhotonReconstructionSummary.model_validate(summary_data)
-
-    assert summary.photon_timing.correction_model == "linear"
-    assert summary.photon_timing.parameters == {"m": -2.5}
-    assert summary.photon_timing.high_tot_anchor == 900.0
-
-
-def test_photon_reconstruction_summary_matches_saved_pixel_setting() -> None:
-    summary_data = _photon_summary_data()
-    parquet = summary_data["parquet"]
-    assert isinstance(parquet, dict)
-    photon_pixels = parquet["photon_pixels"]
-    assert isinstance(photon_pixels, dict)
-    photon_pixels["requested"] = True
-
-    with pytest.raises(ValidationError, match="save_photon_pixels"):
-        Tpx3PhotonReconstructionSummary.model_validate(summary_data)
-
-
-def test_photon_reconstruction_summary_rejects_wrong_output_group() -> None:
-    summary_data = _photon_summary_data()
-    parquet = summary_data["parquet"]
-    assert isinstance(parquet, dict)
-    photon_events = parquet["photon_events"]
-    assert isinstance(photon_events, dict)
-    photon_events["files"] = [
-        "photons/raw-chip-0-photon-pixels-part-00000.parquet"
-    ]
-
-    with pytest.raises(ValidationError, match="photon-events paths"):
+    with pytest.raises(ValidationError, match="quality flag counts cannot exceed"):
         Tpx3PhotonReconstructionSummary.model_validate(summary_data)

--- a/tests/unit/hermes/state/test_state.py
+++ b/tests/unit/hermes/state/test_state.py
@@ -11,14 +11,13 @@ from hermes.state.models.acquisition.serval import (
     ServalEnvironment,
 )
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
-    HermesTpx3AnalysisResults,
     HermesTpx3AnalysisState,
     HermesTpx3UnpackingResult,
-    Tpx3SpidrUnpackerProgram,
+    Tpx3Unpacking,
 )
 from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import BinaryProgram, FileReference
 from hermes.state.state import HermesRecord
 
 
@@ -29,8 +28,6 @@ def test_hermes_record_serializes_paths_datetimes_and_mode_tags(tmp_path: Path) 
     raw_file = FileReference(
         path=tmp_path / "run-001/data/tpx3/raw.tpx3",
         media_type="application/octet-stream",
-        sha256=HASH,
-        size_bytes=1024,
     )
     record = HermesRecord(
         measurement_info=MeasurementInfo(
@@ -44,15 +41,20 @@ def test_hermes_record_serializes_paths_datetimes_and_mode_tags(tmp_path: Path) 
             result=ServalAcquisitionResult(status="completed", output_files=[raw_file])
         ),
         analysis=HermesTpx3AnalysisState(
-            unpacker_program=Tpx3SpidrUnpackerProgram(
-                name="tpx3-spidr-cpp",
-                executable_path=tmp_path / "bin/hermes-tpx3-spidr",
-                version="0.1.0",
-            ),
             analysis_directory=tmp_path / "run-001/data/analyzed",
-            tpx3_files=[raw_file],
-            results=HermesTpx3AnalysisResults(
-                unpacking=HermesTpx3UnpackingResult(status="completed")
+            unpacking=Tpx3Unpacking(
+                program=BinaryProgram(
+                    name="tpx3-spidr-cpp",
+                    executable_path=tmp_path / "bin/hermes-tpx3-spidr",
+                    version="0.1.0",
+                ),
+                tpx3_files=[raw_file],
+                results=[
+                    HermesTpx3UnpackingResult(
+                        input_file=raw_file,
+                        status="completed",
+                    )
+                ],
             ),
         ),
     )
@@ -69,8 +71,12 @@ def test_hermes_record_serializes_paths_datetimes_and_mode_tags(tmp_path: Path) 
         "raw.tpx3"
     )
     assert dumped["analysis"]["mode"] == "hermes"
-    assert dumped["analysis"]["tpx3_files"][0]["path"].endswith("raw.tpx3")
-    assert dumped["analysis"]["results"]["unpacking"]["status"] == "completed"
+    assert dumped["analysis"]["unpacking"]["tpx3_files"][0]["path"].endswith(
+        "raw.tpx3"
+    )
+    assert (
+        dumped["analysis"]["unpacking"]["results"][0]["status"] == "completed"
+    )
 
 
 def test_hermes_record_serializes_serval_requested_applied_and_calibration(

--- a/tests/unit/hermes/state_service/test_state_io.py
+++ b/tests/unit/hermes/state_service/test_state_io.py
@@ -26,7 +26,6 @@ from hermes.state_service.state_io import (
 )
 
 
-HASH = "a" * 64
 NOW = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
 PARTIAL_HERMES_ANALYSIS_YAML = """
 measurement_info:
@@ -36,12 +35,13 @@ environment:
   working_dir: data/examples/analysis/unpacker
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
   analysis_directory: data/examples/analysis/unpacker/analysis
-  tpx3_files:
-    - path: tests/data/Example_1kHz_5frames.tpx3
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: build/backends/tpx3-spidr/hermes-tpx3-spidr
+    tpx3_files:
+      - path: tests/data/Example_1kHz_5frames.tpx3
 """
 
 
@@ -49,8 +49,6 @@ def _example_record(tmp_path: Path) -> HermesRecord:
     raw_file = FileReference(
         path=tmp_path / "run-001/data/raw.tpx3",
         media_type="application/octet-stream",
-        sha256=HASH,
-        size_bytes=2048,
         created_at=NOW,
     )
     return HermesRecord(
@@ -154,17 +152,12 @@ def test_load_partial_hermes_analysis_yaml_applies_nested_defaults(
     assert loaded.acquisition is None
     assert isinstance(loaded.analysis, HermesTpx3AnalysisState)
     assert loaded.analysis.resource_limit_percent == 90
-    assert loaded.analysis.unpacker_program.version is None
+    assert loaded.analysis.unpacking.program.version is None
     assert loaded.analysis.photon_reconstruction is None
-    assert loaded.analysis.results.unpacking.status == "planned"
-    assert loaded.analysis.results.unpacking.started_at is None
-    assert loaded.analysis.results.unpacking.completed_at is None
-    assert loaded.analysis.results.reconstruction is None
+    assert loaded.analysis.unpacking.results == []
 
-    raw_file = loaded.analysis.tpx3_files[0]
+    raw_file = loaded.analysis.unpacking.tpx3_files[0]
     assert raw_file.media_type is None
-    assert raw_file.sha256 is None
-    assert raw_file.size_bytes is None
     assert raw_file.created_at is None
     assert raw_file.description is None
 
@@ -183,9 +176,12 @@ def test_save_partial_loaded_record_writes_defaults_and_round_trips(
 
     assert saved_yaml["acquisition"] is None
     assert saved_yaml["analysis"]["resource_limit_percent"] == 90
-    assert saved_yaml["analysis"]["unpacker_program"]["version"] is None
-    assert saved_yaml["analysis"]["results"]["unpacking"]["status"] == "planned"
-    assert saved_yaml["analysis"]["tpx3_files"][0]["sha256"] is None
+    assert saved_yaml["analysis"]["unpacking"]["program"]["version"] is None
+    assert saved_yaml["analysis"]["unpacking"]["results"] == []
+    assert (
+        saved_yaml["analysis"]["unpacking"]["tpx3_files"][0]["media_type"]
+        is None
+    )
     assert reloaded == loaded
 
 
@@ -208,12 +204,13 @@ measurement_info:
 environment: {{}}
 analysis:
   mode: hermes
-  unpacker_program:
-    name: tpx3-spidr-cpp
-    executable_path: hermes-tpx3-spidr
   analysis_directory: analysis
-  tpx3_files:
-    file_list: {file_list_path}
+  unpacking:
+    program:
+      name: tpx3-spidr-cpp
+      executable_path: hermes-tpx3-spidr
+    tpx3_files:
+      file_list: {file_list_path}
 """,
         encoding="utf-8",
     )
@@ -224,11 +221,13 @@ analysis:
     reloaded = load_hermes_record_from_yaml(final_record_path)
 
     assert isinstance(loaded.analysis, HermesTpx3AnalysisState)
-    assert [raw_file.path for raw_file in loaded.analysis.tpx3_files] == [
+    assert [
+        raw_file.path for raw_file in loaded.analysis.unpacking.tpx3_files
+    ] == [
         (file_list_path.parent / "first.tpx3").resolve(),
         (file_list_path.parent / "second.tpx3").resolve(),
     ]
-    saved_raw_tpx3_files = saved_yaml["analysis"]["tpx3_files"]
+    saved_raw_tpx3_files = saved_yaml["analysis"]["unpacking"]["tpx3_files"]
     assert isinstance(saved_raw_tpx3_files, list)
     assert [Path(raw_file["path"]) for raw_file in saved_raw_tpx3_files] == [
         (file_list_path.parent / "first.tpx3").resolve(),

--- a/tests/unit/hermes/workflows/test_workflow.py
+++ b/tests/unit/hermes/workflows/test_workflow.py
@@ -5,14 +5,13 @@ from pathlib import Path
 import pytest
 
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
-    HermesTpx3AnalysisResults,
     HermesTpx3AnalysisState,
     HermesTpx3UnpackingResult,
-    Tpx3SpidrUnpackerProgram,
+    Tpx3Unpacking,
 )
 from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
-from hermes.state.models.shared_models import FileReference
+from hermes.state.models.shared_models import BinaryProgram, FileReference
 from hermes.state.state import HermesRecord
 from hermes.state_service.state_manager import StateManager
 from hermes.workflows.workflow import Workflow
@@ -26,12 +25,14 @@ def _record(tmp_path: Path) -> HermesRecord:
         ),
         environment=RuntimeEnvironment(working_dir=tmp_path),
         analysis=HermesTpx3AnalysisState(
-            unpacker_program=Tpx3SpidrUnpackerProgram(
-                name="test-unpacker",
-                executable_path=tmp_path / "test-unpacker",
-            ),
             analysis_directory=tmp_path / "analysis",
-            tpx3_files=[FileReference(path=tmp_path / "input.tpx3")],
+            unpacking=Tpx3Unpacking(
+                program=BinaryProgram(
+                    name="test-unpacker",
+                    executable_path=tmp_path / "test-unpacker",
+                ),
+                tpx3_files=[FileReference(path=tmp_path / "input.tpx3")],
+            ),
         ),
     )
 
@@ -49,19 +50,23 @@ def test_run_analysis_returns_files_and_updates_record(
         overwrite: bool = False,
     ) -> list[FileReference]:
         assert overwrite is True
+        analysis = state_manager.get_state().analysis
+        assert isinstance(analysis, HermesTpx3AnalysisState)
         change = state_manager.propose_change(
-            "analysis.results",
-            HermesTpx3AnalysisResults(
-                unpacking=HermesTpx3UnpackingResult(status="completed")
-            ),
+            "analysis.unpacking.results",
+            [
+                HermesTpx3UnpackingResult(
+                    input_file=raw_file,
+                    status="completed",
+                )
+                for raw_file in analysis.unpacking.tpx3_files
+            ],
             origin="trusted_workflow",
             proposer="test_analysis",
         )
         state_manager.apply_change(change.change_id)
 
-        analysis = state_manager.get_state().analysis
-        assert isinstance(analysis, HermesTpx3AnalysisState)
-        return analysis.tpx3_files
+        return analysis.unpacking.tpx3_files
 
     monkeypatch.setattr(
         "hermes.workflows.workflow.run_hermes_analysis",
@@ -70,9 +75,10 @@ def test_run_analysis_returns_files_and_updates_record(
 
     unpacked_files = workflow.run_analysis(overwrite=True)
 
-    assert unpacked_files == initial_record.analysis.tpx3_files
-    assert workflow.record.analysis.results.unpacking.status == "completed"
-    assert initial_record.analysis.results.unpacking.status == "planned"
+    assert unpacked_files == initial_record.analysis.unpacking.tpx3_files
+    updated_results = workflow.record.analysis.unpacking.results
+    assert [result.status for result in updated_results] == ["completed"]
+    assert initial_record.analysis.unpacking.results == []
 
 
 @pytest.mark.parametrize("method_name", ["run_acquisition", "run"])


### PR DESCRIPTION
This pull request refactors the photon reconstruction pipeline to operate on single input/output files instead of directories and file groups. The interface and internal logic have been simplified to remove support for multi-chip, multi-part workflows, focusing on processing one Parquet file at a time. This affects command-line arguments, file discovery, metadata, and summary handling.

**Command-line Interface and File Handling:**

* The command-line interface now requires `--input <pixel_file>` (a single pixelHits Parquet file) and optionally accepts `--output <photon_file>`, removing prior support for directories and base file names. [[1]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL40-L55) [[2]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL162-L177) [[3]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL188-R153) [[4]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL201-R163)
* Output sidecar files (photon_pixels and summary JSON) are now derived from the output file path, not from an output directory.

**API and Type Changes:**

* The photon and pixel writing APIs (`writePhotonEventsParquet`, `writePhotonPixelsParquet`) have been simplified to write a single output file per call, not file groups or parts. The corresponding result struct now holds a single file path.
* The pixel file discovery and grouping logic (`PixelFileGroups`, `discoverPixelFiles`) has been removed, as the pipeline no longer processes multiple files per run.

**Summary and Metadata Changes:**

* The summary content structure (`ReconstructionSummaryContent`) has been simplified: clustering settings, algorithm, and timing blocks are no longer included here, as provenance now lives solely in the photon file metadata. [[1]](diffhunk://#diff-d8979a53b27974e552bc3c24a44d6f6c985aa9b5a91a5517ae7f04676cced796L12-R14) [[2]](diffhunk://#diff-d8979a53b27974e552bc3c24a44d6f6c985aa9b5a91a5517ae7f04676cced796L56-L70) [[3]](diffhunk://#diff-3d5ae56ae818dbb3fab8cb0453a96bdc8051b9697d5d3f0b7b6dfa0e140291ebL289-R255)
* The summary settings transfer logic (`summarySettings`) and related data structures have been removed.

**Other Cleanups:**

* The constant for rows-per-part and related chunking logic have been removed, as all output is written to single files.
* Unused includes (such as `<map>`) have been removed from headers.