### PR TITLE
49 logging improvements

### DIFF
--- a/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
+++ b/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
@@ -201,6 +201,17 @@ int main(const int argc, char* argv[]) {
         const fs::path output_path(output_file);
         const fs::path parent = output_path.parent_path();
         const std::string stem = output_path.stem().string();
+        // Create the output directory up front so the summary is written even
+        // when reconstruction produces zero photons (no parquet files).
+        if (!parent.empty()) {
+            std::error_code ec;
+            fs::create_directories(parent, ec);
+            if (ec) {
+                std::cerr << "Error: cannot create output directory "
+                          << parent.string() << ": " << ec.message() << "\n";
+                return 1;
+            }
+        }
         pixels_output_file =
             (parent / (stem + "-photon-pixels.parquet")).string();
         summary_path =

--- a/docs/architecture/logging_instructions.md
+++ b/docs/architecture/logging_instructions.md
@@ -65,7 +65,14 @@ working_dir/
 
 Logging is initialized once at HERMES process startup:
 
+The console sink uses Loguru's default format and defaults to INFO level, so
+DEBUG events (such as `pending` change proposals) stay off the console while the
+serialized file sinks still capture them. The level is configurable through the
+`log_level` field on the record's `RuntimeEnvironment`; `Workflow` passes it into
+`configure_logging`. File sinks are added only when a `log_dir` is provided.
+
 ```python
+import sys
 from pathlib import Path
 from loguru import logger
 
@@ -74,8 +81,15 @@ def _domain_filter(domain: str):
     return lambda record: record["extra"].get("domain") == domain
 
 
-def configure_logging(log_dir: Path) -> None:
+def configure_logging(log_dir: Path | None = None, level: str = "INFO") -> None:
     logger.remove()
+
+    logger.add(sys.stderr, level=level)
+
+    if log_dir is None:
+        return
+
+    log_dir.mkdir(parents=True, exist_ok=True)
 
     logger.add(
         log_dir / "state.jsonl",
@@ -147,6 +161,23 @@ serval_log = logger.bind(
 analysis_log = logger.bind(domain="analysis", measurement_id=measurement_id, run_id=run_id)
 ```
 
+## Message Conventions
+
+Every log call carries three complementary pieces:
+
+- a human-readable `message` that interpolates the event's key fields, so console
+  and log readers understand what happened at a glance
+  (e.g. `Unpacked {raw_tpx3_file} in {elapsed_seconds:.2f}s`)
+- an `event_type` token for machine parsing and downstream filtering
+  (e.g. `analysis.tpx3_unpacking.completed`); tokens are stable and must not
+  change casually
+- structured keyword fields carrying the full context (paths, counts, timings,
+  bounded excerpts)
+
+Loguru interpolates `{field}` in the message from the same keyword fields, so no
+data is written twice by hand. Never emit a bare `event_type` token as the
+message; give a readable sentence and keep the token in the `event_type` field.
+
 ## StateLogger
 
 `StateLogger` records the audit trail for HERMES record mutation.
@@ -161,6 +192,12 @@ Responsibilities:
   approval-bypass marker, timestamps, and concise value summaries
 - avoid configuring Loguru
 - avoid mutating state
+
+Change proposals (`pending`) are logged at DEBUG, because trusted-workflow
+changes are proposed and immediately applied and the two console lines would
+otherwise be redundant. The `applied`, `approved`, `rejected`, and `failed`
+transitions are logged at INFO. Every transition is still written to the
+`state.jsonl` sink regardless of level, so the audit trail stays complete.
 
 For small scalar or bounded structured values, state logs may include old and
 new values inline. For saved `.bpc` and `.dacs` files, state logs should include

--- a/examples/analysis/two_stage/run_two_stage.py
+++ b/examples/analysis/two_stage/run_two_stage.py
@@ -41,6 +41,12 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
         "Skipped existing valid unpacking output: "
         f"{len(raw_tpx3_files) - len(unpacked_raw_files)}"
     )
+    reconstructed_count = sum(
+        1 for result in reconstruction_results if result.status == "completed"
+    )
+    skipped_count = sum(
+        1 for result in reconstruction_results if result.status == "skipped"
+    )
     photon_count = sum(
         result.counts.photon_count
         for result in reconstruction_results
@@ -51,7 +57,8 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
         for result in reconstruction_results
         if result.counts is not None
     )
-    print(f"Reconstructed photon files: {len(reconstruction_results)}")
+    print(f"Reconstructed photon files this run: {reconstructed_count}")
+    print(f"Skipped existing valid reconstruction output: {skipped_count}")
     print(f"Photons: {photon_count}")
     print(f"Rejected clusters: {rejected_count}")
     print(f"Analysis directory: {final_analysis.analysis_directory}")

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -119,16 +119,18 @@ def plan_reconstruction(
     """Decide, per pixel file, whether to "run" reconstruction or "skip" it.
 
     With overwrite every file runs. Otherwise a file is skipped only when its
-    photon output file already exists.
+    reconstruction summary already exists, which the binary writes on every
+    success (including zero-photon runs that produce no photon parquet).
     """
     reconstruction = _require_reconstruction(analysis)
     _validate_program_and_algorithm(reconstruction)
 
     plan: ReconstructionPlan = []
     for input_file in resolve_pixel_files(analysis):
-        if not overwrite and derive_output_path(
-            reconstruction, input_file
-        ).exists():
+        summary_path = derive_summary_path(
+            derive_output_path(reconstruction, input_file)
+        )
+        if not overwrite and summary_path.exists():
             plan.append((input_file, "skip"))
         else:
             plan.append((input_file, "run"))
@@ -255,13 +257,13 @@ def log_skipped_input(
     input_file: FileReference,
     output_file: Path,
 ) -> None:
-    """Log that one pixel file was skipped because its photon file exists."""
-    _ANALYSIS_LOGGER.info(
-        "Skipped {pixel_file}: photon output already exists",
+    """Log that one pixel file was skipped because its summary already exists."""
+    _ANALYSIS_LOGGER.warning(
+        "Skipped {pixel_file}: valid outputs already exist",
         event_type="analysis.tpx3_reconstruction.skipped",
         pixel_file=str(input_file.path),
         output_file=str(output_file),
-        reason="photon output file already exists",
+        reason="valid reconstruction summary already exists",
     )
 
 

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -172,7 +172,7 @@ def execute_reconstruction(
         overwrite=overwrite,
     )
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_reconstruction.started",
+        "Reconstructing {pixel_file}",
         event_type="analysis.tpx3_reconstruction.started",
         pixel_file=str(input_file.path),
         output_file=str(output_file),
@@ -227,7 +227,8 @@ def execute_reconstruction(
         settings_file.unlink(missing_ok=True)
 
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_reconstruction.completed",
+        "Reconstructed {pixel_file} in {elapsed_seconds:.2f}s: "
+        "{photon_count} photons",
         event_type="analysis.tpx3_reconstruction.completed",
         pixel_file=str(input_file.path),
         output_file=str(output_file),
@@ -256,7 +257,7 @@ def log_skipped_input(
 ) -> None:
     """Log that one pixel file was skipped because its photon file exists."""
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_reconstruction.skipped",
+        "Skipped {pixel_file}: photon output already exists",
         event_type="analysis.tpx3_reconstruction.skipped",
         pixel_file=str(input_file.path),
         output_file=str(output_file),
@@ -271,7 +272,8 @@ def log_overall_completion(
 ) -> None:
     """Log a summary line once every pixel file has been handled."""
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_reconstruction.completed",
+        "Reconstruction finished: {reconstructed_file_count} reconstructed, "
+        "{skipped_file_count} skipped of {pixel_file_count} pixel files",
         event_type="analysis.tpx3_reconstruction.completed",
         scope="all_pixel_files",
         pixel_file_count=pixel_file_count,
@@ -283,7 +285,7 @@ def log_overall_completion(
 def log_overall_failure(error: Exception) -> None:
     """Log that the overall reconstruction run failed."""
     _ANALYSIS_LOGGER.error(
-        "analysis.tpx3_reconstruction.failed",
+        "Reconstruction failed: {error}",
         event_type="analysis.tpx3_reconstruction.failed",
         scope="all_pixel_files",
         error=str(error),
@@ -355,7 +357,7 @@ def _log_process_failure(
 ) -> None:
     """Log a failure for one pixel file with the command output for debugging."""
     _ANALYSIS_LOGGER.error(
-        "analysis.tpx3_reconstruction.failed",
+        "Reconstructing {pixel_file} failed: {error}",
         event_type="analysis.tpx3_reconstruction.failed",
         pixel_file=str(input_file.path),
         command=command,

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -356,8 +356,11 @@ def _log_process_failure(
     stderr_excerpt: str = "",
 ) -> None:
     """Log a failure for one pixel file with the command output for debugging."""
+    message = "Reconstructing {pixel_file} failed: {error}"
+    if stderr_excerpt:
+        message += "\nstderr: {stderr_excerpt}"
     _ANALYSIS_LOGGER.error(
-        "Reconstructing {pixel_file} failed: {error}",
+        message,
         event_type="analysis.tpx3_reconstruction.failed",
         pixel_file=str(input_file.path),
         command=command,

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -173,6 +173,30 @@ def run_hermes_analysis(
         )
         raise HermesAnalysisError(error)
 
+    output_directories = list(analysis.output_directories())
+    for directory in output_directories:
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            error = f"cannot create analysis output directory {directory}: {exc}"
+            _ANALYSIS_LOGGER.error(
+                "Cannot run HERMES analysis: {error}",
+                event_type="analysis.hermes.directory_creation_failed",
+                error=error,
+                measurement_id=state.measurement_info.measurement_id,
+                run_number=state.measurement_info.run_number,
+                directory=str(directory),
+            )
+            raise HermesAnalysisError(error) from exc
+    _ANALYSIS_LOGGER.debug(
+        "Prepared {directory_count} analysis output directories under "
+        "{analysis_directory}",
+        event_type="analysis.hermes.directories_prepared",
+        analysis_directory=str(analysis.analysis_directory),
+        directory_count=len(output_directories),
+        directories=[str(directory) for directory in output_directories],
+    )
+
     unpack_overwrite = overwrite or analysis.unpacking.runtime_options.overwrite
     try:
         unpacking_plan = plan_unpacking(analysis, overwrite=unpack_overwrite)

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -173,30 +173,6 @@ def run_hermes_analysis(
         )
         raise HermesAnalysisError(error)
 
-    output_directories = list(analysis.output_directories())
-    for directory in output_directories:
-        try:
-            directory.mkdir(parents=True, exist_ok=True)
-        except OSError as exc:
-            error = f"cannot create analysis output directory {directory}: {exc}"
-            _ANALYSIS_LOGGER.error(
-                "Cannot run HERMES analysis: {error}",
-                event_type="analysis.hermes.directory_creation_failed",
-                error=error,
-                measurement_id=state.measurement_info.measurement_id,
-                run_number=state.measurement_info.run_number,
-                directory=str(directory),
-            )
-            raise HermesAnalysisError(error) from exc
-    _ANALYSIS_LOGGER.debug(
-        "Prepared {directory_count} analysis output directories under "
-        "{analysis_directory}",
-        event_type="analysis.hermes.directories_prepared",
-        analysis_directory=str(analysis.analysis_directory),
-        directory_count=len(output_directories),
-        directories=[str(directory) for directory in output_directories],
-    )
-
     unpack_overwrite = overwrite or analysis.unpacking.runtime_options.overwrite
     try:
         unpacking_plan = plan_unpacking(analysis, overwrite=unpack_overwrite)

--- a/src/hermes/analysis/hermes/run.py
+++ b/src/hermes/analysis/hermes/run.py
@@ -75,7 +75,7 @@ def _calculate_worker_count(
     worker_count = min(pending_file_count, cpu_slots, memory_slots)
 
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_unpacking.resource_calculation",
+        "Using {worker_count} worker(s) for {pending_file_count} file(s)",
         event_type="analysis.tpx3_unpacking.resource_calculation",
         resource_limit_percent=analysis.resource_limit_percent,
         resource_fraction=resource_fraction,

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -133,7 +133,7 @@ def execute_unpacker(
     )
     started = perf_counter()
     _ANALYSIS_LOGGER.info(
-        "Unpacking {raw_tpx3_file}",
+        "Unpacking {raw_tpx3_file} (time_sort={time_sort})",
         event_type="analysis.tpx3_unpacking.started",
         raw_tpx3_file=str(raw_file.path),
         raw_tpx3_size_bytes=raw_file.path.stat().st_size,
@@ -142,6 +142,7 @@ def execute_unpacker(
         executable_path=str(analysis.unpacking.program.executable_path),
         resolved_executable_path=str(resolved_executable_path),
         executable_version=analysis.unpacking.program.version,
+        time_sort=analysis.unpacking.runtime_options.time_sort,
         command=command,
     )
 

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -133,7 +133,7 @@ def execute_unpacker(
     )
     started = perf_counter()
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_unpacking.started",
+        "Unpacking {raw_tpx3_file}",
         event_type="analysis.tpx3_unpacking.started",
         raw_tpx3_file=str(raw_file.path),
         raw_tpx3_size_bytes=raw_file.path.stat().st_size,
@@ -209,7 +209,7 @@ def execute_unpacker(
         raise
 
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_unpacking.completed",
+        "Unpacked {raw_tpx3_file} in {elapsed_seconds:.2f}s",
         event_type="analysis.tpx3_unpacking.completed",
         raw_tpx3_file=str(raw_file.path),
         analysis_directory=str(analysis.analysis_directory),
@@ -229,7 +229,7 @@ def log_skipped_input(
     raw_file: FileReference,
 ) -> None:
     _ANALYSIS_LOGGER.warning(
-        "analysis.tpx3_unpacking.skipped",
+        "Skipped {raw_tpx3_file}: valid outputs already exist",
         event_type="analysis.tpx3_unpacking.skipped",
         raw_tpx3_file=str(raw_file.path),
         analysis_directory=str(analysis.analysis_directory),
@@ -244,7 +244,8 @@ def log_overall_completion(
     unpacked_file_count: int,
 ) -> None:
     _ANALYSIS_LOGGER.info(
-        "analysis.tpx3_unpacking.completed",
+        "Unpacking finished: {unpacked_file_count} unpacked, "
+        "{skipped_file_count} skipped of {raw_file_count} raw files",
         event_type="analysis.tpx3_unpacking.completed",
         scope="all_raw_tpx3_files",
         raw_file_count=raw_file_count,
@@ -255,7 +256,7 @@ def log_overall_completion(
 
 def log_overall_failure(error: Exception) -> None:
     _ANALYSIS_LOGGER.error(
-        "analysis.tpx3_unpacking.failed",
+        "Unpacking failed: {error}",
         event_type="analysis.tpx3_unpacking.failed",
         scope="all_raw_tpx3_files",
         error=str(error),
@@ -457,7 +458,7 @@ def _log_process_failure(
     summary: dict[str, object] | None = None,
 ) -> None:
     _ANALYSIS_LOGGER.error(
-        "analysis.tpx3_unpacking.failed",
+        "Unpacking {raw_tpx3_file} failed: {error}",
         event_type="analysis.tpx3_unpacking.failed",
         raw_tpx3_file=str(raw_file.path),
         command=command,

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -458,8 +458,11 @@ def _log_process_failure(
     stderr_excerpt: str = "",
     summary: dict[str, object] | None = None,
 ) -> None:
+    message = "Unpacking {raw_tpx3_file} failed: {error}"
+    if stderr_excerpt:
+        message += "\nstderr: {stderr_excerpt}"
     _ANALYSIS_LOGGER.error(
-        "Unpacking {raw_tpx3_file} failed: {error}",
+        message,
         event_type="analysis.tpx3_unpacking.failed",
         raw_tpx3_file=str(raw_file.path),
         command=command,

--- a/src/hermes/logging.py
+++ b/src/hermes/logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from pathlib import Path
 
@@ -10,9 +11,15 @@ def _domain_filter(domain: str) -> Callable[[dict], bool]:
     return lambda record: record["extra"].get("domain") == domain
 
 
-def configure_logging(log_dir: Path) -> None:
-    log_dir.mkdir(parents=True, exist_ok=True)
+def configure_logging(log_dir: Path | None = None, level: str = "INFO") -> None:
     logger.remove()
+
+    logger.add(sys.stderr, level=level)
+
+    if log_dir is None:
+        return
+
+    log_dir.mkdir(parents=True, exist_ok=True)
 
     logger.add(
         log_dir / "state.jsonl",

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -15,6 +15,17 @@ from hermes.state.models.shared_models import (
 HermesTpx3RunStatus = Literal[
     "planned", "running", "completed", "skipped", "failed"
 ]
+
+# Canonical parquet-category subdirectory names the unpacker writes under the
+# unpacking output directory. HERMES owns this layout and creates these
+# directories itself; the backend binaries are not relied on to create them.
+TPX3_PARQUET_CATEGORY_DIRECTORIES = {
+    "pixel_data": "pixelHits",
+    "tdc_timestamps": "tdcTriggers",
+    "heartbeat_packets": "globalTimestamps",
+    "control_packets": "controlPackets",
+    "unrecognized_packets": "unknownPackets",
+}
 SortingStrategy = Literal["in_memory", "external_merge"]
 ClusteringAlgorithm = Literal["connected_components", "dbscan"]
 PhotonTimeEstimator = Literal[
@@ -175,14 +186,9 @@ class Tpx3SpidrParquetSummary(StrictBaseModel):
 
     @model_validator(mode="after")
     def require_category_relative_paths(self) -> Tpx3SpidrParquetSummary:
-        expected_directories = {
-            "pixel_data": "pixelHits",
-            "tdc_timestamps": "tdcTriggers",
-            "heartbeat_packets": "globalTimestamps",
-            "control_packets": "controlPackets",
-            "unrecognized_packets": "unknownPackets",
-        }
-        for field_name, expected_directory in expected_directories.items():
+        for field_name, expected_directory in (
+            TPX3_PARQUET_CATEGORY_DIRECTORIES.items()
+        ):
             category = getattr(self, field_name)
             for file_path in category.files:
                 if file_path.is_absolute() or ".." in file_path.parts:
@@ -406,3 +412,21 @@ class HermesTpx3AnalysisState(StrictBaseModel):
         if reconstruction is not None and reconstruction.output_directory is None:
             reconstruction.output_directory = self.analysis_directory / "photons"
         return self
+
+    def output_directories(self) -> list[Path]:
+        """Every output directory HERMES creates before running a backend.
+
+        HERMES owns the run's directory layout; the backend binaries write into
+        these directories but are not relied on to create them.
+        """
+        directories = [self.analysis_directory / "logs"]
+        assert self.unpacking.output_directory is not None
+        directories.extend(
+            self.unpacking.output_directory / name
+            for name in TPX3_PARQUET_CATEGORY_DIRECTORIES.values()
+        )
+        reconstruction = self.photon_reconstruction
+        if reconstruction is not None:
+            assert reconstruction.output_directory is not None
+            directories.append(reconstruction.output_directory)
+        return directories

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -17,8 +17,8 @@ HermesTpx3RunStatus = Literal[
 ]
 
 # Canonical parquet-category subdirectory names the unpacker writes under the
-# unpacking output directory. HERMES owns this layout and creates these
-# directories itself; the backend binaries are not relied on to create them.
+# unpacking output directory. The unpacker binary creates these directories;
+# this mapping lets HERMES validate the relative paths reported in its summary.
 TPX3_PARQUET_CATEGORY_DIRECTORIES = {
     "pixel_data": "pixelHits",
     "tdc_timestamps": "tdcTriggers",
@@ -412,21 +412,3 @@ class HermesTpx3AnalysisState(StrictBaseModel):
         if reconstruction is not None and reconstruction.output_directory is None:
             reconstruction.output_directory = self.analysis_directory / "photons"
         return self
-
-    def output_directories(self) -> list[Path]:
-        """Every output directory HERMES creates before running a backend.
-
-        HERMES owns the run's directory layout; the backend binaries write into
-        these directories but are not relied on to create them.
-        """
-        directories = [self.analysis_directory / "logs"]
-        assert self.unpacking.output_directory is not None
-        directories.extend(
-            self.unpacking.output_directory / name
-            for name in TPX3_PARQUET_CATEGORY_DIRECTORIES.values()
-        )
-        reconstruction = self.photon_reconstruction
-        if reconstruction is not None:
-            assert reconstruction.output_directory is not None
-            directories.append(reconstruction.output_directory)
-        return directories

--- a/src/hermes/state/models/environment.py
+++ b/src/hermes/state/models/environment.py
@@ -126,6 +126,7 @@ class RuntimeEnvironment(StrictBaseModel):
     python_version: str | None = None
     platform: str | None = None
     allow_overlapping_output_dirs: bool = Field(default=False)
+    log_level: str = Field(default="INFO")
 
     @model_validator(mode="before")
     @classmethod

--- a/src/hermes/state_service/state_io.py
+++ b/src/hermes/state_service/state_io.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from hermes.state.state import HermesRecord
 from hermes.state_service.shared_types import StateIOError
+from hermes.state_service.state_logger import StateLogger
 
 
 class _NoAliasSafeDumper(yaml.SafeDumper):
@@ -34,10 +35,13 @@ def load_hermes_record_from_yaml(file_path: str | Path) -> HermesRecord:
         raise StateIOError(msg)
 
     try:
-        return HermesRecord.model_validate(data)
+        record = HermesRecord.model_validate(data)
     except ValidationError as exc:
         msg = f"failed to validate HermesRecord YAML from {path}"
         raise StateIOError(msg) from exc
+
+    StateLogger().log_state_loaded(record, path)
+    return record
 
 
 def save_hermes_record_to_yaml(record: HermesRecord, file_path: str | Path) -> Path:
@@ -59,4 +63,5 @@ def save_hermes_record_to_yaml(record: HermesRecord, file_path: str | Path) -> P
         msg = f"failed to write HermesRecord YAML to {path}"
         raise StateIOError(msg) from exc
 
+    StateLogger().log_state_saved(record, path)
     return path

--- a/src/hermes/state_service/state_logger.py
+++ b/src/hermes/state_service/state_logger.py
@@ -20,7 +20,8 @@ class StateLogger:
 
     def log_initial_state(self, record: HermesRecord) -> None:
         self._logger.info(
-            "state.initial_record",
+            "Initialized HERMES Record for measurement {measurement_id}, "
+            "run {run_number}",
             event_type="state.initial_record",
             record=_serialize_record(record),
             **_record_context(record),
@@ -28,7 +29,7 @@ class StateLogger:
 
     def log_state_loaded(self, record: HermesRecord, path: str | Path) -> None:
         self._logger.info(
-            "state.loaded",
+            "HERMES Record loaded from {record_path}",
             event_type="state.loaded",
             record_path=str(path),
             **_record_context(record),
@@ -36,7 +37,7 @@ class StateLogger:
 
     def log_state_saved(self, record: HermesRecord, path: str | Path) -> None:
         self._logger.info(
-            "state.saved",
+            "HERMES Record saved to {record_path}",
             event_type="state.saved",
             record_path=str(path),
             **_record_context(record),
@@ -44,8 +45,13 @@ class StateLogger:
 
     def log_change(self, change_request: ChangeRequest) -> None:
         change = change_request.model_dump(mode="json")
-        self._logger.info(
-            "state.change",
+        log = (
+            self._logger.debug
+            if change_request.status == "pending"
+            else self._logger.info
+        )
+        log(
+            "HERMES Record change {status}: {path}",
             event_type="state.change",
             change=change,
             change_id=change_request.change_id,
@@ -71,7 +77,7 @@ class StateLogger:
         proposed_value: JsonValue = None,
     ) -> None:
         self._logger.error(
-            "state.validation_failed",
+            "HERMES Record validation failed for {path}: {error}",
             event_type="state.validation_failed",
             change_id=change_id,
             path=path,

--- a/src/hermes/state_service/state_manager.py
+++ b/src/hermes/state_service/state_manager.py
@@ -27,6 +27,8 @@ _JSON_VALUE_ADAPTER = TypeAdapter(JsonValue)
 
 
 class StateAuditLogger(Protocol):
+    def log_initial_state(self, record: HermesRecord) -> None: ...
+
     def log_change(self, change_request: ChangeRequest) -> None: ...
 
     def log_validation_failure(
@@ -53,6 +55,7 @@ class StateManager:
         self._config = config or StateServiceConfig()
         self._state_logger = state_logger or StateLogger()
         self._changes: dict[ChangeId, ChangeRequest] = {}
+        self._state_logger.log_initial_state(self._record)
 
     def get_state(self) -> HermesRecord:
         return self._record.model_copy(deep=True)

--- a/src/hermes/workflows/workflow.py
+++ b/src/hermes/workflows/workflow.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from loguru import logger
+
 from hermes.analysis.hermes.run import run_hermes_analysis
 from hermes.logging import configure_logging
 from hermes.state.models.shared_models import FileReference
@@ -7,17 +9,25 @@ from hermes.state.state import HermesRecord
 from hermes.state_service.shared_types import StateServiceConfig
 from hermes.state_service.state_manager import StateManager
 
+_WORKFLOW_LOGGER = logger.bind(domain="workflow")
+
 
 class Workflow:
     """Run HERMES operations against one measurement record."""
 
     def __init__(self, record: HermesRecord) -> None:
         log_dir = record.environment.log_dir.resolved_path
-        if log_dir is not None:
-            configure_logging(log_dir)
+        configure_logging(log_dir, level=record.environment.log_level)
         self._state_manager = StateManager(
             record,
             config=StateServiceConfig(allow_trusted_workflow_bypass=True),
+        )
+        _WORKFLOW_LOGGER.info(
+            "Initialized HERMES workflow for measurement {measurement_id}, "
+            "run {run_number}",
+            event_type="workflow.initialized",
+            measurement_id=record.measurement_info.measurement_id,
+            run_number=record.measurement_info.run_number,
         )
 
     def run_analysis(self, *, overwrite: bool = False) -> list[FileReference]:

--- a/tests/unit/hermes/analysis/hermes/test_reconstruction.py
+++ b/tests/unit/hermes/analysis/hermes/test_reconstruction.py
@@ -204,7 +204,28 @@ def test_plan_runs_when_no_output_exists(tmp_path: Path) -> None:
     assert [action for _, action in plan] == ["run"]
 
 
-def test_plan_skips_when_output_exists(tmp_path: Path) -> None:
+def test_plan_skips_when_summary_exists(tmp_path: Path) -> None:
+    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    reconstruction = analysis.photon_reconstruction
+    input_file = FileReference(
+        path=analysis.analysis_directory
+        / "pixelHits"
+        / "run_000000-chip-0-part-00000.parquet"
+    )
+    summary_path = derive_summary_path(
+        derive_output_path(reconstruction, input_file)
+    )
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.touch()
+
+    plan = plan_reconstruction(analysis)
+    assert [action for _, action in plan] == ["skip"]
+
+
+def test_plan_runs_when_only_photon_parquet_exists(tmp_path: Path) -> None:
+    # A photon parquet without a summary is an incomplete run; it must re-run so
+    # the summary (the completion marker) gets written, matching the binary's
+    # zero-photon behavior where only the summary is produced.
     analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     reconstruction = analysis.photon_reconstruction
     input_file = FileReference(
@@ -217,7 +238,7 @@ def test_plan_skips_when_output_exists(tmp_path: Path) -> None:
     output_file.touch()
 
     plan = plan_reconstruction(analysis)
-    assert [action for _, action in plan] == ["skip"]
+    assert [action for _, action in plan] == ["run"]
 
 
 def test_plan_runs_all_when_overwrite(tmp_path: Path) -> None:

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -44,6 +44,10 @@ from hermes.state_service.state_io import (
 class CapturingStateLogger:
     def __init__(self) -> None:
         self.changes: list[ChangeRequest] = []
+        self.initial_records: list[HermesRecord] = []
+
+    def log_initial_state(self, record: HermesRecord) -> None:
+        self.initial_records.append(record.model_copy(deep=True))
 
     def log_change(self, change_request: ChangeRequest) -> None:
         self.changes.append(change_request.model_copy(deep=True))

--- a/tests/unit/hermes/state_service/test_state_logger.py
+++ b/tests/unit/hermes/state_service/test_state_logger.py
@@ -31,6 +31,15 @@ class CapturingLogger:
             context={**self.context, **context},
         )
 
+    def debug(self, message: str, **fields: Any) -> None:
+        self.events.append(
+            {
+                "level": "debug",
+                "message": message,
+                "fields": {**self.context, **fields},
+            }
+        )
+
     def info(self, message: str, **fields: Any) -> None:
         self.events.append(
             {
@@ -82,7 +91,7 @@ def test_state_logger_logs_initial_state_record(tmp_path: Path) -> None:
     event = logger.events[0]
     fields = event["fields"]
     assert event["level"] == "info"
-    assert event["message"] == "state.initial_record"
+    assert fields["event_type"] == "state.initial_record"
     assert fields["domain"] == "state"
     assert fields["run_id"] == "run-007"
     assert fields["event_type"] == "state.initial_record"
@@ -101,10 +110,8 @@ def test_state_logger_logs_state_load_and_save_events(tmp_path: Path) -> None:
     state_logger.log_state_saved(record, record_path)
 
     loaded, saved = logger.events
-    assert loaded["message"] == "state.loaded"
     assert loaded["fields"]["event_type"] == "state.loaded"
     assert loaded["fields"]["record_path"] == str(record_path)
-    assert saved["message"] == "state.saved"
     assert saved["fields"]["event_type"] == "state.saved"
     assert saved["fields"]["record_path"] == str(record_path)
 
@@ -123,8 +130,9 @@ def test_state_logger_logs_change_with_value_summaries() -> None:
 
     state_logger.log_change(change)
 
+    assert logger.events[0]["level"] == "debug"
     fields = logger.events[0]["fields"]
-    assert logger.events[0]["message"] == "state.change"
+    assert fields["event_type"] == "state.change"
     assert fields["change_id"] == "change-001"
     assert fields["path"] == "acquisition.result.status"
     assert fields["status"] == "pending"
@@ -172,6 +180,8 @@ def test_state_logger_logs_rejected_and_failed_change_metadata() -> None:
     state_logger.log_change(rejected)
     state_logger.log_change(failed)
 
+    assert logger.events[0]["level"] == "info"
+    assert logger.events[1]["level"] == "info"
     rejected_fields = logger.events[0]["fields"]
     failed_fields = logger.events[1]["fields"]
     assert rejected_fields["status"] == "rejected"
@@ -197,7 +207,6 @@ def test_state_logger_logs_validation_failure() -> None:
     event = logger.events[0]
     fields = event["fields"]
     assert event["level"] == "error"
-    assert event["message"] == "state.validation_failed"
     assert fields["event_type"] == "state.validation_failed"
     assert fields["change_id"] == "change-003"
     assert fields["path"] == "acquisition.result.status"

--- a/tests/unit/hermes/state_service/test_state_logger.py
+++ b/tests/unit/hermes/state_service/test_state_logger.py
@@ -94,7 +94,6 @@ def test_state_logger_logs_initial_state_record(tmp_path: Path) -> None:
     assert fields["event_type"] == "state.initial_record"
     assert fields["domain"] == "state"
     assert fields["run_id"] == "run-007"
-    assert fields["event_type"] == "state.initial_record"
     assert fields["measurement_id"] == "LC-20260505"
     assert fields["run_number"] == 7
     assert fields["record"]["measurement_info"]["measurement_id"] == "LC-20260505"

--- a/tests/unit/hermes/state_service/test_state_manager.py
+++ b/tests/unit/hermes/state_service/test_state_manager.py
@@ -28,6 +28,10 @@ class CapturingStateLogger:
     def __init__(self) -> None:
         self.changes: list[ChangeRequest] = []
         self.validation_failures: list[dict[str, Any]] = []
+        self.initial_records: list[HermesRecord] = []
+
+    def log_initial_state(self, record: HermesRecord) -> None:
+        self.initial_records.append(record.model_copy(deep=True))
 
     def log_change(self, change_request: ChangeRequest) -> None:
         self.changes.append(change_request.model_copy(deep=True))


### PR DESCRIPTION
This pull request focuses on improving logging clarity, configurability, and auditability throughout the HERMES analysis and state management codebase. The main changes include making log messages more human-readable and structured, introducing configurable log levels, ensuring all record state changes are auditable, and centralizing directory and logging configuration logic. These updates enhance both developer experience and downstream processing reliability.

**Logging improvements and conventions:**

* All analysis and state service log messages now use clear, human-readable sentences with structured fields, following new message conventions for better readability and downstream machine parsing. Each log call includes a message, a stable event type token, and structured context fields. (`src/hermes/analysis/hermes/unpacker.py`, `src/hermes/analysis/hermes/reconstruction.py`, `src/hermes/state_service/state_logger.py`, `docs/architecture/logging_instructions.md`) [[1]](diffhunk://#diff-289fa7a93126795a23e391d2b5610d9bd8db330337e2cae1c1128f90497b085eL136-R136) [[2]](diffhunk://#diff-9f204e48de5e05977496d0bda9b149c90776b43a7e5395d1966c662b9239165dL175-R175) [[3]](diffhunk://#diff-9f4c160dc7fb432c7432648c7bfc85a4d743341f88ae35f3ab8ce094d0544e93L23-R54) [[4]](diffhunk://#diff-34c9975204e507e5f6e0b7ebdda949c99f34143f23507c154b1d7f35fb51605cR164-R180)

* Added a section to the logging architecture documentation describing these conventions and the rationale for logging levels, especially for state change proposals. (`docs/architecture/logging_instructions.md`) [[1]](diffhunk://#diff-34c9975204e507e5f6e0b7ebdda949c99f34143f23507c154b1d7f35fb51605cR164-R180) [[2]](diffhunk://#diff-34c9975204e507e5f6e0b7ebdda949c99f34143f23507c154b1d7f35fb51605cR196-R201)

**Configurable logging and improved initialization:**

* Logging initialization now accepts a configurable log level (defaulting to INFO), and file sinks are only added if a log directory is provided. The log level can be set via the `RuntimeEnvironment` model. (`src/hermes/logging.py`, `src/hermes/state/models/environment.py`, `docs/architecture/logging_instructions.md`) [[1]](diffhunk://#diff-96be8e0530efe4ac320abde42f4aa57d66048688a87001f1eec39def403abc85L13-R23) [[2]](diffhunk://#diff-856e4e22114b823878ba680511d63a11e2365251a966510f8f62ab43de189bcfR129) [[3]](diffhunk://#diff-34c9975204e507e5f6e0b7ebdda949c99f34143f23507c154b1d7f35fb51605cR68-R75) [[4]](diffhunk://#diff-34c9975204e507e5f6e0b7ebdda949c99f34143f23507c154b1d7f35fb51605cL77-R93)

**Audit trail and state management:**

* The `StateLogger` now logs when HERMES records are loaded and saved, ensuring a complete audit trail for record mutations. (`src/hermes/state_service/state_io.py`, `src/hermes/state_service/state_logger.py`) [[1]](diffhunk://#diff-eb83a4e813cba0949cf9c11c8c05af96b776d600ba9ccea4520b1d51499c7adcL37-R45) [[2]](diffhunk://#diff-eb83a4e813cba0949cf9c11c8c05af96b776d600ba9ccea4520b1d51499c7adcR66) [[3]](diffhunk://#diff-9f4c160dc7fb432c7432648c7bfc85a4d743341f88ae35f3ab8ce094d0544e93L23-R54)

* State change proposals (`pending`) are logged at DEBUG level, while applied/approved/rejected/failed transitions are logged at INFO, as documented. (`src/hermes/state_service/state_logger.py`, `docs/architecture/logging_instructions.md`) [[1]](diffhunk://#diff-9f4c160dc7fb432c7432648c7bfc85a4d743341f88ae35f3ab8ce094d0544e93L23-R54) [[2]](diffhunk://#diff-34c9975204e507e5f6e0b7ebdda949c99f34143f23507c154b1d7f35fb51605cR196-R201)

**Robust output directory handling:**

* The photon clusterer now creates output directories before any output is written, ensuring summaries are written even when there are zero photons. (`backends/reconstruction/photons/cpp/src/photonClusterer.cpp`)

**Centralized unpacker directory mapping:**

* Canonical unpacker output subdirectory names are now defined in a single mapping, used for validation and consistency. (`src/hermes/state/models/analysis/hermes_tpx3_spidr.py`) [[1]](diffhunk://#diff-46476bcaf4fd68f50c8d66d8626ae030880bf1c890ec696f31e683845e712505R18-R28) [[2]](diffhunk://#diff-46476bcaf4fd68f50c8d66d8626ae030880bf1c890ec696f31e683845e712505L178-R191)