### PR TITLE
52 improve logging

### DIFF
--- a/src/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
+++ b/src/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
@@ -53,8 +53,11 @@ void printHelp(const char* program_name) {
     std::cout << "  Without --output:\n";
     std::cout << "    Prints summary counts only; writes no files.\n\n";
     std::cout << "  With --output:\n";
-    std::cout << "    Writes one photon file at the given path, a photon_pixels\n";
-    std::cout << "    sidecar when enabled, and a reconstruction-summary JSON.\n";
+    std::cout << "    Writes one photon file at the given path and a "
+                 "photon_pixels\n";
+    std::cout << "    sidecar when enabled. The reconstruction-summary JSON is "
+                 "written\n";
+    std::cout << "    to a logs/ directory beside the output directory.\n";
 }
 
 void printVersion() {
@@ -201,21 +204,28 @@ int main(const int argc, char* argv[]) {
         const fs::path output_path(output_file);
         const fs::path parent = output_path.parent_path();
         const std::string stem = output_path.stem().string();
-        // Create the output directory up front so the summary is written even
-        // when reconstruction produces zero photons (no parquet files).
-        if (!parent.empty()) {
+        // The summary is a log artifact: it goes in a logs/ directory beside the
+        // photon output directory (matching the unpacker), while the photon file
+        // and its photon_pixels sidecar stay at the output path. Both directories
+        // are created up front so the summary is written even when reconstruction
+        // produces zero photons (no parquet files).
+        const fs::path logs_dir = parent.parent_path() / "logs";
+        for (const fs::path& directory : {parent, logs_dir}) {
+            if (directory.empty()) {
+                continue;
+            }
             std::error_code ec;
-            fs::create_directories(parent, ec);
+            fs::create_directories(directory, ec);
             if (ec) {
-                std::cerr << "Error: cannot create output directory "
-                          << parent.string() << ": " << ec.message() << "\n";
+                std::cerr << "Error: cannot create directory "
+                          << directory.string() << ": " << ec.message() << "\n";
                 return 1;
             }
         }
         pixels_output_file =
             (parent / (stem + "-photon-pixels.parquet")).string();
         summary_path =
-            (parent / (stem + "-reconstruction-summary.json")).string();
+            (logs_dir / (stem + "-reconstruction-summary.json")).string();
     }
 
     const auto total_start = Clock::now();

--- a/src/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
+++ b/src/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
@@ -57,7 +57,8 @@ void printHelp(const char* program_name) {
                  "photon_pixels\n";
     std::cout << "    sidecar when enabled. The reconstruction-summary JSON is "
                  "written\n";
-    std::cout << "    to a logs/ directory beside the output directory.\n";
+    std::cout << "    to a logs/photons/ directory beside the output "
+                 "directory.\n";
 }
 
 void printVersion() {
@@ -204,12 +205,13 @@ int main(const int argc, char* argv[]) {
         const fs::path output_path(output_file);
         const fs::path parent = output_path.parent_path();
         const std::string stem = output_path.stem().string();
-        // The summary is a log artifact: it goes in a logs/ directory beside the
-        // photon output directory (matching the unpacker), while the photon file
-        // and its photon_pixels sidecar stay at the output path. Both directories
-        // are created up front so the summary is written even when reconstruction
-        // produces zero photons (no parquet files).
-        const fs::path logs_dir = parent.parent_path() / "logs";
+        // The summary is a log artifact: it goes in a logs/photons/ directory
+        // beside the photon output directory (the unpacker writes to
+        // logs/unpacker/), while the photon file and its photon_pixels sidecar
+        // stay at the output path. Both directories are created up front so the
+        // summary is written even when reconstruction produces zero photons (no
+        // parquet files).
+        const fs::path logs_dir = parent.parent_path() / "logs" / "photons";
         for (const fs::path& directory : {parent, logs_dir}) {
             if (directory.empty()) {
                 continue;

--- a/src/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
@@ -31,7 +31,7 @@ void printHelp(const char* program_name) {
     std::cout << "      - globalTimestamps/   Global timestamp anchors\n";
     std::cout << "      - controlPackets/     Control packets\n";
     std::cout << "      - unknownPackets/     Unknown packets\n";
-    std::cout << "      - logs/               Input-specific summary JSON\n\n";
+    std::cout << "      - logs/unpacker/      Input-specific summary JSON\n\n";
     std::cout << "Examples:\n";
     std::cout << "  # Print summary only\n";
     std::cout << "  " << program_name << " --input data.tpx3\n\n";

--- a/src/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
@@ -285,7 +285,7 @@ constexpr std::array<const char*, 6> analysis_directories = {
     "globalTimestamps",
     "controlPackets",
     "unknownPackets",
-    "logs",
+    "logs/unpacker",
 };
 
 constexpr std::array<const char*, 5> parquet_directories = {
@@ -506,7 +506,7 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
     }
 
     const std::string summary_json_file =
-        "logs/" + raw_file_stem + "-unpacker-summary.json";
+        "logs/unpacker/" + raw_file_stem + "-unpacker-summary.json";
     const auto summary_path = std::filesystem::path(analysis_directory) /
                               summary_json_file;
 

--- a/src/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
@@ -66,12 +66,12 @@ void testWorkflowWithEmptyInput(TestContext& test) {
 
     for (const auto* directory : {"pixelHits", "tdcTriggers",
                                   "globalTimestamps", "controlPackets",
-                                  "unknownPackets", "logs"}) {
+                                  "unknownPackets", "logs/unpacker"}) {
         test.expect(std::filesystem::is_directory(analysis_directory / directory),
                     std::string("created shared directory ") + directory);
     }
     test.expect(std::filesystem::exists(
-                    analysis_directory / "logs/empty-unpacker-summary.json"),
+                    analysis_directory / "logs/unpacker/empty-unpacker-summary.json"),
                 "empty-input summary JSON written");
     test.expectEqual(result.summary.writer_diagnostics.pixel_hits.row_count,
                      std::uint64_t{0}, "empty pixel row count recorded");
@@ -105,9 +105,9 @@ void testSharedDirectoriesForTwoInputs(TestContext& test) {
     const auto second_parquet = analysis_directory /
         "pixelHits/DT_2p0V_000001-chip-0-part-00000.parquet";
     const auto first_summary = analysis_directory /
-        "logs/DT_2p0V_000000-unpacker-summary.json";
+        "logs/unpacker/DT_2p0V_000000-unpacker-summary.json";
     const auto second_summary = analysis_directory /
-        "logs/DT_2p0V_000001-unpacker-summary.json";
+        "logs/unpacker/DT_2p0V_000001-unpacker-summary.json";
 
     test.expect(std::filesystem::exists(first_parquet),
                 "first input-prefixed Parquet file exists");
@@ -154,7 +154,7 @@ void testExistingFilesAreNotOverwritten(TestContext& test) {
                 "existing summary reports an error");
 
     const auto summary_path =
-        analysis_directory / "logs/repeated-unpacker-summary.json";
+        analysis_directory / "logs/unpacker/repeated-unpacker-summary.json";
     std::filesystem::remove(summary_path);
 
     const auto parquet_path = analysis_directory /

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -86,11 +86,11 @@ def derive_output_path(
 def derive_summary_path(output_file: Path) -> Path:
     """Return the reconstruction-summary sidecar the binary writes.
 
-    The binary writes the summary to a ``logs`` directory beside the photon
-    output directory, so it is a log artifact rather than sitting next to the
-    photon files themselves.
+    The binary writes the summary to a ``logs/photons`` directory beside the
+    photon output directory (the unpacker writes to ``logs/unpacker``), so it is
+    a log artifact rather than sitting next to the photon files themselves.
     """
-    logs_directory = output_file.parent.parent / "logs"
+    logs_directory = output_file.parent.parent / "logs" / "photons"
     return logs_directory / f"{output_file.stem}-reconstruction-summary.json"
 
 

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -84,8 +84,14 @@ def derive_output_path(
 
 
 def derive_summary_path(output_file: Path) -> Path:
-    """Return the reconstruction-summary sidecar the binary writes."""
-    return output_file.parent / f"{output_file.stem}-reconstruction-summary.json"
+    """Return the reconstruction-summary sidecar the binary writes.
+
+    The binary writes the summary to a ``logs`` directory beside the photon
+    output directory, so it is a log artifact rather than sitting next to the
+    photon files themselves.
+    """
+    logs_directory = output_file.parent.parent / "logs"
+    return logs_directory / f"{output_file.stem}-reconstruction-summary.json"
 
 
 def derive_reconstruction_command(

--- a/src/hermes/analysis/hermes/reconstruction.py
+++ b/src/hermes/analysis/hermes/reconstruction.py
@@ -84,7 +84,7 @@ def derive_output_path(
 
 
 def derive_summary_path(output_file: Path) -> Path:
-    """Return the reconstruction-summary sidecar the binary writes.
+    """Return the reconstruction-summary JSON file path written by the binary.
 
     The binary writes the summary to a ``logs/photons`` directory beside the
     photon output directory (the unpacker writes to ``logs/unpacker``), so it is

--- a/src/hermes/analysis/hermes/unpacker.py
+++ b/src/hermes/analysis/hermes/unpacker.py
@@ -58,6 +58,7 @@ def derive_summary_path(
     return (
         analysis.analysis_directory
         / "logs"
+        / "unpacker"
         / f"{raw_file.path.stem}-unpacker-summary.json"
     )
 

--- a/tests/unit/hermes/analysis/hermes/test_reconstruction.py
+++ b/tests/unit/hermes/analysis/hermes/test_reconstruction.py
@@ -182,8 +182,10 @@ def _write_fake_clusterer(
         if write_summary:
             output_file.parent.mkdir(parents=True, exist_ok=True)
             output_file.write_bytes(b"")
+            logs_directory = output_file.parent.parent / "logs"
+            logs_directory.mkdir(parents=True, exist_ok=True)
             summary_path = (
-                output_file.parent
+                logs_directory
                 / (output_file.stem + "-reconstruction-summary.json")
             )
             summary_path.write_text({summary_literal!r})

--- a/tests/unit/hermes/analysis/hermes/test_reconstruction.py
+++ b/tests/unit/hermes/analysis/hermes/test_reconstruction.py
@@ -182,7 +182,7 @@ def _write_fake_clusterer(
         if write_summary:
             output_file.parent.mkdir(parents=True, exist_ok=True)
             output_file.write_bytes(b"")
-            logs_directory = output_file.parent.parent / "logs"
+            logs_directory = output_file.parent.parent / "logs" / "photons"
             logs_directory.mkdir(parents=True, exist_ok=True)
             summary_path = (
                 logs_directory
@@ -479,7 +479,7 @@ def _write_fake_unpacker(executable: Path) -> None:
                 }},
             }},
         }}
-        logs = analysis_dir / "logs"
+        logs = analysis_dir / "logs" / "unpacker"
         logs.mkdir(parents=True, exist_ok=True)
         (logs / (stem + "-unpacker-summary.json")).write_text(json.dumps(summary))
         sys.exit(0)

--- a/tests/unit/hermes/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/analysis/hermes/test_unpacker.py
@@ -215,6 +215,7 @@ def _write_fake_unpacker(executable: Path) -> None:
         summary_path = (
             analysis_directory
             / "logs"
+            / "unpacker"
             / f"{{raw_stem}}-unpacker-summary.json"
         )
         summary_path.parent.mkdir(parents=True, exist_ok=True)
@@ -337,7 +338,7 @@ def test_derives_command_and_input_specific_summary_path(tmp_path: Path) -> None
         str(analysis.unpacking.output_directory),
     ]
     assert derive_summary_path(analysis, raw_file) == (
-        analysis.analysis_directory / "logs/first-unpacker-summary.json"
+        analysis.analysis_directory / "logs/unpacker/first-unpacker-summary.json"
     )
 
 
@@ -891,7 +892,9 @@ def test_parallel_unpacking_one_failure_stops_remaining_work(tmp_path: Path) -> 
     assert results
     assert all(result.status == "failed" for result in results)
 
-    summary_files = list((analysis.analysis_directory / "logs").glob("*.json"))
+    summary_files = list(
+        (analysis.analysis_directory / "logs" / "unpacker").glob("*.json")
+    )
     completed_count = len(summary_files)
     assert completed_count < 4
 


### PR DESCRIPTION
This pull request reorganizes where summary JSON files are written for both the photon reconstruction and unpacker workflows, moving them from a generic `logs/` directory to more specific subdirectories: `logs/photons/` for reconstruction summaries and `logs/unpacker/` for unpacker summaries. The changes update both the C++ and Python codebases, as well as the associated tests and documentation, to consistently use these new locations.

**Directory structure and file output changes:**

* Photon reconstruction summary files are now written to `logs/photons/` beside the output directory, rather than directly next to the photon files. This affects both the C++ binary (`photonClusterer.cpp`) and the Python wrapper/utilities (`hermes/reconstruction.py`). [[1]](diffhunk://#diff-55a030ca33e850803192f431357fc6c49f397ea1b25c2e24efb9b804c7ca5176L204-R230) [[2]](diffhunk://#diff-9f204e48de5e05977496d0bda9b149c90776b43a7e5395d1966c662b9239165dL87-R94) [[3]](diffhunk://#diff-3d3b5b7c0ffd1a48e1e1ad41c6429ae79c3f3fc21ea89e4b9315353c71b7e753R185-R188)
* Unpacker summary files are now written to `logs/unpacker/` instead of `logs/`. This change is reflected in the C++ unpacker implementation, Python utilities, and all related tests. [[1]](diffhunk://#diff-e9c41e8353c82bde320f73155dbca78325419b575d464596b8a4c38c4e3385b2L288-R288) [[2]](diffhunk://#diff-e9c41e8353c82bde320f73155dbca78325419b575d464596b8a4c38c4e3385b2L509-R509) [[3]](diffhunk://#diff-289fa7a93126795a23e391d2b5610d9bd8db330337e2cae1c1128f90497b085eR61) [[4]](diffhunk://#diff-3d3b5b7c0ffd1a48e1e1ad41c6429ae79c3f3fc21ea89e4b9315353c71b7e753L480-R482) [[5]](diffhunk://#diff-46b0f9c75014705cd96196f20d291b57da71de44a8c6dea8af203648fdcc21d4R218) [[6]](diffhunk://#diff-46b0f9c75014705cd96196f20d291b57da71de44a8c6dea8af203648fdcc21d4L340-R341) [[7]](diffhunk://#diff-46b0f9c75014705cd96196f20d291b57da71de44a8c6dea8af203648fdcc21d4L894-R897)

**Documentation and help output updates:**

* Updated help messages in both C++ binaries to explain the new summary file locations, ensuring users are aware of where to find the output artifacts. [[1]](diffhunk://#diff-55a030ca33e850803192f431357fc6c49f397ea1b25c2e24efb9b804c7ca5176L56-R61) [[2]](diffhunk://#diff-2b7896f2a53139b14418701eb3706ae7aebc47701f1349dadaa3530310d04149L34-R34)

**Test updates:**

* All affected tests now expect summary files in the new subdirectories, ensuring test coverage matches the updated behavior. [[1]](diffhunk://#diff-e336ead533458be69bfcfde8e1e1979cefce9090a9cad7e877d24f7163694c79L69-R74) [[2]](diffhunk://#diff-e336ead533458be69bfcfde8e1e1979cefce9090a9cad7e877d24f7163694c79L108-R110) [[3]](diffhunk://#diff-e336ead533458be69bfcfde8e1e1979cefce9090a9cad7e877d24f7163694c79L157-R157) [[4]](diffhunk://#diff-3d3b5b7c0ffd1a48e1e1ad41c6429ae79c3f3fc21ea89e4b9315353c71b7e753R185-R188) [[5]](diffhunk://#diff-3d3b5b7c0ffd1a48e1e1ad41c6429ae79c3f3fc21ea89e4b9315353c71b7e753L480-R482) [[6]](diffhunk://#diff-46b0f9c75014705cd96196f20d291b57da71de44a8c6dea8af203648fdcc21d4L340-R341) [[7]](diffhunk://#diff-46b0f9c75014705cd96196f20d291b57da71de44a8c6dea8af203648fdcc21d4L894-R897)

**Directory creation logic:**

* Both binaries now ensure the new log directories (`logs/photons/` and `logs/unpacker/`) are created before writing summary files, even if no data is processed. [[1]](diffhunk://#diff-55a030ca33e850803192f431357fc6c49f397ea1b25c2e24efb9b804c7ca5176L204-R230) [[2]](diffhunk://#diff-e9c41e8353c82bde320f73155dbca78325419b575d464596b8a4c38c4e3385b2L288-R288)

These changes improve organization and clarity by separating log artifacts from primary output files, making it easier to manage and locate summary information.