### PR TITLE
61 empir integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,10 @@ __pycache__/
 *.tiff
 *.tif
 
+# ignore any EMPIR intermediate files
+*.empirphot
+*.empirevent
+
 # ignore all .o files
 *.o
 

--- a/docs/architecture/analysis.md
+++ b/docs/architecture/analysis.md
@@ -106,36 +106,39 @@ EMPIR binaries and remains `mode="empir"`.
 
 ## Analysis Entry Point
 
-`Workflow.run_analysis` is the entry point for analysis. It calls
-`run_hermes_analysis(state_manager)` directly. There is no separate
-`src/hermes/runner/analysis/run.py` dispatcher, because HERMES is the only analysis
-mode with a runner today.
-
-`run_hermes_analysis` reads the selected Pydantic model from `StateManager` and
-guards on its type before doing any work:
+`Workflow.run_analysis` is the entry point for analysis. It calls the dispatcher
+in `src/hermes/runner/analysis/run.py`, which reads the selected Pydantic model
+from `StateManager` and sends it to the matching runner:
 
 ```python
-def run_hermes_analysis(state_manager: StateManager) -> HermesRecord:
+def run_analysis(state_manager, *, overwrite=False):
     analysis = state_manager.get_state().analysis
 
     if isinstance(analysis, EmpirAnalysisState):
-        message = "EMPIR analysis is not implemented yet"
-        logger.error(message)
-        raise HermesAnalysisError(message)
-    if not isinstance(analysis, HermesTpx3AnalysisState):
-        message = "no valid HERMES analysis is configured"
-        logger.error(message)
-        raise HermesAnalysisError(message)
+        return run_empir_analysis(state_manager)
+    if isinstance(analysis, HermesTpx3AnalysisState):
+        return run_hermes_analysis(state_manager, overwrite=overwrite)
 
-    ...
-
-    return state_manager.get_state()
+    raise AnalysisModeError("no valid analysis mode is configured")
 ```
 
-The entry point does not accept a mode argument. This prevents a function
-argument or CLI option from disagreeing with `analysis.mode` in the HERMES state
-file. When an EMPIR runner exists, its guard can dispatch to it instead of
-raising.
+The entry point selects the mode from `analysis.mode` in the saved record, not
+from a function argument or CLI option, so the two cannot disagree. HERMES
+analysis honors `overwrite`; EMPIR has no overwrite behavior, and its preflight
+rejects an output that already exists. EMPIR and HERMES steps are never mixed:
+each runner handles one complete mode.
+
+## Timing Comparison
+
+Both runners measure each program with a monotonic clock and write
+`elapsed_seconds` to `analysis.jsonl`. This is end-to-end process wall time,
+including startup and file I/O, which is the useful measure for the file-based
+design.
+
+When comparing EMPIR with HERMES, compare EMPIR pixel-to-photon time with the
+combined HERMES raw unpacking and photon-reconstruction time for the same input,
+not with the HERMES unpacker alone. EMPIR photon-to-event has no current HERMES
+equivalent, and event-to-image time should be reported separately.
 
 ## HERMES Analysis
 

--- a/examples/analysis/empir/README.md
+++ b/examples/analysis/empir/README.md
@@ -1,0 +1,115 @@
+# EMPIR analysis example
+
+This example runs the three EMPIR programs in order, from a raw TPX3 file to a
+TIFF image:
+
+```text
+raw TPX3 file
+  -> photon file    (.empirphot, from empir_pixel2photon_tpx3spidr)
+  -> event file     (.empirevent, from empir_photon2event)
+  -> TIFF image     (.tiff, from empir_event2image)
+```
+
+The starting raw file (`tests/data/tpx3/Tantalum_IronPowder.tpx3`) is copied
+into the working directory's `rawTpx3/` sub-directory, then the three programs
+run in sequence. The completed HERMES state is saved separately once all three
+stages finish.
+
+Each program is timed with a monotonic clock. The measured duration for each
+stage is written to the analysis log (see [Timing](#timing) below). This is the
+value used to compare EMPIR with the HERMES pipeline: EMPIR pixel-to-photon time
+is comparable to combined HERMES unpacking plus photon reconstruction, not to
+unpacking alone. EMPIR photon-to-event has no current HERMES equivalent, and
+event-to-image time should be reported on its own.
+
+## Requirements
+
+HERMES does not ship or install EMPIR. You supply your own licensed EMPIR
+installation and put its `bin` directory on `PATH` so the three programs resolve
+by name:
+
+```bash
+export PATH="/path/to/EMPIR/bin:$PATH"
+```
+
+The supplied EMPIR binaries target Ubuntu 22.04 and require `libtiff`. Confirm
+the programs run before using this example:
+
+```bash
+empir_pixel2photon_tpx3spidr --help
+empir_photon2event --help
+empir_event2image --help
+```
+
+## Run the example
+
+Run the checked-in `empir.yaml`:
+
+```bash
+pixi run python examples/analysis/empir/run_empir.py
+```
+
+To use another configuration, supply its path:
+
+```bash
+pixi run python examples/analysis/empir/run_empir.py \
+  /path/to/empir.yaml
+```
+
+## Configure the stages
+
+- `analysis.pixel_to_photon` selects `empir_pixel2photon_tpx3spidr`, its
+  clustering settings (`-s` spatial distance in pixels, `-t` time distance in
+  seconds, `-k` minimum pixel count), and whether to read TDC1 (`include_tdc1`
+  adds `-T`).
+- `analysis.photon_to_event` selects `empir_photon2event` and its settings
+  (`-s`, `-t`, and `-D` maximum cluster duration in seconds).
+- `analysis.event_to_image` selects `empir_event2image`, the image width
+  (`-x`), and optional filters and binning. Setting `time_bin_width_seconds`
+  requires `time_bin_count` (both together, producing a TIFF stack).
+- `save_photon_files` and `save_event_files` control whether each stage's input
+  is kept after the downstream stage succeeds. Both are `true` here so you can
+  inspect the intermediates. Inputs are always kept if a downstream stage fails.
+- The stages chain by path: each `photon_to_event` input must match a
+  `pixel_to_photon` requested photon file, and each `event_to_image` input must
+  match a `photon_to_event` requested event file.
+
+## Timing
+
+The example sets `environment.log_dir: logs`, which resolves under the working
+directory, so the analysis log is written to:
+
+```text
+data/examples/analysis/empir/logs/analysis.jsonl
+```
+
+Without `log_dir` set, no `analysis.jsonl` is written and timing goes only to
+the console. Each stage emits a `...completed` event carrying `elapsed_seconds`.
+Read the per-stage durations with `jq`:
+
+```bash
+jq 'select(.record.extra.event_type | endswith(".completed"))
+    | {step: .record.extra.step, elapsed_seconds: .record.extra.elapsed_seconds}' \
+  data/examples/analysis/empir/logs/analysis.jsonl
+```
+
+## Output
+
+The checked-in configuration writes ignored development output under:
+
+```text
+data/examples/analysis/empir/
+├── hermes-record_final.yaml
+├── rawTpx3/
+│   └── Tantalum_IronPowder.tpx3
+├── out/
+│   ├── Tantalum_IronPowder.empirphot
+│   ├── Tantalum_IronPowder.empirevent
+│   └── Tantalum_IronPowder.tiff
+└── logs/
+    └── analysis.jsonl
+```
+
+The completed `hermes-record_final.yaml` records the exact command arguments and
+the timed result for each stage. Re-running the example fails fast if an output
+already exists, so remove the `out/` directory before a fresh run.

--- a/examples/analysis/empir/README.md
+++ b/examples/analysis/empir/README.md
@@ -102,14 +102,17 @@ data/examples/analysis/empir/
 ├── hermes-record_final.yaml
 ├── rawTpx3/
 │   └── Tantalum_IronPowder.tpx3
-├── out/
-│   ├── Tantalum_IronPowder.empirphot
-│   ├── Tantalum_IronPowder.empirevent
-│   └── Tantalum_IronPowder.tiff
+├── results/
+│   ├── photons/
+│   │   └── Tantalum_IronPowder.empirphot
+│   ├── events/
+│   │   └── Tantalum_IronPowder.empirevent
+│   └── final/
+│       └── Tantalum_IronPowder.tiff
 └── logs/
     └── analysis.jsonl
 ```
 
 The completed `hermes-record_final.yaml` records the exact command arguments and
 the timed result for each stage. Re-running the example fails fast if an output
-already exists, so remove the `out/` directory before a fresh run.
+already exists, so remove the `results/` directory before a fresh run.

--- a/examples/analysis/empir/empir.yaml
+++ b/examples/analysis/empir/empir.yaml
@@ -30,7 +30,7 @@ analysis:
       minimum_pixel_count: 2
       include_tdc1: false
     runs:
-      - input_tpx3_file:
+      - tpx3_file:
           path: data/examples/analysis/empir/rawTpx3/Tantalum_IronPowder.tpx3
         photon_file: data/examples/analysis/empir/results/photons/Tantalum_IronPowder.empirphot
 
@@ -45,11 +45,11 @@ analysis:
       time_distance_seconds: 5.0e-6
       maximum_duration_seconds: 25.0e-6
     runs:
-      - input_photon_file:
+      - photon_file:
           path: data/examples/analysis/empir/results/photons/Tantalum_IronPowder.empirphot
         event_file: data/examples/analysis/empir/results/events/Tantalum_IronPowder.empirevent
 
-  # Stage 3: the .empirevent files -> one TIFF image. Each input_event_files
+  # Stage 3: the .empirevent files -> one TIFF image. Each event_files
   # entry must match a event_file from stage 2.
   event_to_image:
     program:
@@ -57,6 +57,6 @@ analysis:
       executable_path: empir_event2image
     settings:
       image_width_pixels: 512
-    input_event_files:
+    event_files:
       - path: data/examples/analysis/empir/results/events/Tantalum_IronPowder.empirevent
     tiff_file: data/examples/analysis/empir/results/final/Tantalum_IronPowder.tiff

--- a/examples/analysis/empir/empir.yaml
+++ b/examples/analysis/empir/empir.yaml
@@ -32,10 +32,11 @@ analysis:
     runs:
       - input_tpx3_file:
           path: data/examples/analysis/empir/rawTpx3/Tantalum_IronPowder.tpx3
-        requested_photon_file: data/examples/analysis/empir/out/Tantalum_IronPowder.empirphot
+        photon_file: data/examples/analysis/empir/results/photons/Tantalum_IronPowder.empirphot
 
   # Stage 2: each .empirphot file -> one .empirevent file. Each input_photon_file
-  # must match a requested_photon_file from stage 1.
+  # must match a photon_file from stage 1.
+  # (The photon_file written in stage 1 is read back here as input_photon_file.)
   photon_to_event:
     program:
       name: empir_photon2event
@@ -46,11 +47,11 @@ analysis:
       maximum_duration_seconds: 25.0e-6
     runs:
       - input_photon_file:
-          path: data/examples/analysis/empir/out/Tantalum_IronPowder.empirphot
-        requested_event_file: data/examples/analysis/empir/out/Tantalum_IronPowder.empirevent
+          path: data/examples/analysis/empir/results/photons/Tantalum_IronPowder.empirphot
+        event_file: data/examples/analysis/empir/results/events/Tantalum_IronPowder.empirevent
 
   # Stage 3: the .empirevent files -> one TIFF image. Each input_event_files
-  # entry must match a requested_event_file from stage 2.
+  # entry must match a event_file from stage 2.
   event_to_image:
     program:
       name: empir_event2image
@@ -58,5 +59,5 @@ analysis:
     settings:
       image_width_pixels: 512
     input_event_files:
-      - path: data/examples/analysis/empir/out/Tantalum_IronPowder.empirevent
-    requested_tiff_file: data/examples/analysis/empir/out/Tantalum_IronPowder.tiff
+      - path: data/examples/analysis/empir/results/events/Tantalum_IronPowder.empirevent
+    tiff_file: data/examples/analysis/empir/results/final/Tantalum_IronPowder.tiff

--- a/examples/analysis/empir/empir.yaml
+++ b/examples/analysis/empir/empir.yaml
@@ -34,9 +34,8 @@ analysis:
           path: data/examples/analysis/empir/rawTpx3/Tantalum_IronPowder.tpx3
         photon_file: data/examples/analysis/empir/results/photons/Tantalum_IronPowder.empirphot
 
-  # Stage 2: each .empirphot file -> one .empirevent file. Each input_photon_file
+  # Stage 2: each .empirphot file -> one .empirevent file. Each photon_file here
   # must match a photon_file from stage 1.
-  # (The photon_file written in stage 1 is read back here as input_photon_file.)
   photon_to_event:
     program:
       name: empir_photon2event

--- a/examples/analysis/empir/empir.yaml
+++ b/examples/analysis/empir/empir.yaml
@@ -1,0 +1,62 @@
+measurement_info:
+  measurement_id: example-empir
+  run_number: 1
+
+environment:
+  working_dir: data/examples/analysis/empir
+  # Relative log_dir resolves under working_dir, so analysis.jsonl is written
+  # to data/examples/analysis/empir/logs/analysis.jsonl. Without log_dir set,
+  # no analysis.jsonl is written and the timing data goes only to the console.
+  log_dir: logs
+
+analysis:
+  mode: empir
+  # Keep the intermediate photon and event files after the run so you can
+  # inspect them. Set either to false to delete that stage's inputs once the
+  # downstream stage succeeds.
+  save_photon_files: true
+  save_event_files: true
+
+  # Stage 1: one .tpx3 file -> one .empirphot file.
+  # The three programs are found on PATH by name; put the EMPIR bin directory
+  # on PATH before running (see README).
+  pixel_to_photon:
+    program:
+      name: empir_pixel2photon_tpx3spidr
+      executable_path: empir_pixel2photon_tpx3spidr
+    settings:
+      spatial_distance_pixels: 10
+      time_distance_seconds: 1.0e-6
+      minimum_pixel_count: 2
+      include_tdc1: false
+    runs:
+      - input_tpx3_file:
+          path: data/examples/analysis/empir/rawTpx3/Tantalum_IronPowder.tpx3
+        requested_photon_file: data/examples/analysis/empir/out/Tantalum_IronPowder.empirphot
+
+  # Stage 2: each .empirphot file -> one .empirevent file. Each input_photon_file
+  # must match a requested_photon_file from stage 1.
+  photon_to_event:
+    program:
+      name: empir_photon2event
+      executable_path: empir_photon2event
+    settings:
+      spatial_distance_pixels: 20
+      time_distance_seconds: 5.0e-6
+      maximum_duration_seconds: 25.0e-6
+    runs:
+      - input_photon_file:
+          path: data/examples/analysis/empir/out/Tantalum_IronPowder.empirphot
+        requested_event_file: data/examples/analysis/empir/out/Tantalum_IronPowder.empirevent
+
+  # Stage 3: the .empirevent files -> one TIFF image. Each input_event_files
+  # entry must match a requested_event_file from stage 2.
+  event_to_image:
+    program:
+      name: empir_event2image
+      executable_path: empir_event2image
+    settings:
+      image_width_pixels: 512
+    input_event_files:
+      - path: data/examples/analysis/empir/out/Tantalum_IronPowder.empirevent
+    requested_tiff_file: data/examples/analysis/empir/out/Tantalum_IronPowder.tiff

--- a/examples/analysis/empir/run_empir.py
+++ b/examples/analysis/empir/run_empir.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+from hermes.state_service.state_io import (
+    load_hermes_record_from_yaml,
+    save_hermes_record_to_yaml,
+)
+from hermes.workflows.workflow import Workflow
+
+DEFAULT_INPUT_YAML_PATH = Path(__file__).with_name("empir.yaml")
+SOURCE_TPX3_FILE = Path("tests/data/tpx3/Tantalum_IronPowder.tpx3")
+
+
+def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
+    # Step 1: Load the initial HERMES record from the configuration YAML file
+    initial_record = load_hermes_record_from_yaml(input_yaml_path)
+
+    # Step 2: Choose a separate path for the completed HERMES record
+    working_directory = initial_record.environment.working_dir.resolved_path
+    final_record_path = working_directory / "hermes-record_final.yaml"
+
+    # Step 3: Copy the starting raw TPX3 file into the rawTpx3 sub-directory the
+    # pixel-to-photon stage reads from
+    raw_directory = working_directory / "rawTpx3"
+    raw_directory.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(SOURCE_TPX3_FILE, raw_directory / SOURCE_TPX3_FILE.name)
+
+    # Step 4: Run the three EMPIR programs in order:
+    # pixel-to-photon -> photon-to-event -> event-to-image
+    workflow = Workflow(initial_record)
+    image_files = workflow.run_analysis()
+
+    # Step 5: Read and save the final HERMES record
+    final_record = workflow.record
+    final_analysis = final_record.analysis
+    save_hermes_record_to_yaml(final_record, final_record_path)
+
+    # Step 6: Display the measured duration for each stage
+    pixel_run = final_analysis.pixel_to_photon.runs[0]
+    photon_run = final_analysis.photon_to_event.runs[0]
+    image_result = final_analysis.event_to_image.result
+
+    print(f"Pixel-to-photon: {pixel_run.result.elapsed_seconds:.3f} s")
+    print(f"Photon-to-event: {photon_run.result.elapsed_seconds:.3f} s")
+    print(f"Event-to-image:  {image_result.elapsed_seconds:.3f} s")
+    print(f"TIFF images written: {len(image_files)}")
+    for image_file in image_files:
+        print(f"  - {image_file.path}")
+    log_directory = initial_record.environment.log_dir.resolved_path
+    if log_directory is not None:
+        print(f"Timing log: {log_directory / 'analysis.jsonl'}")
+    print(f"HERMES state file: {final_record_path}")
+
+
+if __name__ == "__main__":
+    input_yaml_path = (
+        Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_INPUT_YAML_PATH
+    )
+    main(input_yaml_path)

--- a/src/hermes/runner/analysis/empir/__init__.py
+++ b/src/hermes/runner/analysis/empir/__init__.py
@@ -1,0 +1,1 @@
+"""Run the three EMPIR analysis programs as one HERMES analysis mode."""

--- a/src/hermes/runner/analysis/empir/_errors.py
+++ b/src/hermes/runner/analysis/empir/_errors.py
@@ -1,0 +1,28 @@
+"""Exceptions raised while preparing and running EMPIR programs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hermes.runner.analysis.empir._process import EmpirProcessOutcome
+
+
+class EmpirError(Exception):
+    """Base exception for EMPIR analysis failures."""
+
+
+class EmpirPreflightError(EmpirError):
+    """Raised when an EMPIR process cannot safely start."""
+
+
+class EmpirExecutionError(EmpirError):
+    """Raised when an EMPIR process cannot launch or exits with an error."""
+
+    def __init__(self, message: str, outcome: EmpirProcessOutcome) -> None:
+        super().__init__(message)
+        self.outcome = outcome
+
+
+class EmpirOutputError(EmpirExecutionError):
+    """Raised when a successful EMPIR process leaves no requested file."""

--- a/src/hermes/runner/analysis/empir/_executable.py
+++ b/src/hermes/runner/analysis/empir/_executable.py
@@ -1,0 +1,38 @@
+"""Resolve configured EMPIR program names and explicit executable paths."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def resolve_executable(configured_path: Path) -> Path:
+    """Return an absolute executable path for one configured EMPIR program.
+
+    A value containing a directory is treated as an explicit filesystem path.
+    A bare program name is searched for on ``PATH``.
+    """
+    expanded_path = configured_path.expanduser()
+    is_explicit_path = expanded_path.is_absolute() or expanded_path.parent != Path(".")
+
+    if is_explicit_path:
+        resolved_path = expanded_path.resolve()
+    else:
+        matched_path = shutil.which(str(expanded_path))
+        if matched_path is None:
+            raise FileNotFoundError(
+                f"EMPIR executable was not found on PATH: {configured_path}"
+            )
+        resolved_path = Path(matched_path).resolve()
+
+    if not resolved_path.is_file():
+        raise FileNotFoundError(
+            f"EMPIR executable is not a file: {resolved_path}"
+        )
+    if not os.access(resolved_path, os.X_OK):
+        raise PermissionError(
+            f"EMPIR executable is not executable: {resolved_path}"
+        )
+
+    return resolved_path

--- a/src/hermes/runner/analysis/empir/_process.py
+++ b/src/hermes/runner/analysis/empir/_process.py
@@ -1,0 +1,101 @@
+"""Shared EMPIR-only subprocess timing and output checks."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from time import perf_counter
+
+from hermes.runner.analysis.empir._errors import (
+    EmpirExecutionError,
+    EmpirOutputError,
+    EmpirPreflightError,
+)
+from hermes.state.models.shared_models import utc_now
+
+_LOG_TEXT_LIMIT = 4_000
+
+
+@dataclass(frozen=True, slots=True)
+class EmpirProcessOutcome:
+    """Measured process details used for results, logs, and failures."""
+
+    started_at: datetime
+    completed_at: datetime
+    elapsed_seconds: float
+    exit_code: int | None
+    stdout_excerpt: str = ""
+    stderr_excerpt: str = ""
+
+
+def validate_step_paths(
+    step_name: str,
+    input_paths: list[Path],
+    requested_output_path: Path,
+) -> None:
+    """Check immediate inputs and reject an existing requested output."""
+    for input_path in input_paths:
+        if not input_path.is_file():
+            raise EmpirPreflightError(
+                f"{step_name} input is not a regular file: {input_path}"
+            )
+    if requested_output_path.exists():
+        raise EmpirPreflightError(
+            f"{step_name} output already exists: {requested_output_path}"
+        )
+
+
+def run_process(
+    step_name: str,
+    command: list[str],
+    requested_output_path: Path,
+    started_at: datetime,
+) -> EmpirProcessOutcome:
+    """Run one EMPIR command, measure it, and verify its requested file."""
+    started = perf_counter()
+    try:
+        process = subprocess.run(
+            command,
+            shell=False,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        outcome = EmpirProcessOutcome(
+            started_at=started_at,
+            completed_at=utc_now(),
+            elapsed_seconds=perf_counter() - started,
+            exit_code=None,
+        )
+        raise EmpirExecutionError(
+            f"{step_name} failed to launch: {exc}", outcome
+        ) from exc
+
+    outcome = EmpirProcessOutcome(
+        started_at=started_at,
+        completed_at=utc_now(),
+        elapsed_seconds=perf_counter() - started,
+        exit_code=process.returncode,
+        stdout_excerpt=_bounded_text(process.stdout),
+        stderr_excerpt=_bounded_text(process.stderr),
+    )
+    if process.returncode != 0:
+        raise EmpirExecutionError(
+            f"{step_name} exited with code {process.returncode}", outcome
+        )
+    if not requested_output_path.is_file():
+        raise EmpirOutputError(
+            f"{step_name} did not create the requested output file: "
+            f"{requested_output_path}",
+            outcome,
+        )
+
+    return outcome
+
+
+def _bounded_text(text: str) -> str:
+    """Return at most the first 4,000 characters of process text."""
+    return text[:_LOG_TEXT_LIMIT]

--- a/src/hermes/runner/analysis/empir/event_to_image.py
+++ b/src/hermes/runner/analysis/empir/event_to_image.py
@@ -1,0 +1,154 @@
+"""Build commands for the EMPIR event-to-image program."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from hermes.runner.analysis.empir._errors import EmpirExecutionError
+from hermes.runner.analysis.empir._process import (
+    run_process,
+    validate_step_paths,
+)
+from hermes.state.models.analysis.empir import (
+    EmpirEventToImageResult,
+    EmpirEventToImageState,
+)
+from hermes.state.models.shared_models import FileReference, utc_now
+
+_STEP_NAME = "event_to_image"
+_EVENT_PREFIX = "analysis.empir.event_to_image"
+_ANALYSIS_LOGGER = logger.bind(
+    domain="analysis",
+    mode="empir",
+    step=_STEP_NAME,
+)
+
+
+def build_event_to_image_command(
+    stage: EmpirEventToImageState,
+    resolved_executable_path: Path,
+) -> list[str]:
+    """Build the image command with exact, comma-separated event inputs."""
+    settings = stage.settings
+    command = [
+        str(resolved_executable_path),
+        "-i",
+        ",".join(str(file.path) for file in stage.input_event_files),
+        "-o",
+        str(stage.requested_tiff_file),
+        "-x",
+        str(settings.image_width_pixels),
+    ]
+
+    optional_arguments = (
+        ("-y", settings.image_height_pixels),
+        ("-m", settings.minimum_photon_count),
+        ("-M", settings.maximum_photon_count),
+        ("-p", settings.minimum_psd),
+        ("-P", settings.maximum_psd),
+        ("-E", settings.external_trigger_mode),
+        ("-t", settings.time_bin_width_seconds),
+        ("-T", settings.time_bin_count),
+        ("--fileFormat", settings.tiff_format),
+    )
+    for flag, value in optional_arguments:
+        if value is not None:
+            command.extend([flag, str(value)])
+
+    if settings.parallel is not None:
+        command.extend(["--parallel", str(settings.parallel).lower()])
+
+    return command
+
+
+def execute_event_to_image(
+    stage: EmpirEventToImageState,
+    resolved_executable_path: Path,
+) -> EmpirEventToImageResult:
+    """Run event-to-image once and return its verified TIFF result."""
+    input_paths = [file.path for file in stage.input_event_files]
+    output_path = stage.requested_tiff_file
+    validate_step_paths(_STEP_NAME, input_paths, output_path)
+    command = build_event_to_image_command(stage, resolved_executable_path)
+    started_at = utc_now()
+    _ANALYSIS_LOGGER.info(
+        "EMPIR event-to-image started for {input_file_count} files",
+        event_type=f"{_EVENT_PREFIX}.started",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_files=[str(path) for path in input_paths],
+        input_file_count=len(input_paths),
+        requested_output_file=str(output_path),
+    )
+
+    try:
+        outcome = run_process(
+            _STEP_NAME,
+            command,
+            output_path,
+            started_at,
+        )
+    except EmpirExecutionError as exc:
+        _log_failure(stage, resolved_executable_path, command, exc)
+        raise
+
+    _ANALYSIS_LOGGER.info(
+        "EMPIR event-to-image completed in {elapsed_seconds:.3f}s",
+        event_type=f"{_EVENT_PREFIX}.completed",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_files=[str(path) for path in input_paths],
+        input_file_count=len(input_paths),
+        requested_output_file=str(output_path),
+        exit_code=outcome.exit_code,
+        elapsed_seconds=outcome.elapsed_seconds,
+        stdout_excerpt=outcome.stdout_excerpt,
+        stderr_excerpt=outcome.stderr_excerpt,
+    )
+    return EmpirEventToImageResult(
+        status="completed",
+        started_at=outcome.started_at,
+        completed_at=outcome.completed_at,
+        elapsed_seconds=outcome.elapsed_seconds,
+        exit_code=outcome.exit_code,
+        saved_tiff_file=FileReference(path=output_path),
+    )
+
+
+def _log_failure(
+    stage: EmpirEventToImageState,
+    resolved_executable_path: Path,
+    command: list[str],
+    error: EmpirExecutionError,
+) -> None:
+    """Log a bounded event-to-image process failure."""
+    outcome = error.outcome
+    input_paths = [file.path for file in stage.input_event_files]
+    _ANALYSIS_LOGGER.error(
+        "EMPIR event-to-image failed: {error}",
+        event_type=f"{_EVENT_PREFIX}.failed",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_files=[str(path) for path in input_paths],
+        input_file_count=len(input_paths),
+        requested_output_file=str(stage.requested_tiff_file),
+        exit_code=outcome.exit_code,
+        elapsed_seconds=outcome.elapsed_seconds,
+        stdout_excerpt=outcome.stdout_excerpt,
+        stderr_excerpt=outcome.stderr_excerpt,
+        error=str(error),
+    )

--- a/src/hermes/runner/analysis/empir/event_to_image.py
+++ b/src/hermes/runner/analysis/empir/event_to_image.py
@@ -35,7 +35,7 @@ def build_event_to_image_command(
     command = [
         str(resolved_executable_path),
         "-i",
-        ",".join(str(file.path) for file in stage.input_event_files),
+        ",".join(str(file.path) for file in stage.event_files),
         "-o",
         str(stage.tiff_file),
         "-x",
@@ -68,7 +68,7 @@ def execute_event_to_image(
     resolved_executable_path: Path,
 ) -> EmpirEventToImageResult:
     """Run event-to-image once and return its verified TIFF result."""
-    input_paths = [file.path for file in stage.input_event_files]
+    input_paths = [file.path for file in stage.event_files]
     output_path = stage.tiff_file
     validate_step_paths(_STEP_NAME, input_paths, output_path)
     command = build_event_to_image_command(stage, resolved_executable_path)
@@ -121,7 +121,7 @@ def execute_event_to_image(
         completed_at=outcome.completed_at,
         elapsed_seconds=outcome.elapsed_seconds,
         exit_code=outcome.exit_code,
-        saved_tiff_file=FileReference(path=output_path),
+        tiff_file=FileReference(path=output_path),
     )
 
 
@@ -133,7 +133,7 @@ def _log_failure(
 ) -> None:
     """Log a bounded event-to-image process failure."""
     outcome = error.outcome
-    input_paths = [file.path for file in stage.input_event_files]
+    input_paths = [file.path for file in stage.event_files]
     _ANALYSIS_LOGGER.error(
         "EMPIR event-to-image failed: {error}",
         event_type=f"{_EVENT_PREFIX}.failed",

--- a/src/hermes/runner/analysis/empir/event_to_image.py
+++ b/src/hermes/runner/analysis/empir/event_to_image.py
@@ -37,7 +37,7 @@ def build_event_to_image_command(
         "-i",
         ",".join(str(file.path) for file in stage.input_event_files),
         "-o",
-        str(stage.requested_tiff_file),
+        str(stage.tiff_file),
         "-x",
         str(settings.image_width_pixels),
     ]
@@ -69,7 +69,7 @@ def execute_event_to_image(
 ) -> EmpirEventToImageResult:
     """Run event-to-image once and return its verified TIFF result."""
     input_paths = [file.path for file in stage.input_event_files]
-    output_path = stage.requested_tiff_file
+    output_path = stage.tiff_file
     validate_step_paths(_STEP_NAME, input_paths, output_path)
     command = build_event_to_image_command(stage, resolved_executable_path)
     started_at = utc_now()
@@ -145,7 +145,7 @@ def _log_failure(
         command_args=command[1:],
         input_files=[str(path) for path in input_paths],
         input_file_count=len(input_paths),
-        requested_output_file=str(stage.requested_tiff_file),
+        requested_output_file=str(stage.tiff_file),
         exit_code=outcome.exit_code,
         elapsed_seconds=outcome.elapsed_seconds,
         stdout_excerpt=outcome.stdout_excerpt,

--- a/src/hermes/runner/analysis/empir/photon_to_event.py
+++ b/src/hermes/runner/analysis/empir/photon_to_event.py
@@ -37,7 +37,7 @@ def build_photon_to_event_command(
     return [
         str(resolved_executable_path),
         "-i",
-        str(run.input_photon_file.path),
+        str(run.photon_file.path),
         "-o",
         str(run.event_file),
         "-s",
@@ -55,7 +55,7 @@ def execute_photon_to_event(
     resolved_executable_path: Path,
 ) -> EmpirPhotonToEventResult:
     """Run photon-to-event once and return its verified result."""
-    input_path = run.input_photon_file.path
+    input_path = run.photon_file.path
     output_path = run.event_file
     validate_step_paths(_STEP_NAME, [input_path], output_path)
     command = build_photon_to_event_command(
@@ -112,7 +112,7 @@ def execute_photon_to_event(
         completed_at=outcome.completed_at,
         elapsed_seconds=outcome.elapsed_seconds,
         exit_code=outcome.exit_code,
-        saved_event_file=FileReference(path=output_path),
+        event_file=FileReference(path=output_path),
     )
 
 
@@ -134,9 +134,9 @@ def _log_failure(
         executable_version=stage.program.version,
         command=command,
         command_args=command[1:],
-        input_file=str(run.input_photon_file.path),
+        input_file=str(run.photon_file.path),
         requested_output_file=str(run.event_file),
-        input_size_bytes=run.input_photon_file.path.stat().st_size,
+        input_size_bytes=run.photon_file.path.stat().st_size,
         exit_code=outcome.exit_code,
         elapsed_seconds=outcome.elapsed_seconds,
         stdout_excerpt=outcome.stdout_excerpt,

--- a/src/hermes/runner/analysis/empir/photon_to_event.py
+++ b/src/hermes/runner/analysis/empir/photon_to_event.py
@@ -1,0 +1,145 @@
+"""Build commands for the EMPIR photon-to-event program."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from hermes.runner.analysis.empir._errors import EmpirExecutionError
+from hermes.runner.analysis.empir._process import (
+    run_process,
+    validate_step_paths,
+)
+from hermes.state.models.analysis.empir import (
+    EmpirPhotonToEventResult,
+    EmpirPhotonToEventRun,
+    EmpirPhotonToEventState,
+)
+from hermes.state.models.shared_models import FileReference, utc_now
+
+_STEP_NAME = "photon_to_event"
+_EVENT_PREFIX = "analysis.empir.photon_to_event"
+_ANALYSIS_LOGGER = logger.bind(
+    domain="analysis",
+    mode="empir",
+    step=_STEP_NAME,
+)
+
+
+def build_photon_to_event_command(
+    stage: EmpirPhotonToEventState,
+    run: EmpirPhotonToEventRun,
+    resolved_executable_path: Path,
+) -> list[str]:
+    """Build the command for one EMPIR photon input without a shell."""
+    settings = stage.settings
+    return [
+        str(resolved_executable_path),
+        "-i",
+        str(run.input_photon_file.path),
+        "-o",
+        str(run.requested_event_file),
+        "-s",
+        str(settings.spatial_distance_pixels),
+        "-t",
+        str(settings.time_distance_seconds),
+        "-D",
+        str(settings.maximum_duration_seconds),
+    ]
+
+
+def execute_photon_to_event(
+    stage: EmpirPhotonToEventState,
+    run: EmpirPhotonToEventRun,
+    resolved_executable_path: Path,
+) -> EmpirPhotonToEventResult:
+    """Run photon-to-event once and return its verified result."""
+    input_path = run.input_photon_file.path
+    output_path = run.requested_event_file
+    validate_step_paths(_STEP_NAME, [input_path], output_path)
+    command = build_photon_to_event_command(
+        stage,
+        run,
+        resolved_executable_path,
+    )
+    started_at = utc_now()
+    _ANALYSIS_LOGGER.info(
+        "EMPIR photon-to-event started for {input_file}",
+        event_type=f"{_EVENT_PREFIX}.started",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_file=str(input_path),
+        requested_output_file=str(output_path),
+        input_size_bytes=input_path.stat().st_size,
+    )
+
+    try:
+        outcome = run_process(
+            _STEP_NAME,
+            command,
+            output_path,
+            started_at,
+        )
+    except EmpirExecutionError as exc:
+        _log_failure(stage, run, resolved_executable_path, command, exc)
+        raise
+
+    _ANALYSIS_LOGGER.info(
+        "EMPIR photon-to-event completed in {elapsed_seconds:.3f}s",
+        event_type=f"{_EVENT_PREFIX}.completed",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_file=str(input_path),
+        requested_output_file=str(output_path),
+        input_size_bytes=input_path.stat().st_size,
+        exit_code=outcome.exit_code,
+        elapsed_seconds=outcome.elapsed_seconds,
+        stdout_excerpt=outcome.stdout_excerpt,
+        stderr_excerpt=outcome.stderr_excerpt,
+    )
+    return EmpirPhotonToEventResult(
+        status="completed",
+        started_at=outcome.started_at,
+        completed_at=outcome.completed_at,
+        elapsed_seconds=outcome.elapsed_seconds,
+        exit_code=outcome.exit_code,
+        saved_event_file=FileReference(path=output_path),
+    )
+
+
+def _log_failure(
+    stage: EmpirPhotonToEventState,
+    run: EmpirPhotonToEventRun,
+    resolved_executable_path: Path,
+    command: list[str],
+    error: EmpirExecutionError,
+) -> None:
+    """Log a bounded photon-to-event process failure."""
+    outcome = error.outcome
+    _ANALYSIS_LOGGER.error(
+        "EMPIR photon-to-event failed: {error}",
+        event_type=f"{_EVENT_PREFIX}.failed",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_file=str(run.input_photon_file.path),
+        requested_output_file=str(run.requested_event_file),
+        input_size_bytes=run.input_photon_file.path.stat().st_size,
+        exit_code=outcome.exit_code,
+        elapsed_seconds=outcome.elapsed_seconds,
+        stdout_excerpt=outcome.stdout_excerpt,
+        stderr_excerpt=outcome.stderr_excerpt,
+        error=str(error),
+    )

--- a/src/hermes/runner/analysis/empir/photon_to_event.py
+++ b/src/hermes/runner/analysis/empir/photon_to_event.py
@@ -39,7 +39,7 @@ def build_photon_to_event_command(
         "-i",
         str(run.input_photon_file.path),
         "-o",
-        str(run.requested_event_file),
+        str(run.event_file),
         "-s",
         str(settings.spatial_distance_pixels),
         "-t",
@@ -56,7 +56,7 @@ def execute_photon_to_event(
 ) -> EmpirPhotonToEventResult:
     """Run photon-to-event once and return its verified result."""
     input_path = run.input_photon_file.path
-    output_path = run.requested_event_file
+    output_path = run.event_file
     validate_step_paths(_STEP_NAME, [input_path], output_path)
     command = build_photon_to_event_command(
         stage,
@@ -135,7 +135,7 @@ def _log_failure(
         command=command,
         command_args=command[1:],
         input_file=str(run.input_photon_file.path),
-        requested_output_file=str(run.requested_event_file),
+        requested_output_file=str(run.event_file),
         input_size_bytes=run.input_photon_file.path.stat().st_size,
         exit_code=outcome.exit_code,
         elapsed_seconds=outcome.elapsed_seconds,

--- a/src/hermes/runner/analysis/empir/pixel_to_photon.py
+++ b/src/hermes/runner/analysis/empir/pixel_to_photon.py
@@ -37,7 +37,7 @@ def build_pixel_to_photon_command(
     command = [
         str(resolved_executable_path),
         "-i",
-        str(run.input_tpx3_file.path),
+        str(run.tpx3_file.path),
         "-o",
         str(run.photon_file),
         "-s",
@@ -58,7 +58,7 @@ def execute_pixel_to_photon(
     resolved_executable_path: Path,
 ) -> EmpirPixelToPhotonResult:
     """Run pixel-to-photon once and return its verified result."""
-    input_path = run.input_tpx3_file.path
+    input_path = run.tpx3_file.path
     output_path = run.photon_file
     validate_step_paths(_STEP_NAME, [input_path], output_path)
     command = build_pixel_to_photon_command(
@@ -115,7 +115,7 @@ def execute_pixel_to_photon(
         completed_at=outcome.completed_at,
         elapsed_seconds=outcome.elapsed_seconds,
         exit_code=outcome.exit_code,
-        saved_photon_file=FileReference(path=output_path),
+        photon_file=FileReference(path=output_path),
     )
 
 
@@ -137,9 +137,9 @@ def _log_failure(
         executable_version=stage.program.version,
         command=command,
         command_args=command[1:],
-        input_file=str(run.input_tpx3_file.path),
+        input_file=str(run.tpx3_file.path),
         requested_output_file=str(run.photon_file),
-        input_size_bytes=run.input_tpx3_file.path.stat().st_size,
+        input_size_bytes=run.tpx3_file.path.stat().st_size,
         exit_code=outcome.exit_code,
         elapsed_seconds=outcome.elapsed_seconds,
         stdout_excerpt=outcome.stdout_excerpt,

--- a/src/hermes/runner/analysis/empir/pixel_to_photon.py
+++ b/src/hermes/runner/analysis/empir/pixel_to_photon.py
@@ -39,7 +39,7 @@ def build_pixel_to_photon_command(
         "-i",
         str(run.input_tpx3_file.path),
         "-o",
-        str(run.requested_photon_file),
+        str(run.photon_file),
         "-s",
         str(settings.spatial_distance_pixels),
         "-t",
@@ -59,7 +59,7 @@ def execute_pixel_to_photon(
 ) -> EmpirPixelToPhotonResult:
     """Run pixel-to-photon once and return its verified result."""
     input_path = run.input_tpx3_file.path
-    output_path = run.requested_photon_file
+    output_path = run.photon_file
     validate_step_paths(_STEP_NAME, [input_path], output_path)
     command = build_pixel_to_photon_command(
         stage,
@@ -138,7 +138,7 @@ def _log_failure(
         command=command,
         command_args=command[1:],
         input_file=str(run.input_tpx3_file.path),
-        requested_output_file=str(run.requested_photon_file),
+        requested_output_file=str(run.photon_file),
         input_size_bytes=run.input_tpx3_file.path.stat().st_size,
         exit_code=outcome.exit_code,
         elapsed_seconds=outcome.elapsed_seconds,

--- a/src/hermes/runner/analysis/empir/pixel_to_photon.py
+++ b/src/hermes/runner/analysis/empir/pixel_to_photon.py
@@ -1,0 +1,148 @@
+"""Build commands for the EMPIR pixel-to-photon program."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from hermes.runner.analysis.empir._errors import EmpirExecutionError
+from hermes.runner.analysis.empir._process import (
+    run_process,
+    validate_step_paths,
+)
+from hermes.state.models.analysis.empir import (
+    EmpirPixelToPhotonResult,
+    EmpirPixelToPhotonRun,
+    EmpirPixelToPhotonState,
+)
+from hermes.state.models.shared_models import FileReference, utc_now
+
+_STEP_NAME = "pixel_to_photon"
+_EVENT_PREFIX = "analysis.empir.pixel_to_photon"
+_ANALYSIS_LOGGER = logger.bind(
+    domain="analysis",
+    mode="empir",
+    step=_STEP_NAME,
+)
+
+
+def build_pixel_to_photon_command(
+    stage: EmpirPixelToPhotonState,
+    run: EmpirPixelToPhotonRun,
+    resolved_executable_path: Path,
+) -> list[str]:
+    """Build the command for one TPX3 input without invoking a shell."""
+    settings = stage.settings
+    command = [
+        str(resolved_executable_path),
+        "-i",
+        str(run.input_tpx3_file.path),
+        "-o",
+        str(run.requested_photon_file),
+        "-s",
+        str(settings.spatial_distance_pixels),
+        "-t",
+        str(settings.time_distance_seconds),
+        "-k",
+        str(settings.minimum_pixel_count),
+    ]
+    if settings.include_tdc1:
+        command.append("-T")
+    return command
+
+
+def execute_pixel_to_photon(
+    stage: EmpirPixelToPhotonState,
+    run: EmpirPixelToPhotonRun,
+    resolved_executable_path: Path,
+) -> EmpirPixelToPhotonResult:
+    """Run pixel-to-photon once and return its verified result."""
+    input_path = run.input_tpx3_file.path
+    output_path = run.requested_photon_file
+    validate_step_paths(_STEP_NAME, [input_path], output_path)
+    command = build_pixel_to_photon_command(
+        stage,
+        run,
+        resolved_executable_path,
+    )
+    started_at = utc_now()
+    _ANALYSIS_LOGGER.info(
+        "EMPIR pixel-to-photon started for {input_file}",
+        event_type=f"{_EVENT_PREFIX}.started",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_file=str(input_path),
+        requested_output_file=str(output_path),
+        input_size_bytes=input_path.stat().st_size,
+    )
+
+    try:
+        outcome = run_process(
+            _STEP_NAME,
+            command,
+            output_path,
+            started_at,
+        )
+    except EmpirExecutionError as exc:
+        _log_failure(stage, run, resolved_executable_path, command, exc)
+        raise
+
+    _ANALYSIS_LOGGER.info(
+        "EMPIR pixel-to-photon completed in {elapsed_seconds:.3f}s",
+        event_type=f"{_EVENT_PREFIX}.completed",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_file=str(input_path),
+        requested_output_file=str(output_path),
+        input_size_bytes=input_path.stat().st_size,
+        exit_code=outcome.exit_code,
+        elapsed_seconds=outcome.elapsed_seconds,
+        stdout_excerpt=outcome.stdout_excerpt,
+        stderr_excerpt=outcome.stderr_excerpt,
+    )
+    return EmpirPixelToPhotonResult(
+        status="completed",
+        started_at=outcome.started_at,
+        completed_at=outcome.completed_at,
+        elapsed_seconds=outcome.elapsed_seconds,
+        exit_code=outcome.exit_code,
+        saved_photon_file=FileReference(path=output_path),
+    )
+
+
+def _log_failure(
+    stage: EmpirPixelToPhotonState,
+    run: EmpirPixelToPhotonRun,
+    resolved_executable_path: Path,
+    command: list[str],
+    error: EmpirExecutionError,
+) -> None:
+    """Log a bounded pixel-to-photon process failure."""
+    outcome = error.outcome
+    _ANALYSIS_LOGGER.error(
+        "EMPIR pixel-to-photon failed: {error}",
+        event_type=f"{_EVENT_PREFIX}.failed",
+        executable_name=stage.program.name,
+        configured_executable=str(stage.program.executable_path),
+        resolved_executable_path=str(resolved_executable_path),
+        executable_version=stage.program.version,
+        command=command,
+        command_args=command[1:],
+        input_file=str(run.input_tpx3_file.path),
+        requested_output_file=str(run.requested_photon_file),
+        input_size_bytes=run.input_tpx3_file.path.stat().st_size,
+        exit_code=outcome.exit_code,
+        elapsed_seconds=outcome.elapsed_seconds,
+        stdout_excerpt=outcome.stdout_excerpt,
+        stderr_excerpt=outcome.stderr_excerpt,
+        error=str(error),
+    )

--- a/src/hermes/runner/analysis/empir/run.py
+++ b/src/hermes/runner/analysis/empir/run.py
@@ -54,7 +54,7 @@ def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
             event_type="analysis.empir.pipeline.started",
             pixel_to_photon_run_count=len(analysis.pixel_to_photon.runs),
             photon_to_event_run_count=len(analysis.photon_to_event.runs),
-            event_to_image_input_count=len(analysis.event_to_image.input_event_files),
+            event_to_image_input_count=len(analysis.event_to_image.event_files),
             pixel_to_photon_executable=str(resolved.pixel_to_photon),
             photon_to_event_executable=str(resolved.photon_to_event),
             event_to_image_executable=str(resolved.event_to_image),
@@ -138,7 +138,7 @@ def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
                 justification="EMPIR photon-to-event completed",
             )
             _remove_intermediate(
-                current_run.input_photon_file.path,
+                current_run.photon_file.path,
                 keep=analysis.save_photon_files,
                 step_name="photon_to_event",
             )
@@ -172,7 +172,7 @@ def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
             completed_stage,
             justification="EMPIR event-to-image completed",
         )
-        for event_file in stage.input_event_files:
+        for event_file in stage.event_files:
             _remove_intermediate(
                 event_file.path,
                 keep=analysis.save_event_files,
@@ -187,7 +187,7 @@ def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
         )
         raise
 
-    final_file = result.saved_tiff_file
+    final_file = result.tiff_file
     assert final_file is not None
     _ANALYSIS_LOGGER.info(
         "EMPIR analysis completed",
@@ -245,7 +245,7 @@ def _resolve_step_executable(configured_path: Path) -> Path:
 
 def _validate_initial_inputs(analysis: EmpirAnalysisState) -> None:
     for run in analysis.pixel_to_photon.runs:
-        path = run.input_tpx3_file.path
+        path = run.tpx3_file.path
         if not path.is_file():
             raise EmpirPreflightError(
                 f"pixel_to_photon input is not a regular file: {path}"
@@ -253,7 +253,7 @@ def _validate_initial_inputs(analysis: EmpirAnalysisState) -> None:
 
 
 def _validate_path_collisions(analysis: EmpirAnalysisState) -> None:
-    input_paths = [run.input_tpx3_file.path for run in analysis.pixel_to_photon.runs]
+    input_paths = [run.tpx3_file.path for run in analysis.pixel_to_photon.runs]
     output_paths = [
         *(run.photon_file for run in analysis.pixel_to_photon.runs),
         *(run.event_file for run in analysis.photon_to_event.runs),

--- a/src/hermes/runner/analysis/empir/run.py
+++ b/src/hermes/runner/analysis/empir/run.py
@@ -217,7 +217,9 @@ def _preflight(analysis: EmpirAnalysisState) -> _ResolvedExecutables:
             analysis.model_dump(mode="python")
         )
     except ValueError as exc:
-        raise EmpirPreflightError("EMPIR analysis settings are invalid") from exc
+        raise EmpirPreflightError(
+            f"EMPIR analysis settings are invalid: {exc}"
+        ) from exc
 
     resolved = _ResolvedExecutables(
         pixel_to_photon=_resolve_step_executable(

--- a/src/hermes/runner/analysis/empir/run.py
+++ b/src/hermes/runner/analysis/empir/run.py
@@ -255,9 +255,9 @@ def _validate_initial_inputs(analysis: EmpirAnalysisState) -> None:
 def _validate_path_collisions(analysis: EmpirAnalysisState) -> None:
     input_paths = [run.input_tpx3_file.path for run in analysis.pixel_to_photon.runs]
     output_paths = [
-        *(run.requested_photon_file for run in analysis.pixel_to_photon.runs),
-        *(run.requested_event_file for run in analysis.photon_to_event.runs),
-        analysis.event_to_image.requested_tiff_file,
+        *(run.photon_file for run in analysis.pixel_to_photon.runs),
+        *(run.event_file for run in analysis.photon_to_event.runs),
+        analysis.event_to_image.tiff_file,
     ]
     all_paths = input_paths + output_paths
     normalized = [_normalized_path(path) for path in all_paths]
@@ -271,9 +271,9 @@ def _validate_path_collisions(analysis: EmpirAnalysisState) -> None:
 
 def _prepare_output_parents(analysis: EmpirAnalysisState) -> None:
     output_paths = [
-        *(run.requested_photon_file for run in analysis.pixel_to_photon.runs),
-        *(run.requested_event_file for run in analysis.photon_to_event.runs),
-        analysis.event_to_image.requested_tiff_file,
+        *(run.photon_file for run in analysis.pixel_to_photon.runs),
+        *(run.event_file for run in analysis.photon_to_event.runs),
+        analysis.event_to_image.tiff_file,
     ]
     for output_path in output_paths:
         parent = output_path.parent

--- a/src/hermes/runner/analysis/empir/run.py
+++ b/src/hermes/runner/analysis/empir/run.py
@@ -1,0 +1,474 @@
+"""Coordinate the three EMPIR programs for one analysis run."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from hermes.runner.analysis.empir._errors import (
+    EmpirError,
+    EmpirExecutionError,
+    EmpirPreflightError,
+)
+from hermes.runner.analysis.empir._executable import resolve_executable
+from hermes.runner.analysis.empir.event_to_image import (
+    build_event_to_image_command,
+    execute_event_to_image,
+)
+from hermes.runner.analysis.empir.photon_to_event import (
+    build_photon_to_event_command,
+    execute_photon_to_event,
+)
+from hermes.runner.analysis.empir.pixel_to_photon import (
+    build_pixel_to_photon_command,
+    execute_pixel_to_photon,
+)
+from hermes.state.models.analysis.empir import (
+    EmpirAnalysisState,
+    EmpirEventToImageResult,
+    EmpirEventToImageState,
+    EmpirPhotonToEventResult,
+    EmpirPhotonToEventRun,
+    EmpirPixelToPhotonResult,
+    EmpirPixelToPhotonRun,
+)
+from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state_service.state_manager import StateManager
+
+_ANALYSIS_LOGGER = logger.bind(
+    domain="analysis",
+    mode="empir",
+    step="pipeline",
+)
+
+
+def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
+    """Run pixel-to-photon, photon-to-event, and event-to-image in order."""
+    try:
+        analysis = _current_empir_analysis(state_manager)
+        resolved = _preflight(analysis)
+
+        _ANALYSIS_LOGGER.info(
+            "EMPIR analysis started",
+            event_type="analysis.empir.pipeline.started",
+            pixel_to_photon_run_count=len(analysis.pixel_to_photon.runs),
+            photon_to_event_run_count=len(analysis.photon_to_event.runs),
+            event_to_image_input_count=len(analysis.event_to_image.input_event_files),
+            pixel_to_photon_executable=str(resolved.pixel_to_photon),
+            photon_to_event_executable=str(resolved.photon_to_event),
+            event_to_image_executable=str(resolved.event_to_image),
+        )
+
+        for index in range(len(analysis.pixel_to_photon.runs)):
+            current = _current_empir_analysis(state_manager)
+            stage = current.pixel_to_photon
+            current_run = stage.runs[index]
+            command = build_pixel_to_photon_command(
+                stage, current_run, resolved.pixel_to_photon
+            )
+            _apply_pixel_to_photon_run(
+                state_manager,
+                index,
+                current_run.model_copy(
+                    update={
+                        "command_args": command[1:],
+                        "result": EmpirPixelToPhotonResult(
+                            status="running",
+                            started_at=utc_now(),
+                        ),
+                    }
+                ),
+                justification="EMPIR pixel-to-photon started",
+            )
+            try:
+                result = execute_pixel_to_photon(
+                    stage, current_run, resolved.pixel_to_photon
+                )
+            except EmpirError as exc:
+                _apply_pixel_failure(
+                    state_manager, index, current_run, command[1:], exc
+                )
+                raise
+            _apply_pixel_to_photon_run(
+                state_manager,
+                index,
+                current_run.model_copy(
+                    update={"command_args": command[1:], "result": result}
+                ),
+                justification="EMPIR pixel-to-photon completed",
+            )
+
+        for index in range(len(analysis.photon_to_event.runs)):
+            current = _current_empir_analysis(state_manager)
+            stage = current.photon_to_event
+            current_run = stage.runs[index]
+            command = build_photon_to_event_command(
+                stage, current_run, resolved.photon_to_event
+            )
+            _apply_photon_to_event_run(
+                state_manager,
+                index,
+                current_run.model_copy(
+                    update={
+                        "command_args": command[1:],
+                        "result": EmpirPhotonToEventResult(
+                            status="running",
+                            started_at=utc_now(),
+                        ),
+                    }
+                ),
+                justification="EMPIR photon-to-event started",
+            )
+            try:
+                result = execute_photon_to_event(
+                    stage, current_run, resolved.photon_to_event
+                )
+            except EmpirError as exc:
+                _apply_photon_failure(
+                    state_manager, index, current_run, command[1:], exc
+                )
+                raise
+            _apply_photon_to_event_run(
+                state_manager,
+                index,
+                current_run.model_copy(
+                    update={"command_args": command[1:], "result": result}
+                ),
+                justification="EMPIR photon-to-event completed",
+            )
+            _remove_intermediate(
+                current_run.input_photon_file.path,
+                keep=analysis.save_photon_files,
+                step_name="photon_to_event",
+            )
+
+        current = _current_empir_analysis(state_manager)
+        stage = current.event_to_image
+        command = build_event_to_image_command(stage, resolved.event_to_image)
+        _apply_event_to_image_state(
+            state_manager,
+            stage.model_copy(
+                update={
+                    "command_args": command[1:],
+                    "result": EmpirEventToImageResult(
+                        status="running",
+                        started_at=utc_now(),
+                    ),
+                }
+            ),
+            justification="EMPIR event-to-image started",
+        )
+        try:
+            result = execute_event_to_image(stage, resolved.event_to_image)
+        except EmpirError as exc:
+            _apply_event_failure(state_manager, stage, command[1:], exc)
+            raise
+        completed_stage = stage.model_copy(
+            update={"command_args": command[1:], "result": result}
+        )
+        _apply_event_to_image_state(
+            state_manager,
+            completed_stage,
+            justification="EMPIR event-to-image completed",
+        )
+        for event_file in stage.input_event_files:
+            _remove_intermediate(
+                event_file.path,
+                keep=analysis.save_event_files,
+                step_name="event_to_image",
+            )
+
+    except EmpirError as exc:
+        _ANALYSIS_LOGGER.error(
+            "EMPIR analysis failed: {error}",
+            event_type="analysis.empir.pipeline.failed",
+            error=str(exc),
+        )
+        raise
+
+    final_file = result.saved_tiff_file
+    assert final_file is not None
+    _ANALYSIS_LOGGER.info(
+        "EMPIR analysis completed",
+        event_type="analysis.empir.pipeline.completed",
+        output_file=str(final_file.path),
+    )
+    return [final_file]
+
+
+class _ResolvedExecutables:
+    def __init__(
+        self,
+        *,
+        pixel_to_photon: Path,
+        photon_to_event: Path,
+        event_to_image: Path,
+    ) -> None:
+        self.pixel_to_photon = pixel_to_photon
+        self.photon_to_event = photon_to_event
+        self.event_to_image = event_to_image
+
+
+def _preflight(analysis: EmpirAnalysisState) -> _ResolvedExecutables:
+    """Check the whole EMPIR run before the first state update."""
+    try:
+        validated = EmpirAnalysisState.model_validate(
+            analysis.model_dump(mode="python")
+        )
+    except ValueError as exc:
+        raise EmpirPreflightError("EMPIR analysis settings are invalid") from exc
+
+    resolved = _ResolvedExecutables(
+        pixel_to_photon=_resolve_step_executable(
+            validated.pixel_to_photon.program.executable_path
+        ),
+        photon_to_event=_resolve_step_executable(
+            validated.photon_to_event.program.executable_path
+        ),
+        event_to_image=_resolve_step_executable(
+            validated.event_to_image.program.executable_path
+        ),
+    )
+    _validate_initial_inputs(validated)
+    _validate_path_collisions(validated)
+    _prepare_output_parents(validated)
+    return resolved
+
+
+def _resolve_step_executable(configured_path: Path) -> Path:
+    try:
+        return resolve_executable(configured_path)
+    except (FileNotFoundError, PermissionError) as exc:
+        raise EmpirPreflightError(str(exc)) from exc
+
+
+def _validate_initial_inputs(analysis: EmpirAnalysisState) -> None:
+    for run in analysis.pixel_to_photon.runs:
+        path = run.input_tpx3_file.path
+        if not path.is_file():
+            raise EmpirPreflightError(
+                f"pixel_to_photon input is not a regular file: {path}"
+            )
+
+
+def _validate_path_collisions(analysis: EmpirAnalysisState) -> None:
+    input_paths = [run.input_tpx3_file.path for run in analysis.pixel_to_photon.runs]
+    output_paths = [
+        *(run.requested_photon_file for run in analysis.pixel_to_photon.runs),
+        *(run.requested_event_file for run in analysis.photon_to_event.runs),
+        analysis.event_to_image.requested_tiff_file,
+    ]
+    all_paths = input_paths + output_paths
+    normalized = [_normalized_path(path) for path in all_paths]
+    if len(set(normalized)) != len(normalized):
+        raise EmpirPreflightError("EMPIR input and output paths must be unique")
+
+    for path in output_paths:
+        if path.exists():
+            raise EmpirPreflightError(f"EMPIR output already exists: {path}")
+
+
+def _prepare_output_parents(analysis: EmpirAnalysisState) -> None:
+    output_paths = [
+        *(run.requested_photon_file for run in analysis.pixel_to_photon.runs),
+        *(run.requested_event_file for run in analysis.photon_to_event.runs),
+        analysis.event_to_image.requested_tiff_file,
+    ]
+    for output_path in output_paths:
+        parent = output_path.parent
+        if parent.exists() and not parent.is_dir():
+            raise EmpirPreflightError(
+                f"EMPIR output parent is not a directory: {parent}"
+            )
+        try:
+            parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise EmpirPreflightError(
+                f"EMPIR output parent cannot be created: {parent}"
+            ) from exc
+
+
+def _normalized_path(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _current_empir_analysis(state_manager: StateManager) -> EmpirAnalysisState:
+    analysis = state_manager.get_state().analysis
+    if not isinstance(analysis, EmpirAnalysisState):
+        actual_mode = getattr(analysis, "mode", None)
+        raise EmpirPreflightError(
+            f"no valid EMPIR analysis is configured: {actual_mode}"
+        )
+    return analysis
+
+
+def _apply_pixel_to_photon_run(
+    state_manager: StateManager,
+    index: int,
+    updated_run: EmpirPixelToPhotonRun,
+    *,
+    justification: str,
+) -> None:
+    analysis = _current_empir_analysis(state_manager)
+    runs = list(analysis.pixel_to_photon.runs)
+    runs[index] = updated_run
+    _apply_change(
+        state_manager,
+        "analysis.pixel_to_photon.runs",
+        runs,
+        proposer="empir_pixel_to_photon",
+        justification=justification,
+    )
+
+
+def _apply_photon_to_event_run(
+    state_manager: StateManager,
+    index: int,
+    updated_run: EmpirPhotonToEventRun,
+    *,
+    justification: str,
+) -> None:
+    analysis = _current_empir_analysis(state_manager)
+    runs = list(analysis.photon_to_event.runs)
+    runs[index] = updated_run
+    _apply_change(
+        state_manager,
+        "analysis.photon_to_event.runs",
+        runs,
+        proposer="empir_photon_to_event",
+        justification=justification,
+    )
+
+
+def _apply_event_to_image_state(
+    state_manager: StateManager,
+    updated_state: EmpirEventToImageState,
+    *,
+    justification: str,
+) -> None:
+    _apply_change(
+        state_manager,
+        "analysis.event_to_image",
+        updated_state,
+        proposer="empir_event_to_image",
+        justification=justification,
+    )
+
+
+def _apply_pixel_failure(
+    state_manager: StateManager,
+    index: int,
+    run: EmpirPixelToPhotonRun,
+    command_args: list[str],
+    error: EmpirError,
+) -> None:
+    result = EmpirPixelToPhotonResult(
+        status="failed",
+        completed_at=utc_now(),
+        errors=[str(error)],
+    )
+    if isinstance(error, EmpirExecutionError):
+        result = EmpirPixelToPhotonResult(
+            status="failed",
+            started_at=error.outcome.started_at,
+            completed_at=error.outcome.completed_at,
+            elapsed_seconds=error.outcome.elapsed_seconds,
+            exit_code=error.outcome.exit_code,
+            errors=[str(error)],
+        )
+    _apply_pixel_to_photon_run(
+        state_manager,
+        index,
+        run.model_copy(update={"command_args": command_args, "result": result}),
+        justification=f"EMPIR pixel-to-photon failed: {error}",
+    )
+
+
+def _apply_photon_failure(
+    state_manager: StateManager,
+    index: int,
+    run: EmpirPhotonToEventRun,
+    command_args: list[str],
+    error: EmpirError,
+) -> None:
+    result = EmpirPhotonToEventResult(
+        status="failed",
+        completed_at=utc_now(),
+        errors=[str(error)],
+    )
+    if isinstance(error, EmpirExecutionError):
+        result = EmpirPhotonToEventResult(
+            status="failed",
+            started_at=error.outcome.started_at,
+            completed_at=error.outcome.completed_at,
+            elapsed_seconds=error.outcome.elapsed_seconds,
+            exit_code=error.outcome.exit_code,
+            errors=[str(error)],
+        )
+    _apply_photon_to_event_run(
+        state_manager,
+        index,
+        run.model_copy(update={"command_args": command_args, "result": result}),
+        justification=f"EMPIR photon-to-event failed: {error}",
+    )
+
+
+def _apply_event_failure(
+    state_manager: StateManager,
+    stage: EmpirEventToImageState,
+    command_args: list[str],
+    error: EmpirError,
+) -> None:
+    result = EmpirEventToImageResult(
+        status="failed",
+        completed_at=utc_now(),
+        errors=[str(error)],
+    )
+    if isinstance(error, EmpirExecutionError):
+        result = EmpirEventToImageResult(
+            status="failed",
+            started_at=error.outcome.started_at,
+            completed_at=error.outcome.completed_at,
+            elapsed_seconds=error.outcome.elapsed_seconds,
+            exit_code=error.outcome.exit_code,
+            errors=[str(error)],
+        )
+    _apply_event_to_image_state(
+        state_manager,
+        stage.model_copy(update={"command_args": command_args, "result": result}),
+        justification=f"EMPIR event-to-image failed: {error}",
+    )
+
+
+def _remove_intermediate(path: Path, *, keep: bool, step_name: str) -> None:
+    if keep:
+        return
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        _ANALYSIS_LOGGER.warning(
+            "EMPIR intermediate cleanup failed: {error}",
+            event_type="analysis.empir.cleanup.failed",
+            step=step_name,
+            path=str(path),
+            error=str(exc),
+        )
+
+
+def _apply_change(
+    state_manager: StateManager,
+    path: str,
+    value: object,
+    *,
+    proposer: str,
+    justification: str,
+) -> None:
+    change = state_manager.propose_change(
+        path,
+        value,
+        origin="trusted_workflow",
+        proposer=proposer,
+        justification=justification,
+    )
+    state_manager.apply_change(change.change_id)

--- a/src/hermes/runner/analysis/hermes/run.py
+++ b/src/hermes/runner/analysis/hermes/run.py
@@ -46,7 +46,6 @@ from hermes.runner.analysis.hermes.unpacker import (
     log_skipped_input,
     plan_unpacking,
 )
-from hermes.state.models.analysis.empir import EmpirAnalysisState
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
     HermesTpx3EventReconstructionResult,
@@ -166,18 +165,6 @@ def run_hermes_analysis(
 ) -> list[FileReference]:
     state = state_manager.get_state()
     analysis = state.analysis
-    if isinstance(analysis, EmpirAnalysisState):
-        error = "EMPIR analysis is not implemented yet"
-        _ANALYSIS_LOGGER.error(
-            "Cannot run HERMES analysis: {error}",
-            event_type="analysis.hermes.invalid_mode",
-            error=error,
-            measurement_id=state.measurement_info.measurement_id,
-            run_number=state.measurement_info.run_number,
-            expected_analysis_mode="hermes",
-            actual_analysis_mode=getattr(analysis, "mode", None),
-        )
-        raise HermesAnalysisError(error)
     if not isinstance(analysis, HermesTpx3AnalysisState):
         error = "no valid HERMES analysis is configured"
         _ANALYSIS_LOGGER.error(

--- a/src/hermes/runner/analysis/run.py
+++ b/src/hermes/runner/analysis/run.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 from loguru import logger
 
 from hermes.runner.analysis.empir.run import run_empir_analysis
-from hermes.runner.analysis.hermes.run import (
-    HermesAnalysisError,
-    run_hermes_analysis,
-)
+from hermes.runner.analysis.hermes.run import run_hermes_analysis
 from hermes.state.models.analysis.empir import EmpirAnalysisState
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,

--- a/src/hermes/runner/analysis/run.py
+++ b/src/hermes/runner/analysis/run.py
@@ -1,0 +1,50 @@
+"""Select the EMPIR or HERMES analysis runner from the saved analysis mode."""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from hermes.runner.analysis.empir.run import run_empir_analysis
+from hermes.runner.analysis.hermes.run import (
+    HermesAnalysisError,
+    run_hermes_analysis,
+)
+from hermes.state.models.analysis.empir import EmpirAnalysisState
+from hermes.state.models.analysis.hermes_tpx3_spidr import (
+    HermesTpx3AnalysisState,
+)
+from hermes.state.models.shared_models import FileReference
+from hermes.state_service.state_manager import StateManager
+
+_ANALYSIS_LOGGER = logger.bind(domain="analysis", step="dispatch")
+
+
+class AnalysisModeError(Exception):
+    """Raised when the saved state has no runnable analysis mode."""
+
+
+def run_analysis(
+    state_manager: StateManager,
+    *,
+    overwrite: bool = False,
+) -> list[FileReference]:
+    """Run the analysis selected by ``analysis.mode`` in the current record.
+
+    HERMES analysis honors ``overwrite``. EMPIR analysis has no overwrite
+    behavior; its preflight rejects an output that already exists.
+    """
+    analysis = state_manager.get_state().analysis
+
+    if isinstance(analysis, EmpirAnalysisState):
+        return run_empir_analysis(state_manager)
+    if isinstance(analysis, HermesTpx3AnalysisState):
+        return run_hermes_analysis(state_manager, overwrite=overwrite)
+
+    error = "no valid analysis mode is configured"
+    _ANALYSIS_LOGGER.error(
+        "Cannot run analysis: {error}",
+        event_type="analysis.dispatch.invalid_mode",
+        error=error,
+        actual_analysis_mode=getattr(analysis, "mode", None),
+    )
+    raise AnalysisModeError(error)

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -268,6 +268,19 @@ class EmpirAnalysisState(StrictBaseModel):
     @model_validator(mode="after")
     def validate_pipeline_paths(self) -> EmpirAnalysisState:
         """Require each step to read the preceding step's requested files."""
+        # Some type-guard tests deliberately use model_construct() to create an
+        # incomplete instance without validation. Normal model construction
+        # still reports every missing stage before this validator runs.
+        if not all(
+            hasattr(self, field_name)
+            for field_name in (
+                "pixel_to_photon",
+                "photon_to_event",
+                "event_to_image",
+            )
+        ):
+            return self
+
         # List order connects each upstream run to its downstream run.
         requested_photon_files = [
             run.requested_photon_file for run in self.pixel_to_photon.runs

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -69,7 +69,7 @@ class EmpirPixelToPhotonRun(StrictBaseModel):
     """Input, requested output, command, and result for one raw TPX3 file."""
 
     input_tpx3_file: FileReference
-    requested_photon_file: Path
+    photon_file: Path
     command_args: list[str] = Field(
         default_factory=list,
         description="Built and saved by the EMPIR runner.",
@@ -88,12 +88,12 @@ class EmpirPixelToPhotonRun(StrictBaseModel):
             value, (".tpx3",), "input_tpx3_file"
         )
 
-    @field_validator("requested_photon_file")
+    @field_validator("photon_file")
     @classmethod
-    def validate_requested_photon_file(cls, value: Path) -> Path:
+    def validate_photon_file(cls, value: Path) -> Path:
         """Require EMPIR's photon output filename."""
         return _validate_suffix(
-            value, (".empirphot",), "requested_photon_file"
+            value, (".empirphot",), "photon_file"
         )
 
 
@@ -130,7 +130,7 @@ class EmpirPhotonToEventRun(StrictBaseModel):
     """Input, requested output, command, and result for one photon file."""
 
     input_photon_file: FileReference
-    requested_event_file: Path
+    event_file: Path
     command_args: list[str] = Field(
         default_factory=list,
         description="Built and saved by the EMPIR runner.",
@@ -149,12 +149,12 @@ class EmpirPhotonToEventRun(StrictBaseModel):
             value, (".empirphot",), "input_photon_file"
         )
 
-    @field_validator("requested_event_file")
+    @field_validator("event_file")
     @classmethod
-    def validate_requested_event_file(cls, value: Path) -> Path:
+    def validate_event_file(cls, value: Path) -> Path:
         """Require EMPIR's event output filename."""
         return _validate_suffix(
-            value, (".empirevent",), "requested_event_file"
+            value, (".empirevent",), "event_file"
         )
 
 
@@ -226,7 +226,7 @@ class EmpirEventToImageState(StrictBaseModel):
     program: BinaryProgram
     settings: EmpirEventToImageSettings
     input_event_files: list[FileReference] = Field(min_length=1)
-    requested_tiff_file: Path
+    tiff_file: Path
     command_args: list[str] = Field(
         default_factory=list,
         description="Built and saved by the EMPIR runner.",
@@ -245,12 +245,12 @@ class EmpirEventToImageState(StrictBaseModel):
             )
         return value
 
-    @field_validator("requested_tiff_file")
+    @field_validator("tiff_file")
     @classmethod
-    def validate_requested_tiff_file(cls, value: Path) -> Path:
+    def validate_tiff_file(cls, value: Path) -> Path:
         """Require the final output to use a TIFF filename."""
         return _validate_suffix(
-            value, (".tif", ".tiff"), "requested_tiff_file"
+            value, (".tif", ".tiff"), "tiff_file"
         )
 
 
@@ -282,26 +282,26 @@ class EmpirAnalysisState(StrictBaseModel):
             return self
 
         # List order connects each upstream run to its downstream run.
-        requested_photon_files = [
-            run.requested_photon_file for run in self.pixel_to_photon.runs
+        photon_files = [
+            run.photon_file for run in self.pixel_to_photon.runs
         ]
         input_photon_files = [
             run.input_photon_file.path for run in self.photon_to_event.runs
         ]
-        if requested_photon_files != input_photon_files:
+        if photon_files != input_photon_files:
             msg = (
                 "photon_to_event input files must match pixel_to_photon "
                 "requested output files in order"
             )
             raise ValueError(msg)
 
-        requested_event_files = [
-            run.requested_event_file for run in self.photon_to_event.runs
+        event_files = [
+            run.event_file for run in self.photon_to_event.runs
         ]
         input_event_files = [
             file.path for file in self.event_to_image.input_event_files
         ]
-        if requested_event_files != input_event_files:
+        if event_files != input_event_files:
             msg = (
                 "event_to_image input files must match photon_to_event "
                 "requested output files in order"

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -283,10 +283,12 @@ class EmpirAnalysisState(StrictBaseModel):
 
         # List order connects each upstream run to its downstream run.
         photon_files_written = [
-            run.photon_file for run in self.pixel_to_photon.runs
+            run.photon_file.expanduser().resolve(strict=False)
+            for run in self.pixel_to_photon.runs
         ]
         photon_files_read = [
-            run.photon_file.path for run in self.photon_to_event.runs
+            run.photon_file.path.expanduser().resolve(strict=False)
+            for run in self.photon_to_event.runs
         ]
         if photon_files_written != photon_files_read:
             msg = (
@@ -296,10 +298,12 @@ class EmpirAnalysisState(StrictBaseModel):
             raise ValueError(msg)
 
         event_files_written = [
-            run.event_file for run in self.photon_to_event.runs
+            run.event_file.expanduser().resolve(strict=False)
+            for run in self.photon_to_event.runs
         ]
         event_files_read = [
-            file.path for file in self.event_to_image.event_files
+            file.path.expanduser().resolve(strict=False)
+            for file in self.event_to_image.event_files
         ]
         if event_files_written != event_files_read:
             msg = (

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from hermes.state.models.shared_models import (
     BinaryProgram,
@@ -15,6 +15,27 @@ from hermes.state.models.shared_models import (
 EmpirRunStatus = Literal["planned", "running", "completed", "failed"]
 EmpirExternalTriggerMode = Literal["ignore", "reference", "frameSync"]
 EmpirTiffFormat = Literal["tiff_w4", "tiff_w8"]
+
+
+def _validate_suffix(
+    path: Path,
+    suffixes: tuple[str, ...],
+    field_name: str,
+) -> Path:
+    if path.suffix.lower() not in suffixes:
+        expected = " or ".join(suffixes)
+        msg = f"{field_name} must use the {expected} filename suffix"
+        raise ValueError(msg)
+    return path
+
+
+def _validate_file_reference_suffix(
+    file: FileReference,
+    suffixes: tuple[str, ...],
+    field_name: str,
+) -> FileReference:
+    _validate_suffix(file.path, suffixes, field_name)
+    return file
 
 
 class EmpirPixelToPhotonSettings(StrictBaseModel):
@@ -28,6 +49,7 @@ class EmpirPixelToPhotonResult(StrictBaseModel):
     status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
     saved_photon_file: FileReference | None = None
     warnings: list[str] = Field(default_factory=list)
@@ -37,10 +59,29 @@ class EmpirPixelToPhotonResult(StrictBaseModel):
 class EmpirPixelToPhotonRun(StrictBaseModel):
     input_tpx3_file: FileReference
     requested_photon_file: Path
-    command_args: list[str] = Field(default_factory=list)
+    command_args: list[str] = Field(
+        default_factory=list,
+        description="Built and saved by the EMPIR runner.",
+    )
     result: EmpirPixelToPhotonResult = Field(
         default_factory=EmpirPixelToPhotonResult
     )
+
+    @field_validator("input_tpx3_file")
+    @classmethod
+    def validate_input_tpx3_file(
+        cls, value: FileReference
+    ) -> FileReference:
+        return _validate_file_reference_suffix(
+            value, (".tpx3",), "input_tpx3_file"
+        )
+
+    @field_validator("requested_photon_file")
+    @classmethod
+    def validate_requested_photon_file(cls, value: Path) -> Path:
+        return _validate_suffix(
+            value, (".empirphot",), "requested_photon_file"
+        )
 
 
 class EmpirPixelToPhotonState(StrictBaseModel):
@@ -59,6 +100,7 @@ class EmpirPhotonToEventResult(StrictBaseModel):
     status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
     saved_event_file: FileReference | None = None
     warnings: list[str] = Field(default_factory=list)
@@ -68,10 +110,29 @@ class EmpirPhotonToEventResult(StrictBaseModel):
 class EmpirPhotonToEventRun(StrictBaseModel):
     input_photon_file: FileReference
     requested_event_file: Path
-    command_args: list[str] = Field(default_factory=list)
+    command_args: list[str] = Field(
+        default_factory=list,
+        description="Built and saved by the EMPIR runner.",
+    )
     result: EmpirPhotonToEventResult = Field(
         default_factory=EmpirPhotonToEventResult
     )
+
+    @field_validator("input_photon_file")
+    @classmethod
+    def validate_input_photon_file(
+        cls, value: FileReference
+    ) -> FileReference:
+        return _validate_file_reference_suffix(
+            value, (".empirphot",), "input_photon_file"
+        )
+
+    @field_validator("requested_event_file")
+    @classmethod
+    def validate_requested_event_file(cls, value: Path) -> Path:
+        return _validate_suffix(
+            value, (".empirevent",), "requested_event_file"
+        )
 
 
 class EmpirPhotonToEventState(StrictBaseModel):
@@ -122,6 +183,7 @@ class EmpirEventToImageResult(StrictBaseModel):
     status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
+    elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
     saved_tiff_file: FileReference | None = None
     warnings: list[str] = Field(default_factory=list)
@@ -133,8 +195,29 @@ class EmpirEventToImageState(StrictBaseModel):
     settings: EmpirEventToImageSettings
     input_event_files: list[FileReference] = Field(min_length=1)
     requested_tiff_file: Path
-    command_args: list[str] = Field(default_factory=list)
+    command_args: list[str] = Field(
+        default_factory=list,
+        description="Built and saved by the EMPIR runner.",
+    )
     result: EmpirEventToImageResult = Field(default_factory=EmpirEventToImageResult)
+
+    @field_validator("input_event_files")
+    @classmethod
+    def validate_input_event_files(
+        cls, value: list[FileReference]
+    ) -> list[FileReference]:
+        for file in value:
+            _validate_file_reference_suffix(
+                file, (".empirevent",), "input_event_files"
+            )
+        return value
+
+    @field_validator("requested_tiff_file")
+    @classmethod
+    def validate_requested_tiff_file(cls, value: Path) -> Path:
+        return _validate_suffix(
+            value, (".tif", ".tiff"), "requested_tiff_file"
+        )
 
 
 class EmpirAnalysisState(StrictBaseModel):
@@ -145,3 +228,33 @@ class EmpirAnalysisState(StrictBaseModel):
     pixel_to_photon: EmpirPixelToPhotonState
     photon_to_event: EmpirPhotonToEventState
     event_to_image: EmpirEventToImageState
+
+    @model_validator(mode="after")
+    def validate_pipeline_paths(self) -> EmpirAnalysisState:
+        requested_photon_files = [
+            run.requested_photon_file for run in self.pixel_to_photon.runs
+        ]
+        input_photon_files = [
+            run.input_photon_file.path for run in self.photon_to_event.runs
+        ]
+        if requested_photon_files != input_photon_files:
+            msg = (
+                "photon_to_event input files must match pixel_to_photon "
+                "requested output files in order"
+            )
+            raise ValueError(msg)
+
+        requested_event_files = [
+            run.requested_event_file for run in self.photon_to_event.runs
+        ]
+        input_event_files = [
+            file.path for file in self.event_to_image.input_event_files
+        ]
+        if requested_event_files != input_event_files:
+            msg = (
+                "event_to_image input files must match photon_to_event "
+                "requested output files in order"
+            )
+            raise ValueError(msg)
+
+        return self

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -60,15 +60,15 @@ class EmpirPixelToPhotonResult(StrictBaseModel):
     completed_at: datetime | None = None
     elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
-    saved_photon_file: FileReference | None = None
+    photon_file: FileReference | None = None
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
 
 
 class EmpirPixelToPhotonRun(StrictBaseModel):
-    """Input, requested output, command, and result for one raw TPX3 file."""
+    """Input, output, command, and result for one raw TPX3 file."""
 
-    input_tpx3_file: FileReference
+    tpx3_file: FileReference
     photon_file: Path
     command_args: list[str] = Field(
         default_factory=list,
@@ -78,14 +78,14 @@ class EmpirPixelToPhotonRun(StrictBaseModel):
         default_factory=EmpirPixelToPhotonResult
     )
 
-    @field_validator("input_tpx3_file")
+    @field_validator("tpx3_file")
     @classmethod
-    def validate_input_tpx3_file(
+    def validate_tpx3_file(
         cls, value: FileReference
     ) -> FileReference:
         """Require the pixel-to-photon input to be a TPX3 file."""
         return _validate_file_reference_suffix(
-            value, (".tpx3",), "input_tpx3_file"
+            value, (".tpx3",), "tpx3_file"
         )
 
     @field_validator("photon_file")
@@ -121,15 +121,15 @@ class EmpirPhotonToEventResult(StrictBaseModel):
     completed_at: datetime | None = None
     elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
-    saved_event_file: FileReference | None = None
+    event_file: FileReference | None = None
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
 
 
 class EmpirPhotonToEventRun(StrictBaseModel):
-    """Input, requested output, command, and result for one photon file."""
+    """Input, output, command, and result for one photon file."""
 
-    input_photon_file: FileReference
+    photon_file: FileReference
     event_file: Path
     command_args: list[str] = Field(
         default_factory=list,
@@ -139,14 +139,14 @@ class EmpirPhotonToEventRun(StrictBaseModel):
         default_factory=EmpirPhotonToEventResult
     )
 
-    @field_validator("input_photon_file")
+    @field_validator("photon_file")
     @classmethod
-    def validate_input_photon_file(
+    def validate_photon_file(
         cls, value: FileReference
     ) -> FileReference:
         """Require the photon-to-event input to be an EMPIR photon file."""
         return _validate_file_reference_suffix(
-            value, (".empirphot",), "input_photon_file"
+            value, (".empirphot",), "photon_file"
         )
 
     @field_validator("event_file")
@@ -215,17 +215,17 @@ class EmpirEventToImageResult(StrictBaseModel):
     completed_at: datetime | None = None
     elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
-    saved_tiff_file: FileReference | None = None
+    tiff_file: FileReference | None = None
     warnings: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
 
 
 class EmpirEventToImageState(StrictBaseModel):
-    """Inputs, settings, requested TIFF, command, and image result."""
+    """Inputs, settings, output TIFF, command, and image result."""
 
     program: BinaryProgram
     settings: EmpirEventToImageSettings
-    input_event_files: list[FileReference] = Field(min_length=1)
+    event_files: list[FileReference] = Field(min_length=1)
     tiff_file: Path
     command_args: list[str] = Field(
         default_factory=list,
@@ -233,15 +233,15 @@ class EmpirEventToImageState(StrictBaseModel):
     )
     result: EmpirEventToImageResult = Field(default_factory=EmpirEventToImageResult)
 
-    @field_validator("input_event_files")
+    @field_validator("event_files")
     @classmethod
-    def validate_input_event_files(
+    def validate_event_files(
         cls, value: list[FileReference]
     ) -> list[FileReference]:
         """Require every image input to be an EMPIR event file."""
         for file in value:
             _validate_file_reference_suffix(
-                file, (".empirevent",), "input_event_files"
+                file, (".empirevent",), "event_files"
             )
         return value
 
@@ -282,29 +282,29 @@ class EmpirAnalysisState(StrictBaseModel):
             return self
 
         # List order connects each upstream run to its downstream run.
-        photon_files = [
+        photon_files_written = [
             run.photon_file for run in self.pixel_to_photon.runs
         ]
-        input_photon_files = [
-            run.input_photon_file.path for run in self.photon_to_event.runs
+        photon_files_read = [
+            run.photon_file.path for run in self.photon_to_event.runs
         ]
-        if photon_files != input_photon_files:
+        if photon_files_written != photon_files_read:
             msg = (
                 "photon_to_event input files must match pixel_to_photon "
-                "requested output files in order"
+                "output files in order"
             )
             raise ValueError(msg)
 
-        event_files = [
+        event_files_written = [
             run.event_file for run in self.photon_to_event.runs
         ]
-        input_event_files = [
-            file.path for file in self.event_to_image.input_event_files
+        event_files_read = [
+            file.path for file in self.event_to_image.event_files
         ]
-        if event_files != input_event_files:
+        if event_files_written != event_files_read:
             msg = (
                 "event_to_image input files must match photon_to_event "
-                "requested output files in order"
+                "output files in order"
             )
             raise ValueError(msg)
 

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -1,3 +1,5 @@
+"""Typed settings and results for the three-step EMPIR analysis pipeline."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -12,6 +14,7 @@ from hermes.state.models.shared_models import (
     StrictBaseModel,
 )
 
+# Values recorded while each external EMPIR program runs.
 EmpirRunStatus = Literal["planned", "running", "completed", "failed"]
 EmpirExternalTriggerMode = Literal["ignore", "reference", "frameSync"]
 EmpirTiffFormat = Literal["tiff_w4", "tiff_w8"]
@@ -22,6 +25,7 @@ def _validate_suffix(
     suffixes: tuple[str, ...],
     field_name: str,
 ) -> Path:
+    """Require a path to use one of the allowed filename suffixes."""
     if path.suffix.lower() not in suffixes:
         expected = " or ".join(suffixes)
         msg = f"{field_name} must use the {expected} filename suffix"
@@ -34,11 +38,14 @@ def _validate_file_reference_suffix(
     suffixes: tuple[str, ...],
     field_name: str,
 ) -> FileReference:
+    """Apply a filename-suffix check to a file entry."""
     _validate_suffix(file.path, suffixes, field_name)
     return file
 
 
 class EmpirPixelToPhotonSettings(StrictBaseModel):
+    """Settings passed to ``empir_pixel2photon_tpx3spidr``."""
+
     spatial_distance_pixels: float = Field(ge=0)
     time_distance_seconds: float = Field(ge=0)
     minimum_pixel_count: int = Field(ge=1)
@@ -46,6 +53,8 @@ class EmpirPixelToPhotonSettings(StrictBaseModel):
 
 
 class EmpirPixelToPhotonResult(StrictBaseModel):
+    """Recorded outcome from one pixel-to-photon process."""
+
     status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
@@ -57,6 +66,8 @@ class EmpirPixelToPhotonResult(StrictBaseModel):
 
 
 class EmpirPixelToPhotonRun(StrictBaseModel):
+    """Input, requested output, command, and result for one raw TPX3 file."""
+
     input_tpx3_file: FileReference
     requested_photon_file: Path
     command_args: list[str] = Field(
@@ -72,6 +83,7 @@ class EmpirPixelToPhotonRun(StrictBaseModel):
     def validate_input_tpx3_file(
         cls, value: FileReference
     ) -> FileReference:
+        """Require the pixel-to-photon input to be a TPX3 file."""
         return _validate_file_reference_suffix(
             value, (".tpx3",), "input_tpx3_file"
         )
@@ -79,24 +91,31 @@ class EmpirPixelToPhotonRun(StrictBaseModel):
     @field_validator("requested_photon_file")
     @classmethod
     def validate_requested_photon_file(cls, value: Path) -> Path:
+        """Require EMPIR's photon output filename."""
         return _validate_suffix(
             value, (".empirphot",), "requested_photon_file"
         )
 
 
 class EmpirPixelToPhotonState(StrictBaseModel):
+    """Program, shared settings, and runs for pixel-to-photon processing."""
+
     program: BinaryProgram
     settings: EmpirPixelToPhotonSettings
     runs: list[EmpirPixelToPhotonRun] = Field(min_length=1)
 
 
 class EmpirPhotonToEventSettings(StrictBaseModel):
+    """Settings passed to ``empir_photon2event``."""
+
     spatial_distance_pixels: float = Field(ge=0)
     time_distance_seconds: float = Field(ge=0)
     maximum_duration_seconds: float = Field(ge=0)
 
 
 class EmpirPhotonToEventResult(StrictBaseModel):
+    """Recorded outcome from one photon-to-event process."""
+
     status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
@@ -108,6 +127,8 @@ class EmpirPhotonToEventResult(StrictBaseModel):
 
 
 class EmpirPhotonToEventRun(StrictBaseModel):
+    """Input, requested output, command, and result for one photon file."""
+
     input_photon_file: FileReference
     requested_event_file: Path
     command_args: list[str] = Field(
@@ -123,6 +144,7 @@ class EmpirPhotonToEventRun(StrictBaseModel):
     def validate_input_photon_file(
         cls, value: FileReference
     ) -> FileReference:
+        """Require the photon-to-event input to be an EMPIR photon file."""
         return _validate_file_reference_suffix(
             value, (".empirphot",), "input_photon_file"
         )
@@ -130,18 +152,23 @@ class EmpirPhotonToEventRun(StrictBaseModel):
     @field_validator("requested_event_file")
     @classmethod
     def validate_requested_event_file(cls, value: Path) -> Path:
+        """Require EMPIR's event output filename."""
         return _validate_suffix(
             value, (".empirevent",), "requested_event_file"
         )
 
 
 class EmpirPhotonToEventState(StrictBaseModel):
+    """Program, shared settings, and runs for photon-to-event processing."""
+
     program: BinaryProgram
     settings: EmpirPhotonToEventSettings
     runs: list[EmpirPhotonToEventRun] = Field(min_length=1)
 
 
 class EmpirEventToImageSettings(StrictBaseModel):
+    """Settings passed to ``empir_event2image``."""
+
     image_width_pixels: int = Field(gt=0)
     image_height_pixels: int | None = Field(default=None, gt=0)
     minimum_photon_count: int | None = Field(default=None, ge=0)
@@ -156,6 +183,7 @@ class EmpirEventToImageSettings(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_ranges_and_time_bins(self) -> EmpirEventToImageSettings:
+        """Check paired ranges and time-bin settings."""
         if (
             self.minimum_photon_count is not None
             and self.maximum_photon_count is not None
@@ -180,6 +208,8 @@ class EmpirEventToImageSettings(StrictBaseModel):
 
 
 class EmpirEventToImageResult(StrictBaseModel):
+    """Recorded outcome from the event-to-image process."""
+
     status: EmpirRunStatus = "planned"
     started_at: datetime | None = None
     completed_at: datetime | None = None
@@ -191,6 +221,8 @@ class EmpirEventToImageResult(StrictBaseModel):
 
 
 class EmpirEventToImageState(StrictBaseModel):
+    """Inputs, settings, requested TIFF, command, and image result."""
+
     program: BinaryProgram
     settings: EmpirEventToImageSettings
     input_event_files: list[FileReference] = Field(min_length=1)
@@ -206,6 +238,7 @@ class EmpirEventToImageState(StrictBaseModel):
     def validate_input_event_files(
         cls, value: list[FileReference]
     ) -> list[FileReference]:
+        """Require every image input to be an EMPIR event file."""
         for file in value:
             _validate_file_reference_suffix(
                 file, (".empirevent",), "input_event_files"
@@ -215,12 +248,15 @@ class EmpirEventToImageState(StrictBaseModel):
     @field_validator("requested_tiff_file")
     @classmethod
     def validate_requested_tiff_file(cls, value: Path) -> Path:
+        """Require the final output to use a TIFF filename."""
         return _validate_suffix(
             value, (".tif", ".tiff"), "requested_tiff_file"
         )
 
 
 class EmpirAnalysisState(StrictBaseModel):
+    """Configuration and progress for one complete EMPIR analysis."""
+
     mode: Literal["empir"] = "empir"
     version: str | None = None
     save_photon_files: bool = False
@@ -231,6 +267,8 @@ class EmpirAnalysisState(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_pipeline_paths(self) -> EmpirAnalysisState:
+        """Require each step to read the preceding step's requested files."""
+        # List order connects each upstream run to its downstream run.
         requested_photon_files = [
             run.requested_photon_file for run in self.pixel_to_photon.runs
         ]

--- a/src/hermes/workflows/workflow.py
+++ b/src/hermes/workflows/workflow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from loguru import logger
 
-from hermes.runner.analysis.hermes.run import run_hermes_analysis
+from hermes.runner.analysis.run import run_analysis
 from hermes.logging import configure_logging
 from hermes.state.models.shared_models import FileReference
 from hermes.state.state import HermesRecord
@@ -31,7 +31,7 @@ class Workflow:
         )
 
     def run_analysis(self, *, overwrite: bool = False) -> list[FileReference]:
-        return run_hermes_analysis(
+        return run_analysis(
             self._state_manager,
             overwrite=overwrite,
         )

--- a/tests/unit/examples/analysis/test_unpacker_single_file.py
+++ b/tests/unit/examples/analysis/test_unpacker_single_file.py
@@ -70,7 +70,7 @@ def test_invalid_yaml_stops_before_analysis(
         raise AssertionError("analysis must not run for invalid YAML")
 
     monkeypatch.setattr(
-        "hermes.workflows.workflow.run_hermes_analysis",
+        "hermes.workflows.workflow.run_analysis",
         fail_if_called,
     )
 
@@ -123,7 +123,7 @@ analysis:
         return current_record.analysis.unpacking.tpx3_files
 
     monkeypatch.setattr(
-        "hermes.workflows.workflow.run_hermes_analysis",
+        "hermes.workflows.workflow.run_analysis",
         run_without_subprocess,
     )
 

--- a/tests/unit/hermes/runner/analysis/empir/_fake_program.py
+++ b/tests/unit/hermes/runner/analysis/empir/_fake_program.py
@@ -1,0 +1,33 @@
+"""Small fake EMPIR program used by process execution tests."""
+
+import sys
+import textwrap
+from pathlib import Path
+
+
+def write_fake_empir_program(executable: Path) -> None:
+    """Write a program controlled by the contents of its first input file."""
+    script = textwrap.dedent(
+        f"""\
+        #!{sys.executable}
+        import sys
+        from pathlib import Path
+
+        arguments = sys.argv[1:]
+        input_value = arguments[arguments.index("-i") + 1]
+        input_path = Path(input_value.split(",")[0])
+        output_path = Path(arguments[arguments.index("-o") + 1])
+        mode = input_path.read_text(encoding="utf-8").strip() or "success"
+
+        print("o" * 5_000)
+        print("e" * 5_000, file=sys.stderr)
+        if mode == "nonzero":
+            raise SystemExit(7)
+        if mode != "missing_output":
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text("generated", encoding="utf-8")
+        """
+    )
+    executable.parent.mkdir(parents=True, exist_ok=True)
+    executable.write_text(script, encoding="utf-8")
+    executable.chmod(0o755)

--- a/tests/unit/hermes/runner/analysis/empir/test_event_to_image.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_event_to_image.py
@@ -30,7 +30,7 @@ def _stage(
             executable_path="empir_event2image",
         ),
         settings=settings,
-        input_event_files=[
+        event_files=[
             FileReference(path=tmp_path / f"input-{index}.empirevent")
             for index in range(input_count)
         ],
@@ -121,7 +121,7 @@ def test_execute_event_to_image_records_result_and_logs(tmp_path: Path) -> None:
         EmpirEventToImageSettings(image_width_pixels=512),
         input_count=2,
     )
-    for input_file in stage.input_event_files:
+    for input_file in stage.event_files:
         input_file.path.write_text("success", encoding="utf-8")
     executable = tmp_path / "bin/empir_event2image"
     write_fake_empir_program(executable)
@@ -134,8 +134,8 @@ def test_execute_event_to_image_records_result_and_logs(tmp_path: Path) -> None:
         logger.remove(sink_id)
 
     assert result.status == "completed"
-    assert result.saved_tiff_file is not None
-    assert result.saved_tiff_file.path == stage.tiff_file
+    assert result.tiff_file is not None
+    assert result.tiff_file.path == stage.tiff_file
     completed = next(
         record["extra"]
         for record in records
@@ -143,6 +143,6 @@ def test_execute_event_to_image_records_result_and_logs(tmp_path: Path) -> None:
         == "analysis.empir.event_to_image.completed"
     )
     assert completed["input_files"] == [
-        str(file.path) for file in stage.input_event_files
+        str(file.path) for file in stage.event_files
     ]
     assert completed["input_file_count"] == 2

--- a/tests/unit/hermes/runner/analysis/empir/test_event_to_image.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_event_to_image.py
@@ -1,0 +1,148 @@
+"""Tests for EMPIR event-to-image command construction."""
+
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from hermes.runner.analysis.empir.event_to_image import (
+    build_event_to_image_command,
+    execute_event_to_image,
+)
+from hermes.state.models.analysis.empir import (
+    EmpirEventToImageSettings,
+    EmpirEventToImageState,
+)
+from hermes.state.models.shared_models import BinaryProgram, FileReference
+from _fake_program import write_fake_empir_program
+
+
+def _stage(
+    tmp_path: Path,
+    settings: EmpirEventToImageSettings,
+    *,
+    input_count: int = 1,
+) -> EmpirEventToImageState:
+    """Build one event-to-image stage for command tests."""
+    return EmpirEventToImageState(
+        program=BinaryProgram(
+            name="empir-event2image",
+            executable_path="empir_event2image",
+        ),
+        settings=settings,
+        input_event_files=[
+            FileReference(path=tmp_path / f"input-{index}.empirevent")
+            for index in range(input_count)
+        ],
+        requested_tiff_file=tmp_path / "image.tiff",
+    )
+
+
+def test_build_event_to_image_minimal_command(tmp_path: Path) -> None:
+    """Omit every unset image option and pass exact event files with ``-i``."""
+    stage = _stage(
+        tmp_path,
+        EmpirEventToImageSettings(image_width_pixels=512),
+    )
+    executable = tmp_path / "bin/empir_event2image"
+
+    assert build_event_to_image_command(stage, executable) == [
+        str(executable),
+        "-i",
+        str(tmp_path / "input-0.empirevent"),
+        "-o",
+        str(tmp_path / "image.tiff"),
+        "-x",
+        "512",
+    ]
+
+
+@pytest.mark.parametrize(("parallel", "serialized"), [(True, "true"), (False, "false")])
+def test_build_event_to_image_full_command(
+    tmp_path: Path,
+    parallel: bool,
+    serialized: str,
+) -> None:
+    """Map every optional image setting and lowercase the parallel value."""
+    stage = _stage(
+        tmp_path,
+        EmpirEventToImageSettings(
+            image_width_pixels=2048,
+            image_height_pixels=1024,
+            minimum_photon_count=3,
+            maximum_photon_count=20,
+            minimum_psd=5e-6,
+            maximum_psd=2e-5,
+            external_trigger_mode="frameSync",
+            time_bin_width_seconds=10e-6,
+            time_bin_count=1000,
+            tiff_format="tiff_w8",
+            parallel=parallel,
+        ),
+        input_count=2,
+    )
+    executable = tmp_path / "bin/empir_event2image"
+
+    assert build_event_to_image_command(stage, executable) == [
+        str(executable),
+        "-i",
+        f"{tmp_path / 'input-0.empirevent'},{tmp_path / 'input-1.empirevent'}",
+        "-o",
+        str(tmp_path / "image.tiff"),
+        "-x",
+        "2048",
+        "-y",
+        "1024",
+        "-m",
+        "3",
+        "-M",
+        "20",
+        "-p",
+        "5e-06",
+        "-P",
+        "2e-05",
+        "-E",
+        "frameSync",
+        "-t",
+        "1e-05",
+        "-T",
+        "1000",
+        "--fileFormat",
+        "tiff_w8",
+        "--parallel",
+        serialized,
+    ]
+
+
+def test_execute_event_to_image_records_result_and_logs(tmp_path: Path) -> None:
+    """Run event-to-image with multiple exact inputs and verify its TIFF."""
+    stage = _stage(
+        tmp_path,
+        EmpirEventToImageSettings(image_width_pixels=512),
+        input_count=2,
+    )
+    for input_file in stage.input_event_files:
+        input_file.path.write_text("success", encoding="utf-8")
+    executable = tmp_path / "bin/empir_event2image"
+    write_fake_empir_program(executable)
+    records: list[dict[str, object]] = []
+    sink_id = logger.add(lambda message: records.append(message.record))
+
+    try:
+        result = execute_event_to_image(stage, executable)
+    finally:
+        logger.remove(sink_id)
+
+    assert result.status == "completed"
+    assert result.saved_tiff_file is not None
+    assert result.saved_tiff_file.path == stage.requested_tiff_file
+    completed = next(
+        record["extra"]
+        for record in records
+        if record["extra"].get("event_type")
+        == "analysis.empir.event_to_image.completed"
+    )
+    assert completed["input_files"] == [
+        str(file.path) for file in stage.input_event_files
+    ]
+    assert completed["input_file_count"] == 2

--- a/tests/unit/hermes/runner/analysis/empir/test_event_to_image.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_event_to_image.py
@@ -34,7 +34,7 @@ def _stage(
             FileReference(path=tmp_path / f"input-{index}.empirevent")
             for index in range(input_count)
         ],
-        requested_tiff_file=tmp_path / "image.tiff",
+        tiff_file=tmp_path / "image.tiff",
     )
 
 
@@ -135,7 +135,7 @@ def test_execute_event_to_image_records_result_and_logs(tmp_path: Path) -> None:
 
     assert result.status == "completed"
     assert result.saved_tiff_file is not None
-    assert result.saved_tiff_file.path == stage.requested_tiff_file
+    assert result.saved_tiff_file.path == stage.tiff_file
     completed = next(
         record["extra"]
         for record in records

--- a/tests/unit/hermes/runner/analysis/empir/test_executable.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_executable.py
@@ -1,0 +1,52 @@
+"""Tests for resolving configured EMPIR executables."""
+
+from pathlib import Path
+
+import pytest
+
+from hermes.runner.analysis.empir._executable import resolve_executable
+
+
+def _write_executable(path: Path) -> None:
+    """Create a small executable file for resolver tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_resolve_executable_accepts_explicit_path(tmp_path: Path) -> None:
+    """Resolve an explicit relative or absolute executable path."""
+    executable = tmp_path / "bin/empir_photon2event"
+    _write_executable(executable)
+
+    assert resolve_executable(executable) == executable.resolve()
+
+
+def test_resolve_executable_finds_bare_name_on_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use PATH lookup when configuration contains only a program name."""
+    executable = tmp_path / "bin/empir_event2image"
+    _write_executable(executable)
+    monkeypatch.setenv("PATH", str(executable.parent))
+
+    assert resolve_executable(Path(executable.name)) == executable.resolve()
+
+
+def test_resolve_executable_rejects_missing_program(tmp_path: Path) -> None:
+    """Report an explicit executable path that does not exist."""
+    missing_path = tmp_path / "bin/empir_pixel2photon_tpx3spidr"
+
+    with pytest.raises(FileNotFoundError, match="is not a file"):
+        resolve_executable(missing_path)
+
+
+def test_resolve_executable_rejects_non_executable_file(tmp_path: Path) -> None:
+    """Report a configured program file without execute permission."""
+    executable = tmp_path / "bin/empir_photon2event"
+    executable.parent.mkdir(parents=True)
+    executable.write_text("not executable", encoding="utf-8")
+
+    with pytest.raises(PermissionError, match="is not executable"):
+        resolve_executable(executable)

--- a/tests/unit/hermes/runner/analysis/empir/test_photon_to_event.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_photon_to_event.py
@@ -1,0 +1,130 @@
+"""Tests for EMPIR photon-to-event command construction."""
+
+from pathlib import Path
+
+from loguru import logger
+
+from hermes.runner.analysis.empir.photon_to_event import (
+    build_photon_to_event_command,
+    execute_photon_to_event,
+)
+from hermes.state.models.analysis.empir import (
+    EmpirPhotonToEventRun,
+    EmpirPhotonToEventSettings,
+    EmpirPhotonToEventState,
+)
+from hermes.state.models.shared_models import BinaryProgram, FileReference
+from _fake_program import write_fake_empir_program
+
+
+def _stage(
+    tmp_path: Path,
+    *,
+    spatial_distance: float,
+    time_distance: float,
+    maximum_duration: float,
+) -> EmpirPhotonToEventState:
+    """Build one photon-to-event stage for command tests."""
+    return EmpirPhotonToEventState(
+        program=BinaryProgram(
+            name="empir-photon2event",
+            executable_path="empir_photon2event",
+        ),
+        settings=EmpirPhotonToEventSettings(
+            spatial_distance_pixels=spatial_distance,
+            time_distance_seconds=time_distance,
+            maximum_duration_seconds=maximum_duration,
+        ),
+        runs=[
+            EmpirPhotonToEventRun(
+                input_photon_file=FileReference(
+                    path=tmp_path / "raw.empirphot"
+                ),
+                requested_event_file=tmp_path / "raw.empirevent",
+            )
+        ],
+    )
+
+
+def test_build_photon_to_event_minimal_command(tmp_path: Path) -> None:
+    """Build the command when each required numeric setting is zero."""
+    stage = _stage(
+        tmp_path,
+        spatial_distance=0,
+        time_distance=0,
+        maximum_duration=0,
+    )
+    executable = tmp_path / "bin/empir_photon2event"
+
+    assert build_photon_to_event_command(
+        stage, stage.runs[0], executable
+    ) == [
+        str(executable),
+        "-i",
+        str(tmp_path / "raw.empirphot"),
+        "-o",
+        str(tmp_path / "raw.empirevent"),
+        "-s",
+        "0.0",
+        "-t",
+        "0.0",
+        "-D",
+        "0.0",
+    ]
+
+
+def test_build_photon_to_event_full_command(tmp_path: Path) -> None:
+    """Map all photon-to-event settings to their documented short flags."""
+    stage = _stage(
+        tmp_path,
+        spatial_distance=4,
+        time_distance=100e-6,
+        maximum_duration=500e-6,
+    )
+    executable = tmp_path / "bin/empir_photon2event"
+
+    assert build_photon_to_event_command(
+        stage, stage.runs[0], executable
+    ) == [
+        str(executable),
+        "-i",
+        str(tmp_path / "raw.empirphot"),
+        "-o",
+        str(tmp_path / "raw.empirevent"),
+        "-s",
+        "4.0",
+        "-t",
+        "0.0001",
+        "-D",
+        "0.0005",
+    ]
+
+
+def test_execute_photon_to_event_records_result_and_logs(tmp_path: Path) -> None:
+    """Run the photon-to-event program and record its completed event."""
+    stage = _stage(
+        tmp_path,
+        spatial_distance=4,
+        time_distance=100e-6,
+        maximum_duration=500e-6,
+    )
+    run = stage.runs[0]
+    run.input_photon_file.path.write_text("success", encoding="utf-8")
+    executable = tmp_path / "bin/empir_photon2event"
+    write_fake_empir_program(executable)
+    records: list[dict[str, object]] = []
+    sink_id = logger.add(lambda message: records.append(message.record))
+
+    try:
+        result = execute_photon_to_event(stage, run, executable)
+    finally:
+        logger.remove(sink_id)
+
+    assert result.status == "completed"
+    assert result.saved_event_file is not None
+    assert result.saved_event_file.path == run.requested_event_file
+    event_types = [
+        record["extra"].get("event_type") for record in records
+    ]
+    assert "analysis.empir.photon_to_event.started" in event_types
+    assert "analysis.empir.photon_to_event.completed" in event_types

--- a/tests/unit/hermes/runner/analysis/empir/test_photon_to_event.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_photon_to_event.py
@@ -37,7 +37,7 @@ def _stage(
         ),
         runs=[
             EmpirPhotonToEventRun(
-                input_photon_file=FileReference(
+                photon_file=FileReference(
                     path=tmp_path / "raw.empirphot"
                 ),
                 event_file=tmp_path / "raw.empirevent",
@@ -109,7 +109,7 @@ def test_execute_photon_to_event_records_result_and_logs(tmp_path: Path) -> None
         maximum_duration=500e-6,
     )
     run = stage.runs[0]
-    run.input_photon_file.path.write_text("success", encoding="utf-8")
+    run.photon_file.path.write_text("success", encoding="utf-8")
     executable = tmp_path / "bin/empir_photon2event"
     write_fake_empir_program(executable)
     records: list[dict[str, object]] = []
@@ -121,8 +121,8 @@ def test_execute_photon_to_event_records_result_and_logs(tmp_path: Path) -> None
         logger.remove(sink_id)
 
     assert result.status == "completed"
-    assert result.saved_event_file is not None
-    assert result.saved_event_file.path == run.event_file
+    assert result.event_file is not None
+    assert result.event_file.path == run.event_file
     event_types = [
         record["extra"].get("event_type") for record in records
     ]

--- a/tests/unit/hermes/runner/analysis/empir/test_photon_to_event.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_photon_to_event.py
@@ -40,7 +40,7 @@ def _stage(
                 input_photon_file=FileReference(
                     path=tmp_path / "raw.empirphot"
                 ),
-                requested_event_file=tmp_path / "raw.empirevent",
+                event_file=tmp_path / "raw.empirevent",
             )
         ],
     )
@@ -122,7 +122,7 @@ def test_execute_photon_to_event_records_result_and_logs(tmp_path: Path) -> None
 
     assert result.status == "completed"
     assert result.saved_event_file is not None
-    assert result.saved_event_file.path == run.requested_event_file
+    assert result.saved_event_file.path == run.event_file
     event_types = [
         record["extra"].get("event_type") for record in records
     ]

--- a/tests/unit/hermes/runner/analysis/empir/test_pixel_to_photon.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_pixel_to_photon.py
@@ -38,7 +38,7 @@ def _stage(tmp_path: Path, *, include_tdc1: bool) -> EmpirPixelToPhotonState:
         ),
         runs=[
             EmpirPixelToPhotonRun(
-                input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
+                tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
                 photon_file=tmp_path / "raw.empirphot",
             )
         ],
@@ -82,7 +82,7 @@ def test_execute_pixel_to_photon_records_result_and_logs(tmp_path: Path) -> None
     """Record verified output, timing, and bounded process text on success."""
     stage = _stage(tmp_path, include_tdc1=True)
     run = stage.runs[0]
-    run.input_tpx3_file.path.write_text("success", encoding="utf-8")
+    run.tpx3_file.path.write_text("success", encoding="utf-8")
     executable = tmp_path / "bin/empir_pixel2photon_tpx3spidr"
     write_fake_empir_program(executable)
     records: list[dict[str, object]] = []
@@ -97,8 +97,8 @@ def test_execute_pixel_to_photon_records_result_and_logs(tmp_path: Path) -> None
     assert result.exit_code == 0
     assert result.elapsed_seconds is not None
     assert result.elapsed_seconds >= 0
-    assert result.saved_photon_file is not None
-    assert result.saved_photon_file.path == run.photon_file
+    assert result.photon_file is not None
+    assert result.photon_file.path == run.photon_file
     events = [
         record["extra"]
         for record in records
@@ -138,7 +138,7 @@ def test_execute_pixel_to_photon_reports_process_failure(
     """Report nonzero exits and zero exits without the requested output."""
     stage = _stage(tmp_path, include_tdc1=False)
     run = stage.runs[0]
-    run.input_tpx3_file.path.write_text(mode, encoding="utf-8")
+    run.tpx3_file.path.write_text(mode, encoding="utf-8")
     executable = tmp_path / "bin/empir_pixel2photon_tpx3spidr"
     write_fake_empir_program(executable)
     records: list[dict[str, object]] = []
@@ -167,7 +167,7 @@ def test_execute_pixel_to_photon_reports_launch_failure(tmp_path: Path) -> None:
     """Record elapsed time and no exit code when process launch fails."""
     stage = _stage(tmp_path, include_tdc1=False)
     run = stage.runs[0]
-    run.input_tpx3_file.path.write_text("success", encoding="utf-8")
+    run.tpx3_file.path.write_text("success", encoding="utf-8")
     missing_executable = tmp_path / "bin/missing"
 
     with pytest.raises(EmpirExecutionError, match="failed to launch") as raised:

--- a/tests/unit/hermes/runner/analysis/empir/test_pixel_to_photon.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_pixel_to_photon.py
@@ -1,0 +1,186 @@
+"""Tests for EMPIR pixel-to-photon command construction."""
+
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from hermes.runner.analysis.empir._errors import (
+    EmpirExecutionError,
+    EmpirOutputError,
+    EmpirPreflightError,
+)
+from hermes.runner.analysis.empir.pixel_to_photon import (
+    build_pixel_to_photon_command,
+    execute_pixel_to_photon,
+)
+from hermes.state.models.analysis.empir import (
+    EmpirPixelToPhotonRun,
+    EmpirPixelToPhotonSettings,
+    EmpirPixelToPhotonState,
+)
+from hermes.state.models.shared_models import BinaryProgram, FileReference
+from _fake_program import write_fake_empir_program
+
+
+def _stage(tmp_path: Path, *, include_tdc1: bool) -> EmpirPixelToPhotonState:
+    """Build one pixel-to-photon stage for command tests."""
+    return EmpirPixelToPhotonState(
+        program=BinaryProgram(
+            name="empir-pixel2photon",
+            executable_path="empir_pixel2photon_tpx3spidr",
+        ),
+        settings=EmpirPixelToPhotonSettings(
+            spatial_distance_pixels=5,
+            time_distance_seconds=500e-9,
+            minimum_pixel_count=3,
+            include_tdc1=include_tdc1,
+        ),
+        runs=[
+            EmpirPixelToPhotonRun(
+                input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
+                requested_photon_file=tmp_path / "raw.empirphot",
+            )
+        ],
+    )
+
+
+def test_build_pixel_to_photon_minimal_command(tmp_path: Path) -> None:
+    """Omit the optional TDC1 flag when it is disabled."""
+    stage = _stage(tmp_path, include_tdc1=False)
+    executable = tmp_path / "bin/empir_pixel2photon_tpx3spidr"
+
+    assert build_pixel_to_photon_command(
+        stage, stage.runs[0], executable
+    ) == [
+        str(executable),
+        "-i",
+        str(tmp_path / "raw.tpx3"),
+        "-o",
+        str(tmp_path / "raw.empirphot"),
+        "-s",
+        "5.0",
+        "-t",
+        "5e-07",
+        "-k",
+        "3",
+    ]
+
+
+def test_build_pixel_to_photon_full_command(tmp_path: Path) -> None:
+    """Append the standalone TDC1 flag when it is enabled."""
+    stage = _stage(tmp_path, include_tdc1=True)
+    executable = tmp_path / "bin/empir_pixel2photon_tpx3spidr"
+
+    command = build_pixel_to_photon_command(stage, stage.runs[0], executable)
+
+    assert command[-1] == "-T"
+    assert command.count("-T") == 1
+
+
+def test_execute_pixel_to_photon_records_result_and_logs(tmp_path: Path) -> None:
+    """Record verified output, timing, and bounded process text on success."""
+    stage = _stage(tmp_path, include_tdc1=True)
+    run = stage.runs[0]
+    run.input_tpx3_file.path.write_text("success", encoding="utf-8")
+    executable = tmp_path / "bin/empir_pixel2photon_tpx3spidr"
+    write_fake_empir_program(executable)
+    records: list[dict[str, object]] = []
+    sink_id = logger.add(lambda message: records.append(message.record))
+
+    try:
+        result = execute_pixel_to_photon(stage, run, executable)
+    finally:
+        logger.remove(sink_id)
+
+    assert result.status == "completed"
+    assert result.exit_code == 0
+    assert result.elapsed_seconds is not None
+    assert result.elapsed_seconds >= 0
+    assert result.saved_photon_file is not None
+    assert result.saved_photon_file.path == run.requested_photon_file
+    events = [
+        record["extra"]
+        for record in records
+        if str(record["extra"].get("event_type", "")).startswith(
+            "analysis.empir.pixel_to_photon."
+        )
+    ]
+    assert [event["event_type"] for event in events] == [
+        "analysis.empir.pixel_to_photon.started",
+        "analysis.empir.pixel_to_photon.completed",
+    ]
+    completed = events[1]
+    assert completed["domain"] == "analysis"
+    assert completed["mode"] == "empir"
+    assert completed["step"] == "pixel_to_photon"
+    assert completed["resolved_executable_path"] == str(executable)
+    assert completed["input_size_bytes"] == len("success")
+    assert completed["exit_code"] == 0
+    assert len(completed["stdout_excerpt"]) == 4_000
+    assert len(completed["stderr_excerpt"]) == 4_000
+
+
+@pytest.mark.parametrize(
+    ("mode", "error_type", "message", "exit_code"),
+    [
+        ("nonzero", EmpirExecutionError, "exited with code 7", 7),
+        ("missing_output", EmpirOutputError, "did not create", 0),
+    ],
+)
+def test_execute_pixel_to_photon_reports_process_failure(
+    tmp_path: Path,
+    mode: str,
+    error_type: type[EmpirExecutionError],
+    message: str,
+    exit_code: int,
+) -> None:
+    """Report nonzero exits and zero exits without the requested output."""
+    stage = _stage(tmp_path, include_tdc1=False)
+    run = stage.runs[0]
+    run.input_tpx3_file.path.write_text(mode, encoding="utf-8")
+    executable = tmp_path / "bin/empir_pixel2photon_tpx3spidr"
+    write_fake_empir_program(executable)
+    records: list[dict[str, object]] = []
+    sink_id = logger.add(lambda log: records.append(log.record))
+
+    try:
+        with pytest.raises(error_type, match=message) as raised:
+            execute_pixel_to_photon(stage, run, executable)
+    finally:
+        logger.remove(sink_id)
+
+    assert raised.value.outcome.exit_code == exit_code
+    failed = next(
+        record["extra"]
+        for record in records
+        if record["extra"].get("event_type")
+        == "analysis.empir.pixel_to_photon.failed"
+    )
+    assert failed["exit_code"] == exit_code
+    assert len(failed["stdout_excerpt"]) == 4_000
+    assert len(failed["stderr_excerpt"]) == 4_000
+    assert message in failed["error"]
+
+
+def test_execute_pixel_to_photon_reports_launch_failure(tmp_path: Path) -> None:
+    """Record elapsed time and no exit code when process launch fails."""
+    stage = _stage(tmp_path, include_tdc1=False)
+    run = stage.runs[0]
+    run.input_tpx3_file.path.write_text("success", encoding="utf-8")
+    missing_executable = tmp_path / "bin/missing"
+
+    with pytest.raises(EmpirExecutionError, match="failed to launch") as raised:
+        execute_pixel_to_photon(stage, run, missing_executable)
+
+    assert raised.value.outcome.exit_code is None
+    assert raised.value.outcome.elapsed_seconds >= 0
+
+
+def test_execute_pixel_to_photon_checks_paths_before_start(tmp_path: Path) -> None:
+    """Reject a missing input before starting an external process."""
+    stage = _stage(tmp_path, include_tdc1=False)
+    run = stage.runs[0]
+
+    with pytest.raises(EmpirPreflightError, match="input is not a regular file"):
+        execute_pixel_to_photon(stage, run, tmp_path / "bin/program")

--- a/tests/unit/hermes/runner/analysis/empir/test_pixel_to_photon.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_pixel_to_photon.py
@@ -39,7 +39,7 @@ def _stage(tmp_path: Path, *, include_tdc1: bool) -> EmpirPixelToPhotonState:
         runs=[
             EmpirPixelToPhotonRun(
                 input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
-                requested_photon_file=tmp_path / "raw.empirphot",
+                photon_file=tmp_path / "raw.empirphot",
             )
         ],
     )
@@ -98,7 +98,7 @@ def test_execute_pixel_to_photon_records_result_and_logs(tmp_path: Path) -> None
     assert result.elapsed_seconds is not None
     assert result.elapsed_seconds >= 0
     assert result.saved_photon_file is not None
-    assert result.saved_photon_file.path == run.requested_photon_file
+    assert result.saved_photon_file.path == run.photon_file
     events = [
         record["extra"]
         for record in records

--- a/tests/unit/hermes/runner/analysis/empir/test_run.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_run.py
@@ -120,13 +120,13 @@ def _analysis(
         raw_path.write_text(mode, encoding="utf-8")
         pixel_runs.append(
             EmpirPixelToPhotonRun(
-                input_tpx3_file=FileReference(path=raw_path),
+                tpx3_file=FileReference(path=raw_path),
                 photon_file=photon_path,
             )
         )
         photon_runs.append(
             EmpirPhotonToEventRun(
-                input_photon_file=FileReference(path=photon_path),
+                photon_file=FileReference(path=photon_path),
                 event_file=event_path,
             )
         )
@@ -165,7 +165,7 @@ def _analysis(
                 executable_path=executables["image"],
             ),
             settings=EmpirEventToImageSettings(image_width_pixels=512),
-            input_event_files=event_files,
+            event_files=event_files,
             tiff_file=tmp_path / "out/final.tiff",
         ),
     )
@@ -193,8 +193,8 @@ def test_run_empir_analysis_completes_and_removes_intermediates(
     assert current.photon_to_event.runs[0].result.status == "completed"
     assert current.event_to_image.result.status == "completed"
     assert current.pixel_to_photon.runs[0].command_args[0] == "-i"
-    assert current.photon_to_event.runs[0].input_photon_file.path.exists() is False
-    assert current.event_to_image.input_event_files[0].path.exists() is False
+    assert current.photon_to_event.runs[0].photon_file.path.exists() is False
+    assert current.event_to_image.event_files[0].path.exists() is False
     assert initial_analysis.pixel_to_photon.runs[0].result.status == "planned"
     assert [change.status for change in state_logger.changes].count("applied") == 6
     event_types = [
@@ -324,7 +324,7 @@ def test_run_empir_analysis_retains_photon_after_downstream_failure(
 
     current = manager.get_state().analysis
     assert isinstance(current, EmpirAnalysisState)
-    assert current.photon_to_event.runs[0].input_photon_file.path.is_file()
+    assert current.photon_to_event.runs[0].photon_file.path.is_file()
     assert current.photon_to_event.runs[0].result.status == "failed"
     assert current.event_to_image.result.status == "planned"
 
@@ -348,5 +348,5 @@ def test_run_empir_analysis_keeps_intermediates_when_configured(
 
     current = manager.get_state().analysis
     assert isinstance(current, EmpirAnalysisState)
-    assert current.photon_to_event.runs[0].input_photon_file.path.is_file()
-    assert current.event_to_image.input_event_files[0].path.is_file()
+    assert current.photon_to_event.runs[0].photon_file.path.is_file()
+    assert current.event_to_image.event_files[0].path.is_file()

--- a/tests/unit/hermes/runner/analysis/empir/test_run.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_run.py
@@ -1,0 +1,352 @@
+"""Tests for coordinating a complete EMPIR analysis."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from loguru import logger
+
+from hermes.runner.analysis.empir._errors import (
+    EmpirExecutionError,
+    EmpirPreflightError,
+)
+from hermes.runner.analysis.empir.run import run_empir_analysis
+from hermes.state.models.analysis.empir import (
+    EmpirAnalysisState,
+    EmpirEventToImageSettings,
+    EmpirEventToImageState,
+    EmpirPhotonToEventRun,
+    EmpirPhotonToEventSettings,
+    EmpirPhotonToEventState,
+    EmpirPixelToPhotonRun,
+    EmpirPixelToPhotonSettings,
+    EmpirPixelToPhotonState,
+)
+from hermes.state.models.environment import RuntimeEnvironment
+from hermes.state.models.measurement import MeasurementInfo
+from hermes.state.models.shared_models import BinaryProgram, FileReference
+from hermes.state.state import HermesRecord
+from hermes.state_service.change_requests import ChangeRequest
+from hermes.state_service.shared_types import StateServiceConfig
+from hermes.state_service.state_manager import StateManager
+from _fake_program import write_fake_empir_program
+
+
+class CapturingStateLogger:
+    """Capture StateManager writes without touching the JSONL logger."""
+
+    def __init__(self) -> None:
+        self.changes: list[ChangeRequest] = []
+        self.initial_records: list[HermesRecord] = []
+        self.validation_failures: list[dict[str, Any]] = []
+
+    def log_initial_state(self, record: HermesRecord) -> None:
+        self.initial_records.append(record.model_copy(deep=True))
+
+    def log_change(self, change_request: ChangeRequest) -> None:
+        self.changes.append(change_request.model_copy(deep=True))
+
+    def log_validation_failure(
+        self,
+        path: str,
+        error: str,
+        *,
+        change_id: str | None = None,
+        proposed_value: Any = None,
+    ) -> None:
+        self.validation_failures.append(
+            {
+                "path": path,
+                "error": error,
+                "change_id": change_id,
+                "proposed_value": proposed_value,
+            }
+        )
+
+
+def _record(tmp_path: Path, analysis: EmpirAnalysisState) -> HermesRecord:
+    return HermesRecord(
+        measurement_info=MeasurementInfo(
+            measurement_id="empir-test",
+            run_number=1,
+        ),
+        environment=RuntimeEnvironment(working_dir=tmp_path),
+        analysis=analysis,
+    )
+
+
+def _manager(
+    tmp_path: Path,
+    analysis: EmpirAnalysisState,
+) -> tuple[StateManager, CapturingStateLogger]:
+    state_logger = CapturingStateLogger()
+    manager = StateManager(
+        _record(tmp_path, analysis),
+        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
+        state_logger=state_logger,
+    )
+    return manager, state_logger
+
+
+def _install_fake_programs(tmp_path: Path) -> dict[str, Path]:
+    paths = {
+        "pixel": tmp_path / "bin/empir_pixel2photon_tpx3spidr",
+        "photon": tmp_path / "bin/empir_photon2event",
+        "image": tmp_path / "bin/empir_event2image",
+    }
+    for executable in paths.values():
+        write_fake_empir_program(executable)
+    return paths
+
+
+def _analysis(
+    tmp_path: Path,
+    executables: dict[str, Path],
+    *,
+    raw_modes: list[str] | None = None,
+    save_photon_files: bool = False,
+    save_event_files: bool = False,
+) -> EmpirAnalysisState:
+    modes = raw_modes or ["success"]
+    photon_runs = []
+    event_files = []
+    pixel_runs = []
+    for index, mode in enumerate(modes, start=1):
+        raw_path = tmp_path / f"raw-{index}.tpx3"
+        photon_path = tmp_path / f"out/raw-{index}.empirphot"
+        event_path = tmp_path / f"out/raw-{index}.empirevent"
+        raw_path.write_text(mode, encoding="utf-8")
+        pixel_runs.append(
+            EmpirPixelToPhotonRun(
+                input_tpx3_file=FileReference(path=raw_path),
+                requested_photon_file=photon_path,
+            )
+        )
+        photon_runs.append(
+            EmpirPhotonToEventRun(
+                input_photon_file=FileReference(path=photon_path),
+                requested_event_file=event_path,
+            )
+        )
+        event_files.append(FileReference(path=event_path))
+
+    return EmpirAnalysisState(
+        save_photon_files=save_photon_files,
+        save_event_files=save_event_files,
+        pixel_to_photon=EmpirPixelToPhotonState(
+            program=BinaryProgram(
+                name="empir-pixel2photon",
+                executable_path=executables["pixel"],
+            ),
+            settings=EmpirPixelToPhotonSettings(
+                spatial_distance_pixels=5,
+                time_distance_seconds=500e-9,
+                minimum_pixel_count=3,
+            ),
+            runs=pixel_runs,
+        ),
+        photon_to_event=EmpirPhotonToEventState(
+            program=BinaryProgram(
+                name="empir-photon2event",
+                executable_path=executables["photon"],
+            ),
+            settings=EmpirPhotonToEventSettings(
+                spatial_distance_pixels=4,
+                time_distance_seconds=100e-6,
+                maximum_duration_seconds=500e-6,
+            ),
+            runs=photon_runs,
+        ),
+        event_to_image=EmpirEventToImageState(
+            program=BinaryProgram(
+                name="empir-event2image",
+                executable_path=executables["image"],
+            ),
+            settings=EmpirEventToImageSettings(image_width_pixels=512),
+            input_event_files=event_files,
+            requested_tiff_file=tmp_path / "out/final.tiff",
+        ),
+    )
+
+
+def test_run_empir_analysis_completes_and_removes_intermediates(
+    tmp_path: Path,
+) -> None:
+    """Run all three programs and save completed results in StateManager."""
+    executables = _install_fake_programs(tmp_path)
+    initial_analysis = _analysis(tmp_path, executables)
+    manager, state_logger = _manager(tmp_path, initial_analysis)
+    records: list[dict[str, object]] = []
+    sink_id = logger.add(lambda message: records.append(message.record))
+
+    try:
+        files = run_empir_analysis(manager)
+    finally:
+        logger.remove(sink_id)
+
+    assert files == [FileReference(path=tmp_path / "out/final.tiff")]
+    current = manager.get_state().analysis
+    assert isinstance(current, EmpirAnalysisState)
+    assert current.pixel_to_photon.runs[0].result.status == "completed"
+    assert current.photon_to_event.runs[0].result.status == "completed"
+    assert current.event_to_image.result.status == "completed"
+    assert current.pixel_to_photon.runs[0].command_args[0] == "-i"
+    assert current.photon_to_event.runs[0].input_photon_file.path.exists() is False
+    assert current.event_to_image.input_event_files[0].path.exists() is False
+    assert initial_analysis.pixel_to_photon.runs[0].result.status == "planned"
+    assert [change.status for change in state_logger.changes].count("applied") == 6
+    event_types = [
+        record["extra"].get("event_type")
+        for record in records
+        if str(record["extra"].get("event_type", "")).startswith(
+            "analysis.empir.pipeline."
+        )
+    ]
+    assert event_types == [
+        "analysis.empir.pipeline.started",
+        "analysis.empir.pipeline.completed",
+    ]
+
+
+def test_run_empir_analysis_processes_file_runs_in_order(
+    tmp_path: Path,
+) -> None:
+    """Complete each pixel run before moving to photon-to-event runs."""
+    executables = _install_fake_programs(tmp_path)
+    manager, state_logger = _manager(
+        tmp_path,
+        _analysis(tmp_path, executables, raw_modes=["success", "success"]),
+    )
+
+    run_empir_analysis(manager)
+
+    applied_paths = [
+        change.path for change in state_logger.changes if change.status == "applied"
+    ]
+    assert applied_paths == [
+        "analysis.pixel_to_photon.runs",
+        "analysis.pixel_to_photon.runs",
+        "analysis.pixel_to_photon.runs",
+        "analysis.pixel_to_photon.runs",
+        "analysis.photon_to_event.runs",
+        "analysis.photon_to_event.runs",
+        "analysis.photon_to_event.runs",
+        "analysis.photon_to_event.runs",
+        "analysis.event_to_image",
+        "analysis.event_to_image",
+    ]
+
+
+def test_run_empir_analysis_stops_after_first_failed_process(
+    tmp_path: Path,
+) -> None:
+    """Mark only the attempted run failed and leave downstream steps planned."""
+    executables = _install_fake_programs(tmp_path)
+    manager, _state_logger = _manager(
+        tmp_path,
+        _analysis(tmp_path, executables, raw_modes=["success", "nonzero"]),
+    )
+
+    with pytest.raises(EmpirExecutionError, match="exited with code 7"):
+        run_empir_analysis(manager)
+
+    current = manager.get_state().analysis
+    assert isinstance(current, EmpirAnalysisState)
+    assert current.pixel_to_photon.runs[0].result.status == "completed"
+    assert current.pixel_to_photon.runs[1].result.status == "failed"
+    assert current.pixel_to_photon.runs[1].command_args[0] == "-i"
+    assert current.photon_to_event.runs[0].result.status == "planned"
+    assert current.event_to_image.result.status == "planned"
+
+
+def test_run_empir_analysis_rejects_preflight_without_state_changes(
+    tmp_path: Path,
+) -> None:
+    """Reject existing outputs before any running result is saved."""
+    executables = _install_fake_programs(tmp_path)
+    analysis = _analysis(tmp_path, executables)
+    analysis.pixel_to_photon.runs[0].requested_photon_file.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+    analysis.pixel_to_photon.runs[0].requested_photon_file.write_text(
+        "already here",
+        encoding="utf-8",
+    )
+    manager, state_logger = _manager(tmp_path, analysis)
+
+    with pytest.raises(EmpirPreflightError, match="output already exists"):
+        run_empir_analysis(manager)
+
+    assert [change.status for change in state_logger.changes] == []
+    current = manager.get_state().analysis
+    assert isinstance(current, EmpirAnalysisState)
+    assert current.pixel_to_photon.runs[0].result.status == "planned"
+
+
+def test_run_empir_analysis_wraps_missing_executable_as_preflight_error(
+    tmp_path: Path,
+) -> None:
+    """Report missing EMPIR programs before any run status is saved."""
+    executables = _install_fake_programs(tmp_path)
+    executables["pixel"] = tmp_path / "bin/missing-pixel"
+    manager, state_logger = _manager(tmp_path, _analysis(tmp_path, executables))
+
+    with pytest.raises(EmpirPreflightError, match="not a file"):
+        run_empir_analysis(manager)
+
+    assert [change.status for change in state_logger.changes] == []
+    current = manager.get_state().analysis
+    assert isinstance(current, EmpirAnalysisState)
+    assert current.pixel_to_photon.runs[0].result.status == "planned"
+
+
+def test_run_empir_analysis_retains_photon_after_downstream_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep photon inputs when photon-to-event fails."""
+    executables = _install_fake_programs(tmp_path)
+    manager, _state_logger = _manager(tmp_path, _analysis(tmp_path, executables))
+
+    def fail_photon_to_event(*_args: object, **_kwargs: object) -> None:
+        raise EmpirPreflightError("forced photon failure")
+
+    monkeypatch.setattr(
+        "hermes.runner.analysis.empir.run.execute_photon_to_event",
+        fail_photon_to_event,
+    )
+
+    with pytest.raises(EmpirPreflightError, match="forced photon failure"):
+        run_empir_analysis(manager)
+
+    current = manager.get_state().analysis
+    assert isinstance(current, EmpirAnalysisState)
+    assert current.photon_to_event.runs[0].input_photon_file.path.is_file()
+    assert current.photon_to_event.runs[0].result.status == "failed"
+    assert current.event_to_image.result.status == "planned"
+
+
+def test_run_empir_analysis_keeps_intermediates_when_configured(
+    tmp_path: Path,
+) -> None:
+    """Honor save settings after downstream steps succeed."""
+    executables = _install_fake_programs(tmp_path)
+    manager, _state_logger = _manager(
+        tmp_path,
+        _analysis(
+            tmp_path,
+            executables,
+            save_photon_files=True,
+            save_event_files=True,
+        ),
+    )
+
+    run_empir_analysis(manager)
+
+    current = manager.get_state().analysis
+    assert isinstance(current, EmpirAnalysisState)
+    assert current.photon_to_event.runs[0].input_photon_file.path.is_file()
+    assert current.event_to_image.input_event_files[0].path.is_file()

--- a/tests/unit/hermes/runner/analysis/empir/test_run.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_run.py
@@ -121,13 +121,13 @@ def _analysis(
         pixel_runs.append(
             EmpirPixelToPhotonRun(
                 input_tpx3_file=FileReference(path=raw_path),
-                requested_photon_file=photon_path,
+                photon_file=photon_path,
             )
         )
         photon_runs.append(
             EmpirPhotonToEventRun(
                 input_photon_file=FileReference(path=photon_path),
-                requested_event_file=event_path,
+                event_file=event_path,
             )
         )
         event_files.append(FileReference(path=event_path))
@@ -166,7 +166,7 @@ def _analysis(
             ),
             settings=EmpirEventToImageSettings(image_width_pixels=512),
             input_event_files=event_files,
-            requested_tiff_file=tmp_path / "out/final.tiff",
+            tiff_file=tmp_path / "out/final.tiff",
         ),
     )
 
@@ -267,11 +267,11 @@ def test_run_empir_analysis_rejects_preflight_without_state_changes(
     """Reject existing outputs before any running result is saved."""
     executables = _install_fake_programs(tmp_path)
     analysis = _analysis(tmp_path, executables)
-    analysis.pixel_to_photon.runs[0].requested_photon_file.parent.mkdir(
+    analysis.pixel_to_photon.runs[0].photon_file.parent.mkdir(
         parents=True,
         exist_ok=True,
     )
-    analysis.pixel_to_photon.runs[0].requested_photon_file.write_text(
+    analysis.pixel_to_photon.runs[0].photon_file.write_text(
         "already here",
         encoding="utf-8",
     )

--- a/tests/unit/hermes/runner/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_unpacker.py
@@ -510,7 +510,7 @@ def test_run_rejects_empir_analysis(tmp_path: Path) -> None:
     )
 
     try:
-        with pytest.raises(HermesAnalysisError, match="EMPIR analysis is not implemented"):
+        with pytest.raises(HermesAnalysisError, match="no valid HERMES analysis"):
             run_hermes_analysis(manager)
     finally:
         logger.remove(sink_id)

--- a/tests/unit/hermes/runner/analysis/test_dispatch.py
+++ b/tests/unit/hermes/runner/analysis/test_dispatch.py
@@ -63,7 +63,7 @@ def _empir_analysis(tmp_path: Path) -> EmpirAnalysisState:
             runs=[
                 EmpirPixelToPhotonRun(
                     input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
-                    requested_photon_file=photon_path,
+                    photon_file=photon_path,
                 )
             ],
         ),
@@ -80,7 +80,7 @@ def _empir_analysis(tmp_path: Path) -> EmpirAnalysisState:
             runs=[
                 EmpirPhotonToEventRun(
                     input_photon_file=FileReference(path=photon_path),
-                    requested_event_file=event_path,
+                    event_file=event_path,
                 )
             ],
         ),
@@ -91,7 +91,7 @@ def _empir_analysis(tmp_path: Path) -> EmpirAnalysisState:
             ),
             settings=EmpirEventToImageSettings(image_width_pixels=512),
             input_event_files=[FileReference(path=event_path)],
-            requested_tiff_file=tmp_path / "out/final.tiff",
+            tiff_file=tmp_path / "out/final.tiff",
         ),
     )
 

--- a/tests/unit/hermes/runner/analysis/test_dispatch.py
+++ b/tests/unit/hermes/runner/analysis/test_dispatch.py
@@ -1,0 +1,166 @@
+"""Tests for selecting the EMPIR or HERMES analysis runner by mode."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import hermes.runner.analysis.run as dispatcher
+from hermes.runner.analysis.run import AnalysisModeError, run_analysis
+from hermes.state.models.analysis.empir import (
+    EmpirAnalysisState,
+    EmpirEventToImageSettings,
+    EmpirEventToImageState,
+    EmpirPhotonToEventRun,
+    EmpirPhotonToEventSettings,
+    EmpirPhotonToEventState,
+    EmpirPixelToPhotonRun,
+    EmpirPixelToPhotonSettings,
+    EmpirPixelToPhotonState,
+)
+from hermes.state.models.analysis.hermes_tpx3_spidr import (
+    HermesTpx3AnalysisState,
+    Tpx3Unpacking,
+)
+from hermes.state.models.environment import RuntimeEnvironment
+from hermes.state.models.measurement import MeasurementInfo
+from hermes.state.models.shared_models import BinaryProgram, FileReference
+from hermes.state.state import HermesRecord
+from hermes.state_service.shared_types import StateServiceConfig
+from hermes.state_service.state_manager import StateManager
+
+
+def _manager(tmp_path: Path, analysis: object | None) -> StateManager:
+    record = HermesRecord(
+        measurement_info=MeasurementInfo(
+            measurement_id="dispatch-test",
+            run_number=1,
+        ),
+        environment=RuntimeEnvironment(working_dir=tmp_path),
+        analysis=analysis,
+    )
+    return StateManager(
+        record,
+        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
+    )
+
+
+def _empir_analysis(tmp_path: Path) -> EmpirAnalysisState:
+    photon_path = tmp_path / "out/raw.empirphot"
+    event_path = tmp_path / "out/raw.empirevent"
+    return EmpirAnalysisState(
+        pixel_to_photon=EmpirPixelToPhotonState(
+            program=BinaryProgram(
+                name="empir_pixel2photon_tpx3spidr",
+                executable_path=Path("empir_pixel2photon_tpx3spidr"),
+            ),
+            settings=EmpirPixelToPhotonSettings(
+                spatial_distance_pixels=5,
+                time_distance_seconds=500e-9,
+                minimum_pixel_count=3,
+            ),
+            runs=[
+                EmpirPixelToPhotonRun(
+                    input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
+                    requested_photon_file=photon_path,
+                )
+            ],
+        ),
+        photon_to_event=EmpirPhotonToEventState(
+            program=BinaryProgram(
+                name="empir_photon2event",
+                executable_path=Path("empir_photon2event"),
+            ),
+            settings=EmpirPhotonToEventSettings(
+                spatial_distance_pixels=4,
+                time_distance_seconds=100e-6,
+                maximum_duration_seconds=500e-6,
+            ),
+            runs=[
+                EmpirPhotonToEventRun(
+                    input_photon_file=FileReference(path=photon_path),
+                    requested_event_file=event_path,
+                )
+            ],
+        ),
+        event_to_image=EmpirEventToImageState(
+            program=BinaryProgram(
+                name="empir_event2image",
+                executable_path=Path("empir_event2image"),
+            ),
+            settings=EmpirEventToImageSettings(image_width_pixels=512),
+            input_event_files=[FileReference(path=event_path)],
+            requested_tiff_file=tmp_path / "out/final.tiff",
+        ),
+    )
+
+
+def _hermes_analysis(tmp_path: Path) -> HermesTpx3AnalysisState:
+    return HermesTpx3AnalysisState(
+        analysis_directory=tmp_path / "analysis",
+        unpacking=Tpx3Unpacking(
+            program=BinaryProgram(
+                name="test-unpacker",
+                executable_path=tmp_path / "test-unpacker",
+            ),
+            tpx3_files=[FileReference(path=tmp_path / "input.tpx3")],
+        ),
+    )
+
+
+def test_run_analysis_routes_empir_mode_to_empir_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path, _empir_analysis(tmp_path))
+    calls: list[str] = []
+
+    def fake_empir(state_manager: StateManager) -> list[FileReference]:
+        calls.append("empir")
+        return [FileReference(path=tmp_path / "out/final.tiff")]
+
+    def fake_hermes(*args: object, **kwargs: object) -> list[FileReference]:
+        calls.append("hermes")
+        return []
+
+    monkeypatch.setattr(dispatcher, "run_empir_analysis", fake_empir)
+    monkeypatch.setattr(dispatcher, "run_hermes_analysis", fake_hermes)
+
+    result = run_analysis(manager, overwrite=True)
+
+    assert calls == ["empir"]
+    assert result == [FileReference(path=tmp_path / "out/final.tiff")]
+
+
+def test_run_analysis_routes_hermes_mode_and_passes_overwrite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = _manager(tmp_path, _hermes_analysis(tmp_path))
+    seen_overwrite: list[bool] = []
+
+    def fake_empir(state_manager: StateManager) -> list[FileReference]:
+        raise AssertionError("EMPIR runner must not run for HERMES mode")
+
+    def fake_hermes(
+        state_manager: StateManager,
+        *,
+        overwrite: bool = False,
+    ) -> list[FileReference]:
+        seen_overwrite.append(overwrite)
+        return []
+
+    monkeypatch.setattr(dispatcher, "run_empir_analysis", fake_empir)
+    monkeypatch.setattr(dispatcher, "run_hermes_analysis", fake_hermes)
+
+    run_analysis(manager, overwrite=True)
+
+    assert seen_overwrite == [True]
+
+
+def test_run_analysis_rejects_missing_analysis(tmp_path: Path) -> None:
+    manager = _manager(tmp_path, None)
+
+    with pytest.raises(AnalysisModeError, match="no valid analysis mode"):
+        run_analysis(manager)

--- a/tests/unit/hermes/runner/analysis/test_dispatch.py
+++ b/tests/unit/hermes/runner/analysis/test_dispatch.py
@@ -62,7 +62,7 @@ def _empir_analysis(tmp_path: Path) -> EmpirAnalysisState:
             ),
             runs=[
                 EmpirPixelToPhotonRun(
-                    input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
+                    tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
                     photon_file=photon_path,
                 )
             ],
@@ -79,7 +79,7 @@ def _empir_analysis(tmp_path: Path) -> EmpirAnalysisState:
             ),
             runs=[
                 EmpirPhotonToEventRun(
-                    input_photon_file=FileReference(path=photon_path),
+                    photon_file=FileReference(path=photon_path),
                     event_file=event_path,
                 )
             ],
@@ -90,7 +90,7 @@ def _empir_analysis(tmp_path: Path) -> EmpirAnalysisState:
                 executable_path=Path("empir_event2image"),
             ),
             settings=EmpirEventToImageSettings(image_width_pixels=512),
-            input_event_files=[FileReference(path=event_path)],
+            event_files=[FileReference(path=event_path)],
             tiff_file=tmp_path / "out/final.tiff",
         ),
     )

--- a/tests/unit/hermes/state/models/test_empir.py
+++ b/tests/unit/hermes/state/models/test_empir.py
@@ -7,16 +7,70 @@ from pydantic import ValidationError
 
 from hermes.state.models.analysis.empir import (
     EmpirAnalysisState,
+    EmpirEventToImageResult,
     EmpirEventToImageSettings,
     EmpirEventToImageState,
+    EmpirPhotonToEventResult,
     EmpirPhotonToEventRun,
     EmpirPhotonToEventSettings,
     EmpirPhotonToEventState,
+    EmpirPixelToPhotonResult,
     EmpirPixelToPhotonRun,
     EmpirPixelToPhotonSettings,
     EmpirPixelToPhotonState,
 )
 from hermes.state.models.shared_models import BinaryProgram, FileReference
+
+
+def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
+    photon_path = tmp_path / "raw.empirphot"
+    event_path = tmp_path / "raw.empirevent"
+    state = EmpirAnalysisState(
+        pixel_to_photon=EmpirPixelToPhotonState(
+            program=BinaryProgram(
+                name="empir-pixel2photon",
+                executable_path="empir_pixel2photon_tpx3spidr",
+            ),
+            settings=EmpirPixelToPhotonSettings(
+                spatial_distance_pixels=5,
+                time_distance_seconds=500e-9,
+                minimum_pixel_count=3,
+            ),
+            runs=[
+                EmpirPixelToPhotonRun(
+                    input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
+                    requested_photon_file=photon_path,
+                )
+            ],
+        ),
+        photon_to_event=EmpirPhotonToEventState(
+            program=BinaryProgram(
+                name="empir-photon2event",
+                executable_path="empir_photon2event",
+            ),
+            settings=EmpirPhotonToEventSettings(
+                spatial_distance_pixels=4,
+                time_distance_seconds=100e-6,
+                maximum_duration_seconds=500e-6,
+            ),
+            runs=[
+                EmpirPhotonToEventRun(
+                    input_photon_file=FileReference(path=photon_path),
+                    requested_event_file=event_path,
+                )
+            ],
+        ),
+        event_to_image=EmpirEventToImageState(
+            program=BinaryProgram(
+                name="empir-event2image",
+                executable_path="empir_event2image",
+            ),
+            settings=EmpirEventToImageSettings(image_width_pixels=512),
+            input_event_files=[FileReference(path=event_path)],
+            requested_tiff_file=tmp_path / "image.tiff",
+        ),
+    )
+    return state.model_dump()
 
 
 def test_empir_analysis_state_serializes_direct_binary_pipeline(
@@ -45,7 +99,6 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
                 EmpirPixelToPhotonRun(
                     input_tpx3_file=raw_file,
                     requested_photon_file=photon_path,
-                    command_args=["-i", str(raw_file.path), "-o", str(photon_path)],
                 )
             ],
         ),
@@ -63,7 +116,6 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
                 EmpirPhotonToEventRun(
                     input_photon_file=FileReference(path=photon_path),
                     requested_event_file=event_path,
-                    command_args=["-i", str(photon_path), "-o", str(event_path)],
                 )
             ],
         ),
@@ -85,7 +137,6 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
             ),
             input_event_files=[FileReference(path=event_path)],
             requested_tiff_file=tmp_path / "final/image.tiff",
-            command_args=["-i", str(event_path), "-o", "final/image.tiff"],
         ),
     )
 
@@ -105,6 +156,112 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
         "reference"
     )
     assert dumped["event_to_image"]["result"]["status"] == "planned"
+    assert dumped["pixel_to_photon"]["runs"][0]["command_args"] == []
+    assert dumped["photon_to_event"]["runs"][0]["command_args"] == []
+    assert dumped["event_to_image"]["command_args"] == []
+
+
+@pytest.mark.parametrize(
+    "result_model",
+    [
+        EmpirPixelToPhotonResult,
+        EmpirPhotonToEventResult,
+        EmpirEventToImageResult,
+    ],
+)
+def test_empir_results_require_nonnegative_elapsed_seconds(
+    result_model: type[
+        EmpirPixelToPhotonResult
+        | EmpirPhotonToEventResult
+        | EmpirEventToImageResult
+    ],
+) -> None:
+    assert result_model(elapsed_seconds=0).elapsed_seconds == 0
+
+    with pytest.raises(ValidationError, match="greater than or equal to 0"):
+        result_model(elapsed_seconds=-0.01)
+
+
+@pytest.mark.parametrize(
+    ("path_parts", "invalid_name", "message"),
+    [
+        (
+            ("pixel_to_photon", "runs", 0, "input_tpx3_file", "path"),
+            "raw.bin",
+            "input_tpx3_file",
+        ),
+        (
+            ("pixel_to_photon", "runs", 0, "requested_photon_file"),
+            "raw.photons",
+            "requested_photon_file",
+        ),
+        (
+            ("photon_to_event", "runs", 0, "input_photon_file", "path"),
+            "raw.photons",
+            "input_photon_file",
+        ),
+        (
+            ("photon_to_event", "runs", 0, "requested_event_file"),
+            "raw.events",
+            "requested_event_file",
+        ),
+        (
+            ("event_to_image", "input_event_files", 0, "path"),
+            "raw.events",
+            "input_event_files",
+        ),
+        (
+            ("event_to_image", "requested_tiff_file"),
+            "image.png",
+            "requested_tiff_file",
+        ),
+    ],
+)
+def test_empir_analysis_rejects_invalid_filename_suffixes(
+    tmp_path: Path,
+    path_parts: tuple[str | int, ...],
+    invalid_name: str,
+    message: str,
+) -> None:
+    values = _valid_empir_analysis_values(tmp_path)
+    target: object = values
+    for part in path_parts[:-1]:
+        target = target[part]  # type: ignore[index]
+    target[path_parts[-1]] = tmp_path / invalid_name  # type: ignore[index]
+
+    with pytest.raises(ValidationError, match=message):
+        EmpirAnalysisState.model_validate(values)
+
+
+@pytest.mark.parametrize(
+    ("path_parts", "replacement", "message"),
+    [
+        (
+            ("photon_to_event", "runs", 0, "input_photon_file", "path"),
+            "different.empirphot",
+            "photon_to_event input files must match",
+        ),
+        (
+            ("event_to_image", "input_event_files", 0, "path"),
+            "different.empirevent",
+            "event_to_image input files must match",
+        ),
+    ],
+)
+def test_empir_analysis_rejects_disconnected_pipeline_paths(
+    tmp_path: Path,
+    path_parts: tuple[str | int, ...],
+    replacement: str,
+    message: str,
+) -> None:
+    values = _valid_empir_analysis_values(tmp_path)
+    target: object = values
+    for part in path_parts[:-1]:
+        target = target[part]  # type: ignore[index]
+    target[path_parts[-1]] = tmp_path / replacement  # type: ignore[index]
+
+    with pytest.raises(ValidationError, match=message):
+        EmpirAnalysisState.model_validate(values)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/hermes/state/models/test_empir.py
+++ b/tests/unit/hermes/state/models/test_empir.py
@@ -1,3 +1,5 @@
+"""Tests for EMPIR analysis settings, paths, and saved results."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -23,6 +25,7 @@ from hermes.state.models.shared_models import BinaryProgram, FileReference
 
 
 def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
+    """Build valid EMPIR values that individual tests can change."""
     photon_path = tmp_path / "raw.empirphot"
     event_path = tmp_path / "raw.empirevent"
     state = EmpirAnalysisState(
@@ -76,6 +79,7 @@ def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
 def test_empir_analysis_state_serializes_direct_binary_pipeline(
     tmp_path: Path,
 ) -> None:
+    """Serialize a complete EMPIR pipeline with empty runner commands."""
     raw_file = FileReference(path=tmp_path / "raw.tpx3")
     photon_path = tmp_path / "raw.empirphot"
     event_path = tmp_path / "raw.empirevent"
@@ -140,6 +144,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
         ),
     )
 
+    # JSON mode matches the form written to a HERMES YAML file.
     dumped = state.model_dump(mode="json")
 
     assert dumped["mode"] == "empir"
@@ -176,6 +181,7 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
         | EmpirEventToImageResult
     ],
 ) -> None:
+    """Accept zero duration and reject negative duration for every step."""
     assert result_model(elapsed_seconds=0).elapsed_seconds == 0
 
     with pytest.raises(ValidationError, match="greater than or equal to 0"):
@@ -223,7 +229,9 @@ def test_empir_analysis_rejects_invalid_filename_suffixes(
     invalid_name: str,
     message: str,
 ) -> None:
+    """Reject an invalid input or output suffix at each pipeline step."""
     values = _valid_empir_analysis_values(tmp_path)
+    # Walk to the selected nested field so one parameter table covers all steps.
     target: object = values
     for part in path_parts[:-1]:
         target = target[part]  # type: ignore[index]
@@ -254,7 +262,9 @@ def test_empir_analysis_rejects_disconnected_pipeline_paths(
     replacement: str,
     message: str,
 ) -> None:
+    """Reject downstream inputs that differ from requested upstream files."""
     values = _valid_empir_analysis_values(tmp_path)
+    # Change only the downstream input while leaving the upstream output valid.
     target: object = values
     for part in path_parts[:-1]:
         target = target[part]  # type: ignore[index]
@@ -280,11 +290,13 @@ def test_event_to_image_settings_reject_invalid_combinations(
     overrides: dict[str, int | float],
     message: str,
 ) -> None:
+    """Reject reversed ranges and incomplete time-bin pairs."""
     with pytest.raises(ValidationError, match=message):
         EmpirEventToImageSettings(image_width_pixels=512, **overrides)
 
 
 def test_empir_stage_requires_at_least_one_file(tmp_path: Path) -> None:
+    """Require at least one configured run for a file-processing step."""
     with pytest.raises(ValidationError, match="at least 1 item"):
         EmpirPixelToPhotonState(
             program=BinaryProgram(
@@ -301,6 +313,7 @@ def test_empir_stage_requires_at_least_one_file(tmp_path: Path) -> None:
 
 
 def test_empir_settings_reject_unknown_fields() -> None:
+    """Reject settings that are not part of the typed EMPIR options."""
     with pytest.raises(ValidationError, match="extra_forbidden"):
         EmpirPhotonToEventSettings(
             spatial_distance_pixels=4,

--- a/tests/unit/hermes/state/models/test_empir.py
+++ b/tests/unit/hermes/state/models/test_empir.py
@@ -42,7 +42,7 @@ def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
             runs=[
                 EmpirPixelToPhotonRun(
                     input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
-                    requested_photon_file=photon_path,
+                    photon_file=photon_path,
                 )
             ],
         ),
@@ -59,7 +59,7 @@ def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
             runs=[
                 EmpirPhotonToEventRun(
                     input_photon_file=FileReference(path=photon_path),
-                    requested_event_file=event_path,
+                    event_file=event_path,
                 )
             ],
         ),
@@ -70,7 +70,7 @@ def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
             ),
             settings=EmpirEventToImageSettings(image_width_pixels=512),
             input_event_files=[FileReference(path=event_path)],
-            requested_tiff_file=tmp_path / "image.tiff",
+            tiff_file=tmp_path / "image.tiff",
         ),
     )
     return state.model_dump()
@@ -102,7 +102,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
             runs=[
                 EmpirPixelToPhotonRun(
                     input_tpx3_file=raw_file,
-                    requested_photon_file=photon_path,
+                    photon_file=photon_path,
                 )
             ],
         ),
@@ -119,7 +119,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
             runs=[
                 EmpirPhotonToEventRun(
                     input_photon_file=FileReference(path=photon_path),
-                    requested_event_file=event_path,
+                    event_file=event_path,
                 )
             ],
         ),
@@ -140,7 +140,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
                 parallel=True,
             ),
             input_event_files=[FileReference(path=event_path)],
-            requested_tiff_file=tmp_path / "final/image.tiff",
+            tiff_file=tmp_path / "final/image.tiff",
         ),
     )
 
@@ -154,7 +154,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
     assert dumped["pixel_to_photon"]["runs"][0]["result"]["status"] == (
         "planned"
     )
-    assert dumped["photon_to_event"]["runs"][0]["requested_event_file"].endswith(
+    assert dumped["photon_to_event"]["runs"][0]["event_file"].endswith(
         "raw.empirevent"
     )
     assert dumped["event_to_image"]["settings"]["external_trigger_mode"] == (
@@ -197,9 +197,9 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
             "input_tpx3_file",
         ),
         (
-            ("pixel_to_photon", "runs", 0, "requested_photon_file"),
+            ("pixel_to_photon", "runs", 0, "photon_file"),
             "raw.photons",
-            "requested_photon_file",
+            "photon_file",
         ),
         (
             ("photon_to_event", "runs", 0, "input_photon_file", "path"),
@@ -207,9 +207,9 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
             "input_photon_file",
         ),
         (
-            ("photon_to_event", "runs", 0, "requested_event_file"),
+            ("photon_to_event", "runs", 0, "event_file"),
             "raw.events",
-            "requested_event_file",
+            "event_file",
         ),
         (
             ("event_to_image", "input_event_files", 0, "path"),
@@ -217,9 +217,9 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
             "input_event_files",
         ),
         (
-            ("event_to_image", "requested_tiff_file"),
+            ("event_to_image", "tiff_file"),
             "image.png",
-            "requested_tiff_file",
+            "tiff_file",
         ),
     ],
 )

--- a/tests/unit/hermes/state/models/test_empir.py
+++ b/tests/unit/hermes/state/models/test_empir.py
@@ -41,7 +41,7 @@ def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
             ),
             runs=[
                 EmpirPixelToPhotonRun(
-                    input_tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
+                    tpx3_file=FileReference(path=tmp_path / "raw.tpx3"),
                     photon_file=photon_path,
                 )
             ],
@@ -58,7 +58,7 @@ def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
             ),
             runs=[
                 EmpirPhotonToEventRun(
-                    input_photon_file=FileReference(path=photon_path),
+                    photon_file=FileReference(path=photon_path),
                     event_file=event_path,
                 )
             ],
@@ -69,7 +69,7 @@ def _valid_empir_analysis_values(tmp_path: Path) -> dict[str, object]:
                 executable_path="empir_event2image",
             ),
             settings=EmpirEventToImageSettings(image_width_pixels=512),
-            input_event_files=[FileReference(path=event_path)],
+            event_files=[FileReference(path=event_path)],
             tiff_file=tmp_path / "image.tiff",
         ),
     )
@@ -101,7 +101,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
             ),
             runs=[
                 EmpirPixelToPhotonRun(
-                    input_tpx3_file=raw_file,
+                    tpx3_file=raw_file,
                     photon_file=photon_path,
                 )
             ],
@@ -118,7 +118,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
             ),
             runs=[
                 EmpirPhotonToEventRun(
-                    input_photon_file=FileReference(path=photon_path),
+                    photon_file=FileReference(path=photon_path),
                     event_file=event_path,
                 )
             ],
@@ -139,7 +139,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
                 tiff_format="tiff_w8",
                 parallel=True,
             ),
-            input_event_files=[FileReference(path=event_path)],
+            event_files=[FileReference(path=event_path)],
             tiff_file=tmp_path / "final/image.tiff",
         ),
     )
@@ -148,7 +148,7 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
     dumped = state.model_dump(mode="json")
 
     assert dumped["mode"] == "empir"
-    assert dumped["pixel_to_photon"]["runs"][0]["input_tpx3_file"][
+    assert dumped["pixel_to_photon"]["runs"][0]["tpx3_file"][
         "path"
     ].endswith("raw.tpx3")
     assert dumped["pixel_to_photon"]["runs"][0]["result"]["status"] == (
@@ -192,9 +192,9 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
     ("path_parts", "invalid_name", "message"),
     [
         (
-            ("pixel_to_photon", "runs", 0, "input_tpx3_file", "path"),
+            ("pixel_to_photon", "runs", 0, "tpx3_file", "path"),
             "raw.bin",
-            "input_tpx3_file",
+            "tpx3_file",
         ),
         (
             ("pixel_to_photon", "runs", 0, "photon_file"),
@@ -202,9 +202,9 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
             "photon_file",
         ),
         (
-            ("photon_to_event", "runs", 0, "input_photon_file", "path"),
+            ("photon_to_event", "runs", 0, "photon_file", "path"),
             "raw.photons",
-            "input_photon_file",
+            "photon_file",
         ),
         (
             ("photon_to_event", "runs", 0, "event_file"),
@@ -212,9 +212,9 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
             "event_file",
         ),
         (
-            ("event_to_image", "input_event_files", 0, "path"),
+            ("event_to_image", "event_files", 0, "path"),
             "raw.events",
-            "input_event_files",
+            "event_files",
         ),
         (
             ("event_to_image", "tiff_file"),
@@ -245,12 +245,12 @@ def test_empir_analysis_rejects_invalid_filename_suffixes(
     ("path_parts", "replacement", "message"),
     [
         (
-            ("photon_to_event", "runs", 0, "input_photon_file", "path"),
+            ("photon_to_event", "runs", 0, "photon_file", "path"),
             "different.empirphot",
             "photon_to_event input files must match",
         ),
         (
-            ("event_to_image", "input_event_files", 0, "path"),
+            ("event_to_image", "event_files", 0, "path"),
             "different.empirevent",
             "event_to_image input files must match",
         ),

--- a/tests/unit/hermes/workflows/test_workflow.py
+++ b/tests/unit/hermes/workflows/test_workflow.py
@@ -69,7 +69,7 @@ def test_run_analysis_returns_files_and_updates_record(
         return analysis.unpacking.tpx3_files
 
     monkeypatch.setattr(
-        "hermes.workflows.workflow.run_hermes_analysis",
+        "hermes.workflows.workflow.run_analysis",
         complete_analysis,
     )
 


### PR DESCRIPTION

This pull request adds support for running EMPIR as a new analysis mode alongside HERMES, including a full implementation of the EMPIR pipeline, configuration, error handling, and documentation. The changes introduce the ability to run the three EMPIR binaries in sequence (pixel-to-photon, photon-to-event, event-to-image), with robust subprocess management, logging, and output verification. The documentation and example configuration make it easy to use and compare EMPIR and HERMES analysis modes.

The most important changes are:

**EMPIR Analysis Mode Implementation**
* Added a new EMPIR analysis mode, including a dispatcher that selects the analysis mode from the saved state and runs the appropriate pipeline (`src/hermes/runner/analysis/empir/__init__.py`, `src/hermes/runner/analysis/empir/_executable.py`, `src/hermes/runner/analysis/empir/_process.py`, `src/hermes/runner/analysis/empir/event_to_image.py`, `src/hermes/runner/analysis/empir/_errors.py`). [[1]](diffhunk://#diff-e97a8bddf3ba8405955f4e8138af76eb198a855b5c310f9d37bb9724ea5a4e5dR1) [[2]](diffhunk://#diff-6b7d4f89f7bee46c9ee3e82cd8f6656048f76f76ec4a48f77912a5fbbba9aa0dR1-R38) [[3]](diffhunk://#diff-1ec9489affcb1cd52b2f5a858c53a5d9ee6c7dd8b22b1dfd2cb6e3672a4c7c59R1-R101) [[4]](diffhunk://#diff-ba41dcaa1049f35a7403fd46fdc47bd73e2fd972b998623308d7630364234a0aR1-R154) [[5]](diffhunk://#diff-a8f40ca5502bf868afa856b6839209b68a5d18f4f9dc07b4457bee49d095c1c2R1-R28)

**Example and Configuration**
* Added a complete EMPIR analysis example, including a sample YAML configuration, a README explaining the pipeline, requirements, and timing, and a Python script to run the pipeline and report results (`examples/analysis/empir/README.md`, `examples/analysis/empir/empir.yaml`, `examples/analysis/empir/run_empir.py`). [[1]](diffhunk://#diff-c574e8b2a5e2628d48ca8d1d9d5c441b8781f578e0faed63f3fbb38e4ad10e11R1-R118) [[2]](diffhunk://#diff-4b49cb7508e4db70be9ff089df627c3f65d813bda3f59732e64653d90d84a916R1-R62) [[3]](diffhunk://#diff-dbc806627bdba62630c8643e71b175d96c61552a28004c0a4b1f2084edd79eebR1-R62)

**Documentation and Usage Guidance**
* Updated architecture documentation to describe the new EMPIR analysis entry point, clarify mode selection, and provide guidance for timing comparisons between EMPIR and HERMES (`docs/architecture/analysis.md`).

**Robust Error Handling and Logging**
* Implemented detailed error classes for EMPIR subprocess management, including preflight, execution, and output errors, and ensured that all subprocesses are timed, logged, and their outputs verified (`src/hermes/runner/analysis/empir/_errors.py`, `src/hermes/runner/analysis/empir/_process.py`, `src/hermes/runner/analysis/empir/event_to_image.py`). [[1]](diffhunk://#diff-a8f40ca5502bf868afa856b6839209b68a5d18f4f9dc07b4457bee49d095c1c2R1-R28) [[2]](diffhunk://#diff-1ec9489affcb1cd52b2f5a858c53a5d9ee6c7dd8b22b1dfd2cb6e3672a4c7c59R1-R101) [[3]](diffhunk://#diff-ba41dcaa1049f35a7403fd46fdc47bd73e2fd972b998623308d7630364234a0aR1-R154)

These changes collectively enable EMPIR as a first-class analysis mode, with robust execution, clear configuration, and comprehensive documentation and examples.