### PR TITLE
62 running status

### DIFF
--- a/docs/architecture/analysis.md
+++ b/docs/architecture/analysis.md
@@ -286,17 +286,14 @@ files:
    summary is invalid, or when its saved settings differ from the requested
    settings.
 
-The runner applies the overall reconstruction status `running` through
-`StateManager` before launching the first reconstruction process. If that
-trusted-workflow change is not allowed, it stops before launching the process.
-Reconstruction runs sequentially by raw filename stem in the first
-implementation. State changes remain on the main thread.
+The runner records one result per pixel file after that file finishes: it never
+writes a start-of-work status. Each result is `completed`, `skipped`, or
+`failed`.
 
-If one reconstruction process fails, the runner marks the overall
-reconstruction result `failed`, raises a HERMES reconstruction error, and
-keeps valid photon files and summaries from inputs that completed. A later run
-validates and skips those inputs. After every input validates, the runner marks
-the overall reconstruction result `completed`.
+If one reconstruction process fails, the runner marks the affected results
+`failed`, raises a HERMES reconstruction error, and keeps valid photon files and
+summaries from inputs that completed. A later run validates and skips those
+inputs.
 
 HERMES programs may be implemented in C++ or Rust, but they must read and write
 the HERMES files and columns defined for that analysis step. Choosing a C++ or
@@ -340,14 +337,11 @@ Each mode-specific pipeline should:
 
 - read its executable paths, inputs, settings, and requested output paths from
   its selected analysis model
-- apply `planned`, `running`, `completed`, and `failed` status through
-  `StateManager`
-- record the overall step start and finish times in the corresponding Pydantic
-  result model
+- write one result per step through `StateManager` once the step finishes, with
+  status `completed`, `skipped`, or `failed`; a step that has not run yet has no
+  result object
 - keep detailed results in the program-specific files defined by the selected
   analysis mode
-- stop before launching an executable when a required state change has not been
-  approved
 - return completed or failed state through `StateManager`
 
 The calling workflow saves `StateManager.get_state()` as the HERMES YAML file

--- a/docs/architecture/state-model.md
+++ b/docs/architecture/state-model.md
@@ -161,7 +161,8 @@ rejected. Saving the HERMES record always writes the expanded explicit
 - `HermesTpx3AnalysisState.unpacker_program`, `analysis_directory`, and
   `tpx3_files` are required. `tpx3_files` must contain at least one entry.
 - `HermesTpx3AnalysisState.resource_limit_percent`, `photon_reconstruction`,
-  and `results` have defaults. Nested unpacking results default to `planned`.
+  and `results` have defaults. A raw file with no recorded result has not run
+  yet.
 - `Tpx3SpidrUnpackerProgram.name` and `executable_path` are required; `version`
   defaults to `None`.
 - `FileReference.path` is required; its file information fields default to
@@ -663,14 +664,10 @@ HermesTpx3AnalysisResults
   reconstruction: HermesTpx3ReconstructionResult | None
 
 HermesTpx3UnpackingResult
-  status: planned | running | completed | failed
-  started_at: datetime | None
-  completed_at: datetime | None
+  status: completed | skipped | failed
 
 HermesTpx3ReconstructionResult
-  status: planned | running | completed | failed
-  started_at: datetime | None
-  completed_at: datetime | None
+  status: completed | skipped | failed
   photon_count: int
   rejected_count: int
   warnings: list[str]
@@ -729,32 +726,27 @@ raw TPX3 filename stem. Input-specific summary paths are derived as:
 The HERMES state does not save one result per raw file, generated command
 arguments, summary JSON paths, Parquet filenames, file counts, packet or row
 counts, timestamp diagnostics, sorting diagnostics, detailed rejection counts,
-quality-flag counts, processing times, or per-file exit codes. Each summary JSON
-file is the sole saved detailed result for its raw TPX3 file. The overall
-reconstruction result keeps only status and times, total accepted and rejected
+quality-flag counts, or per-file exit codes. Each summary JSON
+file is the sole saved detailed result for its raw TPX3 file. The
+reconstruction result keeps only status, total accepted and rejected
 component counts, and combined warnings and errors.
 
-The unpacking status applies to the complete `tpx3_files` list:
+HERMES writes one result per raw file after that file finishes, using these
+terminal values (a file that has not run yet has no result):
 
-- `planned`: processing has not started
-- `running`: HERMES is checking or unpacking the list
-- `completed`: every raw file has a valid summary and valid listed Parquet files
-- `failed`: at least one raw file could not be unpacked or validated
+- `completed`: the file has a valid summary and valid listed Parquet files
+- `skipped`: a valid result already existed, so the file was not reprocessed
+- `failed`: the file could not be unpacked or validated
 
 A repeated run skips a raw file only when its summary is valid and every listed
 Parquet file exists. It runs an input only when neither its summary nor matching
 Parquet files exist. Matching Parquet files without a valid summary, or an
-invalid existing summary, cause the overall run to fail. No resume flag is
-saved.
+invalid existing summary, cause the run to fail. No resume flag is saved.
 
-The reconstruction status applies to the complete `tpx3_files` list:
-
-- `planned`: photon reconstruction has not started
-- `running`: HERMES has applied the state change and may launch the selected
-  program
-- `completed`: every raw filename stem has a valid reconstruction summary and
-  every required photon file
-- `failed`: at least one input could not be reconstructed or validated
+Reconstruction records the same terminal values per photon file: `completed`
+when a file has a valid reconstruction summary and every required photon file,
+`skipped` when a valid result already existed, and `failed` when a file could
+not be reconstructed or validated.
 
 A repeated reconstruction run also verifies that the saved summary settings
 match the requested settings. It requires `photon_pixels` files only when the

--- a/docs/architecture/unpacker.md
+++ b/docs/architecture/unpacker.md
@@ -52,7 +52,7 @@ set, then call the binary with the flags. Do not add helper functions or a
 builder abstraction for assembling the command.
 
 The HERMES state should save the raw TPX3 input files, shared analysis
-directory, unpacker program, and overall unpacking status and times. Each
+directory, unpacker program, and per-file unpacking status. Each
 input-specific summary JSON file should save its byte and packet counts,
 Parquet filenames and row counts, timestamp-processing information, sorting
 information, processing times, throughput, warnings, and errors.

--- a/docs/architecture/workflows.md
+++ b/docs/architecture/workflows.md
@@ -70,26 +70,24 @@ The first workflow should be intentionally narrow:
 6. Check that all raw TPX3 filename stems are unique before starting analysis.
 7. Validate the unpacker executable, every raw TPX3 file, every existing
    summary, and every existing Parquet file before launching any unpacker.
-8. Apply the HERMES `running` status. If the trusted-workflow state change is
-   not allowed, do not launch an unpacker.
-9. Calculate the worker count from the saved `resource_limit_percent`, physical
+8. Calculate the worker count from the saved `resource_limit_percent`, physical
    CPU count, available memory, and the largest pending raw file size.
-10. Run independent unpacker processes concurrently using `ThreadPoolExecutor`
-    with the calculated worker count. Each worker waits for one C++ subprocess.
-11. Write each packet category to its shared directory. Start every Parquet
+9. Run independent unpacker processes concurrently using `ThreadPoolExecutor`
+   with the calculated worker count. Each worker waits for one C++ subprocess.
+10. Write each packet category to its shared directory. Start every Parquet
     filename with the raw TPX3 filename stem, followed by its chip and part
     numbers.
-12. Write one input-specific unpacker summary JSON file under `analysis/logs/`.
-13. Keep the summary JSON file as the sole detailed result for its raw TPX3
+11. Write one input-specific unpacker summary JSON file under `analysis/logs/`.
+12. Keep the summary JSON file as the sole detailed result for its raw TPX3
     file. Save only the shared analysis directory, raw TPX3 list, unpacker
-    program, resource limit percentage, and overall unpacking status and times
-    in the HERMES record.
-14. Return completed files in the original input order, regardless of completion
+    program, resource limit percentage, and per-file unpacking status in the
+    HERMES record.
+13. Return completed files in the original input order, regardless of completion
     order.
-15. If one unpacker fails, cancel work that has not started, allow already
-    running processes to finish, mark overall unpacking `failed`, and keep valid
-    output from successful processes.
-16. When repeating the workflow, skip an input only when its summary is valid
+14. If one unpacker fails, cancel work that has not started, allow already
+    running processes to finish, mark the affected results `failed`, and keep
+    valid output from successful processes.
+15. When repeating the workflow, skip an input only when its summary is valid
     and every listed Parquet file exists. Run an input only when neither its
     summary nor matching Parquet files exist. Stop on an invalid summary or
     partial output files.

--- a/examples/analysis/empir/run_empir.py
+++ b/examples/analysis/empir/run_empir.py
@@ -14,6 +14,13 @@ DEFAULT_INPUT_YAML_PATH = Path(__file__).with_name("empir.yaml")
 SOURCE_TPX3_FILE = Path("tests/data/tpx3/Tantalum_IronPowder.tpx3")
 
 
+def _describe(result: object) -> str:
+    """Return the step duration, or its status when nothing timed the step."""
+    if result.elapsed_seconds is None:
+        return result.status
+    return f"{result.elapsed_seconds:.3f} s"
+
+
 def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
     # Step 1: Load the initial HERMES record from the configuration YAML file
     initial_record = load_hermes_record_from_yaml(input_yaml_path)
@@ -43,9 +50,9 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
     photon_run = final_analysis.photon_to_event.runs[0]
     image_result = final_analysis.event_to_image.result
 
-    print(f"Pixel-to-photon: {pixel_run.result.elapsed_seconds:.3f} s")
-    print(f"Photon-to-event: {photon_run.result.elapsed_seconds:.3f} s")
-    print(f"Event-to-image:  {image_result.elapsed_seconds:.3f} s")
+    print(f"Pixel-to-photon: {_describe(pixel_run.result)}")
+    print(f"Photon-to-event: {_describe(photon_run.result)}")
+    print(f"Event-to-image:  {_describe(image_result)}")
     print(f"TIFF images written: {len(image_files)}")
     for image_file in image_files:
         print(f"  - {image_file.path}")

--- a/src/hermes/runner/analysis/empir/_process.py
+++ b/src/hermes/runner/analysis/empir/_process.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import subprocess
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from time import perf_counter
 
@@ -13,7 +12,6 @@ from hermes.runner.analysis.empir._errors import (
     EmpirOutputError,
     EmpirPreflightError,
 )
-from hermes.state.models.shared_models import utc_now
 
 _LOG_TEXT_LIMIT = 4_000
 
@@ -22,8 +20,6 @@ _LOG_TEXT_LIMIT = 4_000
 class EmpirProcessOutcome:
     """Measured process details used for results, logs, and failures."""
 
-    started_at: datetime
-    completed_at: datetime
     elapsed_seconds: float
     exit_code: int | None
     stdout_excerpt: str = ""
@@ -33,25 +29,19 @@ class EmpirProcessOutcome:
 def validate_step_paths(
     step_name: str,
     input_paths: list[Path],
-    requested_output_path: Path,
 ) -> None:
-    """Check immediate inputs and reject an existing requested output."""
+    """Check that each immediate input is a regular file."""
     for input_path in input_paths:
         if not input_path.is_file():
             raise EmpirPreflightError(
                 f"{step_name} input is not a regular file: {input_path}"
             )
-    if requested_output_path.exists():
-        raise EmpirPreflightError(
-            f"{step_name} output already exists: {requested_output_path}"
-        )
 
 
 def run_process(
     step_name: str,
     command: list[str],
     requested_output_path: Path,
-    started_at: datetime,
 ) -> EmpirProcessOutcome:
     """Run one EMPIR command, measure it, and verify its requested file."""
     started = perf_counter()
@@ -65,8 +55,6 @@ def run_process(
         )
     except OSError as exc:
         outcome = EmpirProcessOutcome(
-            started_at=started_at,
-            completed_at=utc_now(),
             elapsed_seconds=perf_counter() - started,
             exit_code=None,
         )
@@ -75,8 +63,6 @@ def run_process(
         ) from exc
 
     outcome = EmpirProcessOutcome(
-        started_at=started_at,
-        completed_at=utc_now(),
         elapsed_seconds=perf_counter() - started,
         exit_code=process.returncode,
         stdout_excerpt=_bounded_text(process.stdout),

--- a/src/hermes/runner/analysis/empir/event_to_image.py
+++ b/src/hermes/runner/analysis/empir/event_to_image.py
@@ -15,7 +15,7 @@ from hermes.state.models.analysis.empir import (
     EmpirEventToImageResult,
     EmpirEventToImageState,
 )
-from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state.models.shared_models import FileReference
 
 _STEP_NAME = "event_to_image"
 _EVENT_PREFIX = "analysis.empir.event_to_image"
@@ -70,9 +70,8 @@ def execute_event_to_image(
     """Run event-to-image once and return its verified TIFF result."""
     input_paths = [file.path for file in stage.event_files]
     output_path = stage.tiff_file
-    validate_step_paths(_STEP_NAME, input_paths, output_path)
+    validate_step_paths(_STEP_NAME, input_paths)
     command = build_event_to_image_command(stage, resolved_executable_path)
-    started_at = utc_now()
     _ANALYSIS_LOGGER.info(
         "EMPIR event-to-image started for {input_file_count} files",
         event_type=f"{_EVENT_PREFIX}.started",
@@ -92,7 +91,6 @@ def execute_event_to_image(
             _STEP_NAME,
             command,
             output_path,
-            started_at,
         )
     except EmpirExecutionError as exc:
         _log_failure(stage, resolved_executable_path, command, exc)
@@ -117,8 +115,6 @@ def execute_event_to_image(
     )
     return EmpirEventToImageResult(
         status="completed",
-        started_at=outcome.started_at,
-        completed_at=outcome.completed_at,
         elapsed_seconds=outcome.elapsed_seconds,
         exit_code=outcome.exit_code,
         tiff_file=FileReference(path=output_path),

--- a/src/hermes/runner/analysis/empir/photon_to_event.py
+++ b/src/hermes/runner/analysis/empir/photon_to_event.py
@@ -16,7 +16,7 @@ from hermes.state.models.analysis.empir import (
     EmpirPhotonToEventRun,
     EmpirPhotonToEventState,
 )
-from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state.models.shared_models import FileReference
 
 _STEP_NAME = "photon_to_event"
 _EVENT_PREFIX = "analysis.empir.photon_to_event"
@@ -57,13 +57,12 @@ def execute_photon_to_event(
     """Run photon-to-event once and return its verified result."""
     input_path = run.photon_file.path
     output_path = run.event_file
-    validate_step_paths(_STEP_NAME, [input_path], output_path)
+    validate_step_paths(_STEP_NAME, [input_path])
     command = build_photon_to_event_command(
         stage,
         run,
         resolved_executable_path,
     )
-    started_at = utc_now()
     _ANALYSIS_LOGGER.info(
         "EMPIR photon-to-event started for {input_file}",
         event_type=f"{_EVENT_PREFIX}.started",
@@ -83,7 +82,6 @@ def execute_photon_to_event(
             _STEP_NAME,
             command,
             output_path,
-            started_at,
         )
     except EmpirExecutionError as exc:
         _log_failure(stage, run, resolved_executable_path, command, exc)
@@ -108,8 +106,6 @@ def execute_photon_to_event(
     )
     return EmpirPhotonToEventResult(
         status="completed",
-        started_at=outcome.started_at,
-        completed_at=outcome.completed_at,
         elapsed_seconds=outcome.elapsed_seconds,
         exit_code=outcome.exit_code,
         event_file=FileReference(path=output_path),

--- a/src/hermes/runner/analysis/empir/pixel_to_photon.py
+++ b/src/hermes/runner/analysis/empir/pixel_to_photon.py
@@ -16,7 +16,7 @@ from hermes.state.models.analysis.empir import (
     EmpirPixelToPhotonRun,
     EmpirPixelToPhotonState,
 )
-from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state.models.shared_models import FileReference
 
 _STEP_NAME = "pixel_to_photon"
 _EVENT_PREFIX = "analysis.empir.pixel_to_photon"
@@ -60,13 +60,12 @@ def execute_pixel_to_photon(
     """Run pixel-to-photon once and return its verified result."""
     input_path = run.tpx3_file.path
     output_path = run.photon_file
-    validate_step_paths(_STEP_NAME, [input_path], output_path)
+    validate_step_paths(_STEP_NAME, [input_path])
     command = build_pixel_to_photon_command(
         stage,
         run,
         resolved_executable_path,
     )
-    started_at = utc_now()
     _ANALYSIS_LOGGER.info(
         "EMPIR pixel-to-photon started for {input_file}",
         event_type=f"{_EVENT_PREFIX}.started",
@@ -86,7 +85,6 @@ def execute_pixel_to_photon(
             _STEP_NAME,
             command,
             output_path,
-            started_at,
         )
     except EmpirExecutionError as exc:
         _log_failure(stage, run, resolved_executable_path, command, exc)
@@ -111,8 +109,6 @@ def execute_pixel_to_photon(
     )
     return EmpirPixelToPhotonResult(
         status="completed",
-        started_at=outcome.started_at,
-        completed_at=outcome.completed_at,
         elapsed_seconds=outcome.elapsed_seconds,
         exit_code=outcome.exit_code,
         photon_file=FileReference(path=output_path),

--- a/src/hermes/runner/analysis/empir/run.py
+++ b/src/hermes/runner/analysis/empir/run.py
@@ -33,7 +33,7 @@ from hermes.state.models.analysis.empir import (
     EmpirPixelToPhotonResult,
     EmpirPixelToPhotonRun,
 )
-from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state.models.shared_models import FileReference
 from hermes.state_service.state_manager import StateManager
 
 _ANALYSIS_LOGGER = logger.bind(
@@ -67,36 +67,29 @@ def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
             command = build_pixel_to_photon_command(
                 stage, current_run, resolved.pixel_to_photon
             )
-            _apply_pixel_to_photon_run(
-                state_manager,
-                index,
-                current_run.model_copy(
-                    update={
-                        "command_args": command[1:],
-                        "result": EmpirPixelToPhotonResult(
-                            status="running",
-                            started_at=utc_now(),
-                        ),
-                    }
-                ),
-                justification="EMPIR pixel-to-photon started",
-            )
-            try:
-                result = execute_pixel_to_photon(
-                    stage, current_run, resolved.pixel_to_photon
+            if current_run.photon_file.exists():
+                _log_skipped("pixel_to_photon", current_run.photon_file)
+                result = EmpirPixelToPhotonResult(
+                    status="skipped",
+                    photon_file=FileReference(path=current_run.photon_file),
                 )
-            except EmpirError as exc:
-                _apply_pixel_failure(
-                    state_manager, index, current_run, command[1:], exc
-                )
-                raise
+            else:
+                try:
+                    result = execute_pixel_to_photon(
+                        stage, current_run, resolved.pixel_to_photon
+                    )
+                except EmpirError as exc:
+                    _apply_pixel_failure(
+                        state_manager, index, current_run, command[1:], exc
+                    )
+                    raise
             _apply_pixel_to_photon_run(
                 state_manager,
                 index,
                 current_run.model_copy(
                     update={"command_args": command[1:], "result": result}
                 ),
-                justification="EMPIR pixel-to-photon completed",
+                justification="EMPIR pixel-to-photon done",
             )
 
         for index in range(len(analysis.photon_to_event.runs)):
@@ -106,36 +99,29 @@ def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
             command = build_photon_to_event_command(
                 stage, current_run, resolved.photon_to_event
             )
-            _apply_photon_to_event_run(
-                state_manager,
-                index,
-                current_run.model_copy(
-                    update={
-                        "command_args": command[1:],
-                        "result": EmpirPhotonToEventResult(
-                            status="running",
-                            started_at=utc_now(),
-                        ),
-                    }
-                ),
-                justification="EMPIR photon-to-event started",
-            )
-            try:
-                result = execute_photon_to_event(
-                    stage, current_run, resolved.photon_to_event
+            if current_run.event_file.exists():
+                _log_skipped("photon_to_event", current_run.event_file)
+                result = EmpirPhotonToEventResult(
+                    status="skipped",
+                    event_file=FileReference(path=current_run.event_file),
                 )
-            except EmpirError as exc:
-                _apply_photon_failure(
-                    state_manager, index, current_run, command[1:], exc
-                )
-                raise
+            else:
+                try:
+                    result = execute_photon_to_event(
+                        stage, current_run, resolved.photon_to_event
+                    )
+                except EmpirError as exc:
+                    _apply_photon_failure(
+                        state_manager, index, current_run, command[1:], exc
+                    )
+                    raise
             _apply_photon_to_event_run(
                 state_manager,
                 index,
                 current_run.model_copy(
                     update={"command_args": command[1:], "result": result}
                 ),
-                justification="EMPIR photon-to-event completed",
+                justification="EMPIR photon-to-event done",
             )
             _remove_intermediate(
                 current_run.photon_file.path,
@@ -146,31 +132,25 @@ def run_empir_analysis(state_manager: StateManager) -> list[FileReference]:
         current = _current_empir_analysis(state_manager)
         stage = current.event_to_image
         command = build_event_to_image_command(stage, resolved.event_to_image)
-        _apply_event_to_image_state(
-            state_manager,
-            stage.model_copy(
-                update={
-                    "command_args": command[1:],
-                    "result": EmpirEventToImageResult(
-                        status="running",
-                        started_at=utc_now(),
-                    ),
-                }
-            ),
-            justification="EMPIR event-to-image started",
-        )
-        try:
-            result = execute_event_to_image(stage, resolved.event_to_image)
-        except EmpirError as exc:
-            _apply_event_failure(state_manager, stage, command[1:], exc)
-            raise
+        if stage.tiff_file.exists():
+            _log_skipped("event_to_image", stage.tiff_file)
+            result = EmpirEventToImageResult(
+                status="skipped",
+                tiff_file=FileReference(path=stage.tiff_file),
+            )
+        else:
+            try:
+                result = execute_event_to_image(stage, resolved.event_to_image)
+            except EmpirError as exc:
+                _apply_event_failure(state_manager, stage, command[1:], exc)
+                raise
         completed_stage = stage.model_copy(
             update={"command_args": command[1:], "result": result}
         )
         _apply_event_to_image_state(
             state_manager,
             completed_stage,
-            justification="EMPIR event-to-image completed",
+            justification="EMPIR event-to-image done",
         )
         for event_file in stage.event_files:
             _remove_intermediate(
@@ -265,10 +245,6 @@ def _validate_path_collisions(analysis: EmpirAnalysisState) -> None:
     normalized = [_normalized_path(path) for path in all_paths]
     if len(set(normalized)) != len(normalized):
         raise EmpirPreflightError("EMPIR input and output paths must be unique")
-
-    for path in output_paths:
-        if path.exists():
-            raise EmpirPreflightError(f"EMPIR output already exists: {path}")
 
 
 def _prepare_output_parents(analysis: EmpirAnalysisState) -> None:
@@ -365,16 +341,10 @@ def _apply_pixel_failure(
     command_args: list[str],
     error: EmpirError,
 ) -> None:
-    result = EmpirPixelToPhotonResult(
-        status="failed",
-        completed_at=utc_now(),
-        errors=[str(error)],
-    )
+    result = EmpirPixelToPhotonResult(status="failed", errors=[str(error)])
     if isinstance(error, EmpirExecutionError):
         result = EmpirPixelToPhotonResult(
             status="failed",
-            started_at=error.outcome.started_at,
-            completed_at=error.outcome.completed_at,
             elapsed_seconds=error.outcome.elapsed_seconds,
             exit_code=error.outcome.exit_code,
             errors=[str(error)],
@@ -394,16 +364,10 @@ def _apply_photon_failure(
     command_args: list[str],
     error: EmpirError,
 ) -> None:
-    result = EmpirPhotonToEventResult(
-        status="failed",
-        completed_at=utc_now(),
-        errors=[str(error)],
-    )
+    result = EmpirPhotonToEventResult(status="failed", errors=[str(error)])
     if isinstance(error, EmpirExecutionError):
         result = EmpirPhotonToEventResult(
             status="failed",
-            started_at=error.outcome.started_at,
-            completed_at=error.outcome.completed_at,
             elapsed_seconds=error.outcome.elapsed_seconds,
             exit_code=error.outcome.exit_code,
             errors=[str(error)],
@@ -422,16 +386,10 @@ def _apply_event_failure(
     command_args: list[str],
     error: EmpirError,
 ) -> None:
-    result = EmpirEventToImageResult(
-        status="failed",
-        completed_at=utc_now(),
-        errors=[str(error)],
-    )
+    result = EmpirEventToImageResult(status="failed", errors=[str(error)])
     if isinstance(error, EmpirExecutionError):
         result = EmpirEventToImageResult(
             status="failed",
-            started_at=error.outcome.started_at,
-            completed_at=error.outcome.completed_at,
             elapsed_seconds=error.outcome.elapsed_seconds,
             exit_code=error.outcome.exit_code,
             errors=[str(error)],
@@ -440,6 +398,15 @@ def _apply_event_failure(
         state_manager,
         stage.model_copy(update={"command_args": command_args, "result": result}),
         justification=f"EMPIR event-to-image failed: {error}",
+    )
+
+
+def _log_skipped(step_name: str, output_path: Path) -> None:
+    _ANALYSIS_LOGGER.info(
+        "EMPIR {step} skipped: output already exists at {path}",
+        event_type=f"analysis.empir.{step_name}.skipped",
+        step=step_name,
+        path=str(output_path),
     )
 
 

--- a/src/hermes/runner/analysis/hermes/event_reconstruction.py
+++ b/src/hermes/runner/analysis/hermes/event_reconstruction.py
@@ -24,7 +24,7 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     Tpx3EventReconstruction,
     Tpx3EventReconstructionSummary,
 )
-from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state.models.shared_models import FileReference
 
 ContinuationAction: TypeAlias = Literal["run", "skip"]
 EventReconstructionPlan: TypeAlias = list[tuple[FileReference, ContinuationAction]]
@@ -168,7 +168,6 @@ def execute_event_reconstruction(
     event_reconstruction = _require_event_reconstruction(analysis)
     output_file = derive_output_path(event_reconstruction, input_file)
     summary_path = derive_summary_path(output_file)
-    started_at = utc_now()
     started = perf_counter()
 
     # The complete event settings go to the binary in a temporary JSON file; the
@@ -265,8 +264,6 @@ def execute_event_reconstruction(
         input_file=input_file,
         output_file=output_file,
         status="completed",
-        started_at=started_at,
-        completed_at=utc_now(),
         counts=summary.reconstruction,
     )
 

--- a/src/hermes/runner/analysis/hermes/reconstruction.py
+++ b/src/hermes/runner/analysis/hermes/reconstruction.py
@@ -24,7 +24,7 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     Tpx3PhotonReconstruction,
     Tpx3PhotonReconstructionSummary,
 )
-from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state.models.shared_models import FileReference
 
 ContinuationAction: TypeAlias = Literal["run", "skip"]
 ReconstructionPlan: TypeAlias = list[tuple[FileReference, ContinuationAction]]
@@ -157,7 +157,6 @@ def execute_reconstruction(
     reconstruction = _require_reconstruction(analysis)
     output_file = derive_output_path(reconstruction, input_file)
     summary_path = derive_summary_path(output_file)
-    started_at = utc_now()
     started = perf_counter()
 
     # The complete clustering settings go to the binary in a temporary JSON
@@ -253,8 +252,6 @@ def execute_reconstruction(
         input_file=input_file,
         output_file=output_file,
         status="completed",
-        started_at=started_at,
-        completed_at=utc_now(),
         counts=summary.reconstruction,
     )
 

--- a/src/hermes/runner/analysis/hermes/run.py
+++ b/src/hermes/runner/analysis/hermes/run.py
@@ -52,7 +52,7 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3ReconstructionResult,
     HermesTpx3UnpackingResult,
 )
-from hermes.state.models.shared_models import FileReference, utc_now
+from hermes.state.models.shared_models import FileReference
 from hermes.state_service.state_manager import StateManager
 
 _ANALYSIS_LOGGER = logger.bind(
@@ -195,7 +195,6 @@ def run_hermes_analysis(
                 if action == "skip":
                     log_skipped_input(analysis, raw_file)
 
-            started_at = utc_now()
             if files_to_run:
                 worker_count = _calculate_worker_count(analysis, files_to_run)
                 completed = _run_parallel(
@@ -207,13 +206,10 @@ def run_hermes_analysis(
                 )
                 unpacked_files = [files_to_run[i] for i in sorted(completed)]
 
-            completed_at = utc_now()
             unpacking_results = [
                 HermesTpx3UnpackingResult(
                     input_file=raw_file,
                     status="completed" if action == "run" else "skipped",
-                    started_at=started_at if action == "run" else None,
-                    completed_at=completed_at if action == "run" else None,
                 )
                 for raw_file, action in unpacking_plan
             ]
@@ -254,7 +250,6 @@ def run_hermes_analysis(
                     HermesTpx3UnpackingResult(
                         input_file=raw_file,
                         status="failed",
-                        completed_at=utc_now(),
                     )
                     for raw_file in current_analysis.unpacking.tpx3_files
                 ],
@@ -327,7 +322,6 @@ def _run_photon_reconstruction(
                     input_file=input_file,
                     output_file=derive_output_path(reconstruction, input_file),
                     status="failed",
-                    completed_at=utc_now(),
                 )
                 for input_file in _reconstruction_inputs(analysis)
             ],
@@ -416,7 +410,6 @@ def _run_event_reconstruction(
                         event_reconstruction, input_file
                     ),
                     status="failed",
-                    completed_at=utc_now(),
                 )
                 for input_file in _event_reconstruction_inputs(analysis)
             ],

--- a/src/hermes/state/models/analysis/empir.py
+++ b/src/hermes/state/models/analysis/empir.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -11,11 +10,10 @@ from pydantic import Field, field_validator, model_validator
 from hermes.state.models.shared_models import (
     BinaryProgram,
     FileReference,
+    ResultStatus,
     StrictBaseModel,
 )
 
-# Values recorded while each external EMPIR program runs.
-EmpirRunStatus = Literal["planned", "running", "completed", "failed"]
 EmpirExternalTriggerMode = Literal["ignore", "reference", "frameSync"]
 EmpirTiffFormat = Literal["tiff_w4", "tiff_w8"]
 
@@ -55,9 +53,7 @@ class EmpirPixelToPhotonSettings(StrictBaseModel):
 class EmpirPixelToPhotonResult(StrictBaseModel):
     """Recorded outcome from one pixel-to-photon process."""
 
-    status: EmpirRunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    status: ResultStatus
     elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
     photon_file: FileReference | None = None
@@ -74,9 +70,7 @@ class EmpirPixelToPhotonRun(StrictBaseModel):
         default_factory=list,
         description="Built and saved by the EMPIR runner.",
     )
-    result: EmpirPixelToPhotonResult = Field(
-        default_factory=EmpirPixelToPhotonResult
-    )
+    result: EmpirPixelToPhotonResult | None = None
 
     @field_validator("tpx3_file")
     @classmethod
@@ -116,9 +110,7 @@ class EmpirPhotonToEventSettings(StrictBaseModel):
 class EmpirPhotonToEventResult(StrictBaseModel):
     """Recorded outcome from one photon-to-event process."""
 
-    status: EmpirRunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    status: ResultStatus
     elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
     event_file: FileReference | None = None
@@ -135,9 +127,7 @@ class EmpirPhotonToEventRun(StrictBaseModel):
         default_factory=list,
         description="Built and saved by the EMPIR runner.",
     )
-    result: EmpirPhotonToEventResult = Field(
-        default_factory=EmpirPhotonToEventResult
-    )
+    result: EmpirPhotonToEventResult | None = None
 
     @field_validator("photon_file")
     @classmethod
@@ -210,9 +200,7 @@ class EmpirEventToImageSettings(StrictBaseModel):
 class EmpirEventToImageResult(StrictBaseModel):
     """Recorded outcome from the event-to-image process."""
 
-    status: EmpirRunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    status: ResultStatus
     elapsed_seconds: float | None = Field(default=None, ge=0)
     exit_code: int | None = None
     tiff_file: FileReference | None = None
@@ -231,7 +219,7 @@ class EmpirEventToImageState(StrictBaseModel):
         default_factory=list,
         description="Built and saved by the EMPIR runner.",
     )
-    result: EmpirEventToImageResult = Field(default_factory=EmpirEventToImageResult)
+    result: EmpirEventToImageResult | None = None
 
     @field_validator("event_files")
     @classmethod

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -9,12 +8,9 @@ from pydantic import Field, field_validator, model_validator
 from hermes.state.models.shared_models import (
     BinaryProgram,
     FileReference,
+    ResultStatus,
     StrictBaseModel,
 )
-
-HermesTpx3RunStatus = Literal[
-    "planned", "running", "completed", "skipped", "failed"
-]
 
 # Canonical parquet-category subdirectory names the unpacker writes under the
 # unpacking output directory. The unpacker binary creates these directories;
@@ -439,26 +435,20 @@ class Tpx3EventReconstructionSummary(StrictBaseModel):
 
 class HermesTpx3UnpackingResult(StrictBaseModel):
     input_file: FileReference
-    status: HermesTpx3RunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    status: ResultStatus
 
 
 class HermesTpx3ReconstructionResult(StrictBaseModel):
     input_file: FileReference
     output_file: Path
-    status: HermesTpx3RunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    status: ResultStatus
     counts: Tpx3PhotonReconstructionCountsSummary | None = None
 
 
 class HermesTpx3EventReconstructionResult(StrictBaseModel):
     input_file: FileReference
     output_file: Path
-    status: HermesTpx3RunStatus = "planned"
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
+    status: ResultStatus
     counts: Tpx3EventReconstructionCountsSummary | None = None
 
 

--- a/src/hermes/state/models/shared_models.py
+++ b/src/hermes/state/models/shared_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 try:
     from typing import TypeAliasType
 except ImportError:  # pragma: no cover - compatibility for Python 3.11
@@ -15,6 +16,11 @@ JsonValue = TypeAliasType(
     JsonScalar | list["JsonValue"] | dict[str, "JsonValue"],
 )
 JsonObject = dict[str, JsonValue]
+
+# Terminal outcome of one analysis step, shared by both analysis modes. A step
+# records exactly one of these once it finishes; "not run yet" is the result
+# object being absent, not a status value.
+ResultStatus = Literal["completed", "skipped", "failed"]
 
 
 def utc_now() -> datetime:

--- a/tests/unit/hermes/runner/analysis/empir/test_run.py
+++ b/tests/unit/hermes/runner/analysis/empir/test_run.py
@@ -195,8 +195,8 @@ def test_run_empir_analysis_completes_and_removes_intermediates(
     assert current.pixel_to_photon.runs[0].command_args[0] == "-i"
     assert current.photon_to_event.runs[0].photon_file.path.exists() is False
     assert current.event_to_image.event_files[0].path.exists() is False
-    assert initial_analysis.pixel_to_photon.runs[0].result.status == "planned"
-    assert [change.status for change in state_logger.changes].count("applied") == 6
+    assert initial_analysis.pixel_to_photon.runs[0].result is None
+    assert [change.status for change in state_logger.changes].count("applied") == 3
     event_types = [
         record["extra"].get("event_type")
         for record in records
@@ -228,13 +228,8 @@ def test_run_empir_analysis_processes_file_runs_in_order(
     assert applied_paths == [
         "analysis.pixel_to_photon.runs",
         "analysis.pixel_to_photon.runs",
-        "analysis.pixel_to_photon.runs",
-        "analysis.pixel_to_photon.runs",
         "analysis.photon_to_event.runs",
         "analysis.photon_to_event.runs",
-        "analysis.photon_to_event.runs",
-        "analysis.photon_to_event.runs",
-        "analysis.event_to_image",
         "analysis.event_to_image",
     ]
 
@@ -242,7 +237,7 @@ def test_run_empir_analysis_processes_file_runs_in_order(
 def test_run_empir_analysis_stops_after_first_failed_process(
     tmp_path: Path,
 ) -> None:
-    """Mark only the attempted run failed and leave downstream steps planned."""
+    """Mark only the attempted run failed and leave downstream steps unrun."""
     executables = _install_fake_programs(tmp_path)
     manager, _state_logger = _manager(
         tmp_path,
@@ -257,16 +252,16 @@ def test_run_empir_analysis_stops_after_first_failed_process(
     assert current.pixel_to_photon.runs[0].result.status == "completed"
     assert current.pixel_to_photon.runs[1].result.status == "failed"
     assert current.pixel_to_photon.runs[1].command_args[0] == "-i"
-    assert current.photon_to_event.runs[0].result.status == "planned"
-    assert current.event_to_image.result.status == "planned"
+    assert current.photon_to_event.runs[0].result is None
+    assert current.event_to_image.result is None
 
 
-def test_run_empir_analysis_rejects_preflight_without_state_changes(
+def test_run_empir_analysis_skips_step_when_output_exists(
     tmp_path: Path,
 ) -> None:
-    """Reject existing outputs before any running result is saved."""
+    """Skip a step whose output already exists and run the rest normally."""
     executables = _install_fake_programs(tmp_path)
-    analysis = _analysis(tmp_path, executables)
+    analysis = _analysis(tmp_path, executables, save_photon_files=True)
     analysis.pixel_to_photon.runs[0].photon_file.parent.mkdir(
         parents=True,
         exist_ok=True,
@@ -275,15 +270,16 @@ def test_run_empir_analysis_rejects_preflight_without_state_changes(
         "already here",
         encoding="utf-8",
     )
-    manager, state_logger = _manager(tmp_path, analysis)
+    manager, _state_logger = _manager(tmp_path, analysis)
 
-    with pytest.raises(EmpirPreflightError, match="output already exists"):
-        run_empir_analysis(manager)
+    files = run_empir_analysis(manager)
 
-    assert [change.status for change in state_logger.changes] == []
+    assert files == [FileReference(path=tmp_path / "out/final.tiff")]
     current = manager.get_state().analysis
     assert isinstance(current, EmpirAnalysisState)
-    assert current.pixel_to_photon.runs[0].result.status == "planned"
+    assert current.pixel_to_photon.runs[0].result.status == "skipped"
+    assert current.photon_to_event.runs[0].result.status == "completed"
+    assert current.event_to_image.result.status == "completed"
 
 
 def test_run_empir_analysis_wraps_missing_executable_as_preflight_error(
@@ -300,7 +296,7 @@ def test_run_empir_analysis_wraps_missing_executable_as_preflight_error(
     assert [change.status for change in state_logger.changes] == []
     current = manager.get_state().analysis
     assert isinstance(current, EmpirAnalysisState)
-    assert current.pixel_to_photon.runs[0].result.status == "planned"
+    assert current.pixel_to_photon.runs[0].result is None
 
 
 def test_run_empir_analysis_retains_photon_after_downstream_failure(
@@ -326,7 +322,7 @@ def test_run_empir_analysis_retains_photon_after_downstream_failure(
     assert isinstance(current, EmpirAnalysisState)
     assert current.photon_to_event.runs[0].photon_file.path.is_file()
     assert current.photon_to_event.runs[0].result.status == "failed"
-    assert current.event_to_image.result.status == "planned"
+    assert current.event_to_image.result is None
 
 
 def test_run_empir_analysis_keeps_intermediates_when_configured(

--- a/tests/unit/hermes/runner/analysis/hermes/test_event_reconstruction.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_event_reconstruction.py
@@ -662,8 +662,6 @@ def test_run_hermes_analysis_completes_event_reconstruction(
     event_results = result_analysis.event_reconstruction.results
     assert len(event_results) == 1
     assert event_results[0].status == "completed"
-    assert event_results[0].started_at is not None
-    assert event_results[0].completed_at is not None
     assert event_results[0].counts.event_count == 4
 
 

--- a/tests/unit/hermes/runner/analysis/hermes/test_reconstruction.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_reconstruction.py
@@ -520,8 +520,6 @@ def test_run_hermes_analysis_completes_reconstruction(tmp_path: Path) -> None:
     reconstruction_results = result_analysis.photon_reconstruction.results
     assert len(reconstruction_results) == 1
     assert reconstruction_results[0].status == "completed"
-    assert reconstruction_results[0].started_at is not None
-    assert reconstruction_results[0].completed_at is not None
     assert reconstruction_results[0].counts.photon_count == 4
 
 

--- a/tests/unit/hermes/runner/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_unpacker.py
@@ -473,8 +473,6 @@ def test_run_marks_analysis_only_state_running_through_state_manager(
         "second.tpx3",
     ]
     assert all(result.status == "completed" for result in results)
-    assert all(result.started_at is not None for result in results)
-    assert all(result.completed_at is not None for result in results)
     assert state_logger.changes[-1].path == "analysis.unpacking.results"
     assert state_logger.changes[-1].origin == "trusted_workflow"
     assert state_logger.changes[-1].proposer == "tpx3_spidr_unpacking"
@@ -496,8 +494,6 @@ def test_run_with_only_completed_files_does_not_mark_running(
     results = manager.get_state().analysis.unpacking.results
     assert len(results) == 1
     assert results[0].status == "skipped"
-    assert results[0].started_at is None
-    assert results[0].completed_at is None
 
 
 def test_run_rejects_empir_analysis(tmp_path: Path) -> None:
@@ -599,8 +595,6 @@ def test_run_executes_fake_unpacker_logs_details_and_round_trips_yaml(
     results = manager.get_state().analysis.unpacking.results
     assert len(results) == 1
     assert results[0].status == "completed"
-    assert results[0].started_at is not None
-    assert results[0].completed_at is not None
 
     started = next(
         record
@@ -718,7 +712,6 @@ def test_run_saves_failed_state_before_raising_for_output_failures(
     results = manager.get_state().analysis.unpacking.results
     assert results
     assert all(result.status == "failed" for result in results)
-    assert all(result.completed_at is not None for result in results)
     failures = [
         record
         for record in records
@@ -758,7 +751,6 @@ def test_run_saves_failed_state_for_preflight_failure(tmp_path: Path) -> None:
     results = manager.get_state().analysis.unpacking.results
     assert results
     assert all(result.status == "failed" for result in results)
-    assert all(result.completed_at is not None for result in results)
 
 
 def test_resource_limit_percent_field_defaults_to_90(tmp_path: Path) -> None:

--- a/tests/unit/hermes/runner/analysis/hermes/test_unpacker_integration.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_unpacker_integration.py
@@ -90,8 +90,6 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     unpacking_results = completed_state.analysis.unpacking.results
     assert [result.input_file.path for result in unpacking_results] == raw_paths
     assert all(result.status == "completed" for result in unpacking_results)
-    assert all(result.started_at is not None for result in unpacking_results)
-    assert all(result.completed_at is not None for result in unpacking_results)
 
     summaries: list[Tpx3SpidrSummary] = []
     generated_paths: set[Path] = set()
@@ -150,8 +148,6 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
         assert set(saved_result) == {
             "input_file",
             "status",
-            "started_at",
-            "completed_at",
         }
     assert not _contains_key(
         saved_analysis,

--- a/tests/unit/hermes/state/models/test_empir.py
+++ b/tests/unit/hermes/state/models/test_empir.py
@@ -151,16 +151,14 @@ def test_empir_analysis_state_serializes_direct_binary_pipeline(
     assert dumped["pixel_to_photon"]["runs"][0]["tpx3_file"][
         "path"
     ].endswith("raw.tpx3")
-    assert dumped["pixel_to_photon"]["runs"][0]["result"]["status"] == (
-        "planned"
-    )
+    assert dumped["pixel_to_photon"]["runs"][0]["result"] is None
     assert dumped["photon_to_event"]["runs"][0]["event_file"].endswith(
         "raw.empirevent"
     )
     assert dumped["event_to_image"]["settings"]["external_trigger_mode"] == (
         "reference"
     )
-    assert dumped["event_to_image"]["result"]["status"] == "planned"
+    assert dumped["event_to_image"]["result"] is None
     assert dumped["pixel_to_photon"]["runs"][0]["command_args"] == []
     assert dumped["photon_to_event"]["runs"][0]["command_args"] == []
     assert dumped["event_to_image"]["command_args"] == []
@@ -182,10 +180,12 @@ def test_empir_results_require_nonnegative_elapsed_seconds(
     ],
 ) -> None:
     """Accept zero duration and reject negative duration for every step."""
-    assert result_model(elapsed_seconds=0).elapsed_seconds == 0
+    assert (
+        result_model(status="completed", elapsed_seconds=0).elapsed_seconds == 0
+    )
 
     with pytest.raises(ValidationError, match="greater than or equal to 0"):
-        result_model(elapsed_seconds=-0.01)
+        result_model(status="completed", elapsed_seconds=-0.01)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
+++ b/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -40,8 +39,6 @@ def _analysis_state(tmp_path: Path, *raw_names: str) -> HermesTpx3AnalysisState:
                 HermesTpx3UnpackingResult(
                     input_file=FileReference(path=tmp_path / "rawTpx3" / raw_name),
                     status="completed",
-                    started_at=datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc),
-                    completed_at=datetime(2026, 7, 23, 12, 1, tzinfo=timezone.utc),
                 )
                 for raw_name in raw_names
             ],
@@ -310,11 +307,10 @@ def test_reconstruction_result_defaults_and_rejects_undefined_fields(
     result = HermesTpx3ReconstructionResult(
         input_file=FileReference(path=tmp_path / "pixelHits/raw.parquet"),
         output_file=tmp_path / "photons/raw.parquet",
+        status="completed",
     )
 
-    assert result.status == "planned"
-    assert result.started_at is None
-    assert result.completed_at is None
+    assert result.status == "completed"
     assert result.counts is None
 
     with pytest.raises(ValidationError, match="extra_forbidden"):


### PR DESCRIPTION
This pull request updates the HERMES analysis pipeline to simplify and clarify how per-file step results and statuses are recorded, and removes unused timing fields from the EMPIR processing code. It also updates the documentation and example code to reflect these changes and improves result reporting.

**Pipeline result recording and status simplification:**

* Changes the pipeline to write one result per file after each finishes, using only terminal statuses (`completed`, `skipped`, `failed`), and removes all usage and recording of `planned` and `running` statuses in both code and documentation. [[1]](diffhunk://#diff-3de6297c0debf34b4727dd407fc31afb4504bb7ec2deac4e50f35203c5a86216L289-R296) [[2]](diffhunk://#diff-3de6297c0debf34b4727dd407fc31afb4504bb7ec2deac4e50f35203c5a86216L343-L350) [[3]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL666-R670) [[4]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL732-R749) [[5]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afL55-R55) [[6]](diffhunk://#diff-d89e192376bc12278be73d2e513f13bf71bab8806666a7effb2d14a08a8e473eL73-R90) [[7]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL164-R165)

**EMPIR processing code cleanup:**

* Removes the `started_at` and `completed_at` fields from `EmpirProcessOutcome` and related code, as these are no longer used; only `elapsed_seconds` is now reported. [[1]](diffhunk://#diff-1ec9489affcb1cd52b2f5a858c53a5d9ee6c7dd8b22b1dfd2cb6e3672a4c7c59L7) [[2]](diffhunk://#diff-1ec9489affcb1cd52b2f5a858c53a5d9ee6c7dd8b22b1dfd2cb6e3672a4c7c59L16) [[3]](diffhunk://#diff-1ec9489affcb1cd52b2f5a858c53a5d9ee6c7dd8b22b1dfd2cb6e3672a4c7c59L25-L26) [[4]](diffhunk://#diff-1ec9489affcb1cd52b2f5a858c53a5d9ee6c7dd8b22b1dfd2cb6e3672a4c7c59L68-L69) [[5]](diffhunk://#diff-1ec9489affcb1cd52b2f5a858c53a5d9ee6c7dd8b22b1dfd2cb6e3672a4c7c59L78-L79)
* Updates all EMPIR step execution functions to match the new interface, removing unused timing arguments and fields. [[1]](diffhunk://#diff-ba41dcaa1049f35a7403fd46fdc47bd73e2fd972b998623308d7630364234a0aL18-R18) [[2]](diffhunk://#diff-ba41dcaa1049f35a7403fd46fdc47bd73e2fd972b998623308d7630364234a0aL73-L75) [[3]](diffhunk://#diff-ba41dcaa1049f35a7403fd46fdc47bd73e2fd972b998623308d7630364234a0aL95) [[4]](diffhunk://#diff-ba41dcaa1049f35a7403fd46fdc47bd73e2fd972b998623308d7630364234a0aL120-L121) [[5]](diffhunk://#diff-1dea25ce58f4572c798f1f642bf8345d42879096ca28701c7f04271fb674214eL19-R19) [[6]](diffhunk://#diff-1dea25ce58f4572c798f1f642bf8345d42879096ca28701c7f04271fb674214eL60-L66) [[7]](diffhunk://#diff-1dea25ce58f4572c798f1f642bf8345d42879096ca28701c7f04271fb674214eL86) [[8]](diffhunk://#diff-1dea25ce58f4572c798f1f642bf8345d42879096ca28701c7f04271fb674214eL111-L112) [[9]](diffhunk://#diff-d9b53768547d3877b117217fe7e1dbf2dca0f428efaa2389f24c392e9d0b71ebL19-R19) [[10]](diffhunk://#diff-d9b53768547d3877b117217fe7e1dbf2dca0f428efaa2389f24c392e9d0b71ebL63-L69)

**Documentation updates:**

* Updates architecture and workflow documentation to clarify the new per-file result recording, the removal of `planned`/`running` statuses, and the meaning of result objects. [[1]](diffhunk://#diff-3de6297c0debf34b4727dd407fc31afb4504bb7ec2deac4e50f35203c5a86216L289-R296) [[2]](diffhunk://#diff-3de6297c0debf34b4727dd407fc31afb4504bb7ec2deac4e50f35203c5a86216L343-L350) [[3]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL666-R670) [[4]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL732-R749) [[5]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afL55-R55) [[6]](diffhunk://#diff-d89e192376bc12278be73d2e513f13bf71bab8806666a7effb2d14a08a8e473eL73-R90) [[7]](diffhunk://#diff-70e3c07746be20a678ef9f93e38922ccf087aaea331d7b7b3010f2f396ee67bbL164-R165)

**Example code improvements:**

* Updates the EMPIR example script to print step durations or statuses in a more robust way, reflecting the new result model. [[1]](diffhunk://#diff-dbc806627bdba62630c8643e71b175d96c61552a28004c0a4b1f2084edd79eebR17-R23) [[2]](diffhunk://#diff-dbc806627bdba62630c8643e71b175d96c61552a28004c0a4b1f2084edd79eebL46-R55)

**API simplification:**

* Simplifies the `validate_step_paths` function to only check input files, no longer rejecting if the output file already exists (this logic is now handled elsewhere).

These changes together make the pipeline more robust, easier to understand, and more consistent in how results and statuses are handled.