### PR TITLE
71 binary output names

### DIFF
--- a/docs/architecture/photon_reconstruction.md
+++ b/docs/architecture/photon_reconstruction.md
@@ -166,19 +166,27 @@ reserved timing values and must be rejected until implemented.
 
 ## Photon Parquet Files
 
-The `analysis/photons/` directory contains two distinct filename groups:
+Reconstruction writes two tables in two directories under `analysis/`. The
+photon table goes in `photons/` and the pixel-to-cluster table goes in
+`pixel_clusters/`. Both filenames join the raw TPX3 filename stem, a descriptive
+label, and the pixel file's five-digit part index with underscores:
 
 ```text
-<raw-file-stem>-chip-<chip-index>-photon-events-part-<five-digit-part-index>.parquet
-<raw-file-stem>-chip-<chip-index>-photon-pixels-part-<five-digit-part-index>.parquet
+photons/<raw-file-stem>_photon_<five-digit-part-index>.parquet
+pixel_clusters/<raw-file-stem>_pixel_clusters_<five-digit-part-index>.parquet
 ```
 
-Part numbers start at zero independently for each raw input, chip, and file
-group. `photon_events` is always written when accepted photons exist.
-`photon_pixels` is written only when `save_photon_pixels` is true. An empty file
-group has zero files and a zero row count in the summary.
+For example, reconstructing
+`pixel_hits/Tantalum_IronPowder_chip_0_pixels_00000.parquet` writes
+`photons/Tantalum_IronPowder_photon_00000.parquet` and, when
+`save_photon_pixels` is true, `pixel_clusters/Tantalum_IronPowder_pixel_clusters_00000.parquet`.
 
-### `photon_events`
+The part index matches the pixel file the run read. The photon table is always
+written when accepted photons exist. The pixel-to-cluster table is written only
+when `save_photon_pixels` is true, in its own `pixel_clusters/` directory. An
+empty table has zero files and a zero row count in the summary.
+
+### photon table
 
 | Column | Arrow type | Nullable | Description |
 | --- | --- | --- | --- |
@@ -192,11 +200,11 @@ group has zero files and a zero row count in the summary.
 The first position rule is `arithmetic`. ToT-weighted or fitted positions are
 reserved for later work.
 
-### `photon_pixels`
+### pixel-to-cluster table
 
 | Column | Arrow type | Nullable | Description |
 | --- | --- | --- | --- |
-| `photon_id` | `uint64` | no | Photon number matching `photon_events` for the same raw input and chip |
+| `photon_id` | `uint64` | no | Photon number matching the photon table for the same raw input and chip |
 | `pixel_event_id` | `uint64` | no | Zero-based row number after reading the chip's sorted input parts in order |
 | `x` | `uint16` | no | Source pixel `local_x` |
 | `y` | `uint16` | no | Source pixel `local_y` |
@@ -217,25 +225,30 @@ Every photon Parquet file records these string metadata values:
 
 ## Reconstruction Summary JSON File
 
-Each raw TPX3 filename stem has one reconstruction summary:
+Each raw TPX3 filename stem has one reconstruction summary in
+`analysis/logs/photon_reconstruction/`:
 
 ```text
-analysis/logs/<raw-file-stem>-reconstruction-summary.json
+analysis/logs/photon_reconstruction/<raw-file-stem>_photon_reconstruction_summary.json
 ```
 
-It is written only after every final photon Parquet file closes successfully.
-Paths are relative to the analysis directory. The summary has this structure:
+The reconstruction program reads the same run-identity inputs as the unpacker
+(`--measurement-id` and `--run`) and copies them into the summary so it names
+the measurement and run it belongs to. The summary is written only after every
+final photon Parquet file closes successfully. Each listed Parquet path is the
+`--input` path or the output path the program wrote, so a reader can open the
+file directly from the working directory. The summary has this structure:
 
 ```yaml
-schema_version: 1
+measurement_info:
+  measurement_id: 02-two-stage
+  run: tantalum-ironpowder
 
 reconstruction:
-  pixel_rows_read: 0
-  pixel_rows_below_min_tot: 0
-  components_formed: 0
-  photon_count: 0
-  rejected_component_count: 0
-  rejection_counts:
+  pixels_read: 0
+  clusters_formed: 0
+  rejected_clusters: 0
+  rejection_reasons:
     below_min_cluster_size: 0
     above_max_cluster_size: 0
     below_min_cluster_tot: 0
@@ -247,6 +260,7 @@ reconstruction:
     bridged_components: 0
   warnings: []
   errors: []
+  total_photons: 0
 
 clustering:
   algorithm: connected_components
@@ -259,12 +273,12 @@ photon_timing:
   parameters: {}
   high_tot_anchor: null
 
-parquet:
-  input_pixel_data_files: []
-  photon_events:
+parquet_files:
+  input_pixel_data_file: []
+  photons:
     row_count: 0
     files: []
-  photon_pixels:
+  pixel_clusters:
     requested: false
     row_count: 0
     files: []
@@ -279,9 +293,10 @@ processing_times_seconds:
     photons_per_second: 0.0
 ```
 
-The complete saved settings include adjacency, maximum time spread, cluster-size
-limits, pixel and cluster ToT limits, maximum aspect ratio, minimum filled
-fraction, position rule, timing rule, optional calibration path, and
-`save_photon_pixels`. Detailed per-input counts, filenames, warnings, errors,
-timing, and throughput stay in this summary and are not copied into the HERMES
-YAML file.
+`clustering.settings` holds the complete settings the run used: adjacency,
+maximum time spread, cluster-size limits, pixel and cluster ToT limits, maximum
+aspect ratio, minimum filled fraction, position rule, timing rule, optional
+calibration path, and `save_photon_pixels`. `pixel_clusters.requested` mirrors
+`save_photon_pixels`, and its `row_count` counts the pixels in accepted
+clusters. Detailed per-input counts, filenames, warnings, errors, timing, and
+throughput stay in this summary and are not copied into the HERMES YAML file.

--- a/docs/architecture/unpacker.md
+++ b/docs/architecture/unpacker.md
@@ -26,7 +26,7 @@ The Python runner should call the unpacker with the raw TPX3 file and the
 shared analysis directory:
 
 ```text
-<executable> --input <input.tpx3> [--output <analysis_directory>] [--overwrite] [--time-sort]
+<executable> --input <input.tpx3> --output <analysis_directory> --measurement-id <measurement-id> --run <run> [--overwrite] [--time-sort]
 ```
 
 The unpacker accepts exactly these options and no others:
@@ -37,13 +37,20 @@ The unpacker accepts exactly these options and no others:
   creates all category directories and output filenames from it. Optional; when
   omitted, the unpacker prints summary statistics only and writes no files. The
   HERMES analysis workflow always supplies it. Implemented.
+- `--measurement-id <measurement-id>` — the measurement identifier. The unpacker
+  copies it into the summary JSON so each summary names the measurement it
+  belongs to. Required when `--output` is given.
+- `--run <run>` — the run label within the measurement. The unpacker copies it
+  into the summary JSON next to the measurement identifier. Required when
+  `--output` is given.
 - `--overwrite` — redo the unpacking or reconstruction and replace existing
   output files instead of stopping. Optional, defaults to false. Without it the
   unpacker preserves existing files (see below). Implemented.
 - `--time-sort` — sort output by canonical timestamp. Optional, defaults to
   false. Not implemented yet.
 
-Do not add any option outside this list. In particular, do not add separate
+Do not add any option outside this list. The measurement identifier and run
+label are the only run-identity inputs; in particular, do not add separate
 command options for category directories, a filename prefix, or a summary
 filename; the unpacker creates those from `--output`.
 
@@ -100,39 +107,46 @@ The directory names and the corresponding Parquet data category names are:
 
 ## Parquet Filenames
 
-Pixel data can come from more than one chip, so its filenames carry the raw TPX3
-filename stem, chip index, and part index:
+Filenames join the raw TPX3 filename stem, a descriptive data label, and a
+five-digit part index with underscores:
 
 ```text
-<raw-file-stem>-chip-<chip-index>-part-<five-digit-part-index>.parquet
+<raw-file-stem>_<data-label>_<five-digit-part-index>.parquet
 ```
 
-For example, the first pixel-data part for chip 0 from
-`DT_2p0V_000000.tpx3` is:
+Pixel data can come from more than one chip, so its label carries the chip
+index:
 
 ```text
-analysis/pixel_hits/DT_2p0V_000000-chip-0-part-00000.parquet
+<raw-file-stem>_chip_<chip-index>_pixels_<five-digit-part-index>.parquet
 ```
 
-The other categories (`tdc_triggers`, `global_timestamps`, `control_packets`, and
-`unknownPackets`) are not associated with a chip, so their filenames omit the
-chip index and carry only the raw TPX3 filename stem and part index:
+For example, the first pixel-data part for chip 0 from `DT_2p0V_000000.tpx3` is:
 
 ```text
-<raw-file-stem>-part-<five-digit-part-index>.parquet
+analysis/pixel_hits/DT_2p0V_000000_chip_0_pixels_00000.parquet
 ```
+
+The other categories are not associated with a chip, so their label is just the
+category name:
+
+| Directory | Data label |
+| --- | --- |
+| `tdc_triggers/` | `tdc_triggers` |
+| `global_timestamps/` | `global_timestamps` |
+| `control_packets/` | `control_packets` |
+| `unknownPackets/` | `unrecognized_packets` |
 
 For example, the first TDC-timestamps part from `DT_2p0V_000000.tpx3` is:
 
 ```text
-analysis/tdc_triggers/DT_2p0V_000000-part-00000.parquet
+analysis/tdc_triggers/DT_2p0V_000000_tdc_triggers_00000.parquet
 ```
 
 Part numbers start at zero independently for each raw file, data category, and
-(for pixel data) chip. The category name does not need to be repeated in the
-filename because it is already stated by the parent directory. When a chip index
-is present it should not be repeated in the rows. When a schema includes
-`packet_index`, it is the packet index within its chunk.
+(for pixel data) chip. The descriptive label makes each file readable on its
+own; when a chip index is present it should not be repeated in the rows. When a
+schema includes `packet_index`, it is the packet index within its chunk.
 
 Raw TPX3 filename stems must be unique within one measurement. The HERMES
 runner must reject duplicate stems before launching any unpacker so one input
@@ -279,26 +293,35 @@ files.
 
 ## Summary JSON File
 
-Each raw TPX3 file has one summary JSON file in `analysis/logs/`:
+Each raw TPX3 file has one summary JSON file in `analysis/logs/unpacking/`:
 
 ```text
-<raw-file-stem>-unpacker-summary.json
+<raw-file-stem>_unpacker_summary.json
 ```
 
 For example:
 
 ```text
-analysis/logs/DT_2p0V_000000-unpacker-summary.json
+analysis/logs/unpacking/DT_2p0V_000000_unpacker_summary.json
 ```
 
 The summary JSON file is the sole saved detailed result for that raw TPX3 file.
 It contains information calculated by the unpacker, including the raw byte
-count. It does not repeat the unpacker program, raw input path, shared analysis
-directory, summary filename, or overall HERMES unpacking status.
+count. It opens with the measurement identifier and run label (from
+`--measurement-id` and `--run`) and the raw input path, so each summary names
+the measurement, run, and file it belongs to. It does not repeat the unpacker
+program, shared analysis directory, summary filename, or overall HERMES
+unpacking status.
 
 The summary should have this structure:
 
 ```yaml
+measurement_info:
+  measurement_id: harness-01-unpacking
+  run: 1kHz-testing
+
+inputfile: tests/data/tpx3/Example_1kHz_5frames.tpx3
+
 unpacking:
   bytes_read: 0
   chunks_read: 0
@@ -330,14 +353,14 @@ sorting:
   strategy: in_memory
   memory_budget_bytes: 0
   estimated_memory_bytes: 0
-  temporary_runs_created: 0
+  sorting_time_seconds: 0.0
 
-parquet:
+output_parquet:
   pixel_data:
     row_count: 1200000
     files:
-      - pixel_hits/DT_2p0V_000000-chip-0-part-00000.parquet
-      - pixel_hits/DT_2p0V_000000-chip-0-part-00001.parquet
+      - data/expt/1kHz-testing/analysis/pixel_hits/DT_2p0V_000000_chip_0_pixels_00000.parquet
+      - data/expt/1kHz-testing/analysis/pixel_hits/DT_2p0V_000000_chip_0_pixels_00001.parquet
   tdc_timestamps:
     row_count: 0
     files: []
@@ -368,9 +391,10 @@ processing_times_seconds:
 All five category entries are required, including categories with no rows. The
 file list contains only final Parquet files written for the raw TPX3 file named
 by the summary filename; it must not list temporary sorting files or files from
-a different input. Paths are relative to the shared analysis directory and
-begin with their category directory, so the directory is not repeated in
-another field. The file count is calculated from `len(files)` and is not saved.
+a different input. Each path is the `--output` directory joined with the
+category directory and filename, exactly as `--output` was given, so a reader
+can open the file directly from the working directory. The file count is
+calculated from `len(files)` and is not saved.
 
 Unpacked packet counts and Parquet row counts both remain because they describe
 different processing stages. An unpacked packet may be rejected before a

--- a/evals/cases/01-unpacking/input/config.yaml
+++ b/evals/cases/01-unpacking/input/config.yaml
@@ -6,11 +6,11 @@ measurement_info:
 
 environment:
   working_directory: data/01-unpacking
-  run_directory: data/01-unpacking/1kHz-testing
-  log_directory: data/01-unpacking/1kHz-testing/logs
+  run_directory: 1kHz-testing
+  log_directory: logs
   raw_data_directory: tests/data/tpx3
-  analysis_directory: data/01-unpacking/1kHz-testing/analysis
-  config_file: data/01-unpacking/1kHz-testing/HERMES_record.yaml
+  analysis_directory: analysis
+  config_file: HERMES_record.yaml
 
 analysis:
   mode: hermes

--- a/evals/cases/02-two-stage/input/config.yaml
+++ b/evals/cases/02-two-stage/input/config.yaml
@@ -6,11 +6,11 @@ measurement_info:
 
 environment:
   working_directory: data/02-two-stage
-  run_directory: data/02-two-stage/tantalum-ironpowder
-  log_directory: data/02-two-stage/tantalum-ironpowder/logs
+  run_directory: tantalum-ironpowder
+  log_directory: logs
   raw_data_directory: tests/data/tpx3
-  analysis_directory: data/02-two-stage/tantalum-ironpowder/analysis
-  config_file: data/02-two-stage/tantalum-ironpowder/HERMES_record.yaml
+  analysis_directory: analysis
+  config_file: HERMES_record.yaml
 
 analysis:
   mode: hermes

--- a/examples/analysis/two_stage/run_two_stage.py
+++ b/examples/analysis/two_stage/run_two_stage.py
@@ -48,12 +48,12 @@ def main(input_yaml_path: Path = DEFAULT_INPUT_YAML_PATH) -> None:
         1 for result in reconstruction_results if result.status == "skipped"
     )
     photon_count = sum(
-        result.counts.photon_count
+        result.counts.total_photons
         for result in reconstruction_results
         if result.counts is not None
     )
     rejected_count = sum(
-        result.counts.rejected_component_count
+        result.counts.rejected_clusters
         for result in reconstruction_results
         if result.counts is not None
     )

--- a/src/backends/reconstruction/photons/cpp/inc/summary_writer.h
+++ b/src/backends/reconstruction/photons/cpp/inc/summary_writer.h
@@ -6,24 +6,51 @@
 #include <vector>
 
 #include "cluster_filter.h"
+#include "settings.h"
+#include "timewalk.h"
 
 namespace hermes_photon_clusterer {
 
-// All content needed to render one input file's reconstruction summary. The
-// summary is purely informational (counts and timing); settings provenance
-// lives in the photon-file metadata, not here.
+// All content needed to render one input file's reconstruction summary. It names
+// the measurement and run it belongs to, the reconstruction counts, the exact
+// clustering settings the run used, the photon-timing correction, the input and
+// output Parquet paths, and the timing breakdown.
 struct ReconstructionSummaryContent {
+    // run identity, copied from the command line
+    std::string measurement_id;
+    std::string run;
+
     // reconstruction counts
-    std::uint64_t pixel_rows_read = 0;
-    std::uint64_t pixel_rows_below_min_tot = 0;
-    std::uint64_t components_formed = 0;
-    std::uint64_t photon_count = 0;
-    std::uint64_t rejected_component_count = 0;
-    RejectionCounts rejection_counts;
+    std::uint64_t pixels_read = 0;
+    std::uint64_t clusters_formed = 0;
+    std::uint64_t rejected_clusters = 0;
+    RejectionCounts rejection_reasons;
     std::uint64_t saturated_pixel_count = 0;
     std::uint64_t bridged_components_count = 0;
     std::vector<std::string> warnings;
     std::vector<std::string> errors;
+    std::uint64_t total_photons = 0;
+
+    // clustering algorithm and the complete settings the run used
+    std::string clustering_algorithm;
+    ClusteringSettings settings;
+
+    // photon timing: the estimator, and the time-walk correction when one was
+    // loaded. When has_correction is false the correction fields are ignored and
+    // the correction model is reported as "none".
+    std::string photon_time_estimator;
+    bool has_correction = false;
+    TimewalkCorrection correction;
+
+    // input and output Parquet paths, exactly as passed to or written by the
+    // binary so a reader can open them from the working directory. Output paths
+    // are empty when no file was written.
+    std::string input_pixel_data_file;
+    std::string photons_file;
+    std::uint64_t photons_row_count = 0;
+    bool pixel_clusters_requested = false;
+    std::string pixel_clusters_file;
+    std::uint64_t pixel_clusters_row_count = 0;
 
     // processing times (seconds)
     double parquet_reading_seconds = 0.0;

--- a/src/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
+++ b/src/backends/reconstruction/photons/cpp/src/photonClusterer.cpp
@@ -34,13 +34,22 @@ void printHelp(const char* program_name) {
     std::cout << "HERMES Photon Clusterer v" << hermes_photon_clusterer::kVersion
               << "\n\n";
     std::cout << "Usage: " << program_name
-              << " --input <pixel_file> [--output <photon_file>]"
+              << " --input <pixel_file> [--output <analysis_directory>"
+                 " --measurement-id <id> --run <run>]"
                  " [--settings <file>] [--overwrite]\n\n";
     std::cout << "Options:\n";
     std::cout << "  --input <pixel_file>           One pixel_hits Parquet file "
                  "to reconstruct (required)\n";
-    std::cout << "  --output <photon_file>         Full path of the photon file "
-                 "to write (optional)\n";
+    std::cout << "  --output <analysis_directory>  Analysis directory the photon "
+                 "files are\n";
+    std::cout << "                                 written under (optional)\n";
+    std::cout << "  --measurement-id <id>          Measurement identifier copied "
+                 "into the\n";
+    std::cout << "                                 summary JSON (required with "
+                 "--output)\n";
+    std::cout << "  --run <run>                    Run label copied into the "
+                 "summary JSON\n";
+    std::cout << "                                 (required with --output)\n";
     std::cout << "  --settings <file>              JSON file overriding "
                  "individual clustering\n";
     std::cout << "                                 settings (any field omitted "
@@ -53,12 +62,10 @@ void printHelp(const char* program_name) {
     std::cout << "  Without --output:\n";
     std::cout << "    Prints summary counts only; writes no files.\n\n";
     std::cout << "  With --output:\n";
-    std::cout << "    Writes one photon file at the given path and a "
-                 "photon_pixels\n";
-    std::cout << "    sidecar when enabled. The reconstruction-summary JSON is "
-                 "written\n";
-    std::cout << "    to a logs/photons/ directory beside the output "
-                 "directory.\n";
+    std::cout << "    Writes the photon table to photons/ and, when enabled, the\n";
+    std::cout << "    pixel-to-cluster table to pixel_clusters/. The "
+                 "reconstruction\n";
+    std::cout << "    summary JSON is written to logs/photon_reconstruction/.\n";
 }
 
 void printVersion() {
@@ -108,15 +115,49 @@ std::vector<std::pair<std::string, double>> correctionParameters(
     return {{"m", c.m}};
 }
 
+// The raw TPX3 filename stem and five-digit part index carried by an unpacked
+// pixel file. The unpacker names pixel files
+// "<raw_file_stem>_chip_<chip>_pixels_<part>.parquet"; reconstruction reuses the
+// raw stem and part index when naming its own photon, pixel-cluster, and summary
+// files so every output for one raw file shares a stem.
+struct PixelFileName {
+    std::string raw_file_stem;
+    std::string part_index;
+    bool matched = false;
+};
+
+PixelFileName parsePixelFileName(const std::string& input_stem) {
+    PixelFileName parsed;
+    const std::string chip_marker = "_chip_";
+    const std::string pixels_marker = "_pixels_";
+    const auto chip_position = input_stem.find(chip_marker);
+    const auto pixels_position = input_stem.rfind(pixels_marker);
+    if (chip_position == std::string::npos ||
+        pixels_position == std::string::npos ||
+        pixels_position < chip_position) {
+        return parsed;
+    }
+    parsed.raw_file_stem = input_stem.substr(0, chip_position);
+    parsed.part_index =
+        input_stem.substr(pixels_position + pixels_marker.size());
+    parsed.matched =
+        !parsed.raw_file_stem.empty() && !parsed.part_index.empty();
+    return parsed;
+}
+
 }  // namespace
 
 int main(const int argc, char* argv[]) {
     std::string input_file;
-    std::string output_file;
+    std::string analysis_directory;
     std::string settings_file;
+    std::string measurement_id;
+    std::string run;
     bool overwrite = false;
     bool have_input = false;
     bool have_output = false;
+    bool have_measurement_id = false;
+    bool have_run = false;
 
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
@@ -151,11 +192,29 @@ int main(const int argc, char* argv[]) {
         }
         if (arg == "--output") {
             if (i + 1 >= argc) {
-                std::cerr << "Error: --output requires a file path\n";
+                std::cerr << "Error: --output requires a directory path\n";
                 return 2;
             }
-            output_file = argv[++i];
+            analysis_directory = argv[++i];
             have_output = true;
+            continue;
+        }
+        if (arg == "--measurement-id") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --measurement-id requires a value\n";
+                return 2;
+            }
+            measurement_id = argv[++i];
+            have_measurement_id = true;
+            continue;
+        }
+        if (arg == "--run") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --run requires a value\n";
+                return 2;
+            }
+            run = argv[++i];
+            have_run = true;
             continue;
         }
         std::cerr << "Error: unrecognized argument: " << arg << "\n\n";
@@ -165,6 +224,12 @@ int main(const int argc, char* argv[]) {
 
     if (!have_input) {
         std::cerr << "Error: --input <pixel_file> is required\n";
+        return 2;
+    }
+
+    if (have_output && (!have_measurement_id || !have_run)) {
+        std::cerr << "Error: --measurement-id and --run are required with "
+                     "--output\n";
         return 2;
     }
 
@@ -197,25 +262,33 @@ int main(const int argc, char* argv[]) {
         }
     }
 
-    // Sidecar photon_pixels and summary paths derive from the output file: same
-    // directory, output basename with a suffix. Only used when --output is set.
+    // Every output for one raw file shares its raw filename stem and part index.
+    // The photon table goes in photons/, the pixel-to-cluster table in
+    // pixel_clusters/, and the summary in logs/photon_reconstruction/, all under
+    // the analysis directory. The directories are created up front so the
+    // summary is written even when reconstruction produces zero photons.
+    const std::string input_stem = fs::path(input_file).stem().string();
+    const PixelFileName pixel_name = parsePixelFileName(input_stem);
+    std::string photon_output_file;
     std::string pixels_output_file;
     std::string summary_path;
     if (have_output) {
-        const fs::path output_path(output_file);
-        const fs::path parent = output_path.parent_path();
-        const std::string stem = output_path.stem().string();
-        // The summary is a log artifact: it goes in a logs/photons/ directory
-        // beside the photon output directory (the unpacker writes to
-        // logs/unpacker/), while the photon file and its photon_pixels sidecar
-        // stay at the output path. Both directories are created up front so the
-        // summary is written even when reconstruction produces zero photons (no
-        // parquet files).
-        const fs::path logs_dir = parent.parent_path() / "logs" / "photons";
-        for (const fs::path& directory : {parent, logs_dir}) {
-            if (directory.empty()) {
-                continue;
-            }
+        if (!pixel_name.matched) {
+            std::cerr << "Error: input filename does not match "
+                         "<stem>_chip_<chip>_pixels_<part>.parquet: "
+                      << input_file << "\n";
+            return 2;
+        }
+        const fs::path analysis_path(analysis_directory);
+        const fs::path photons_dir = analysis_path / "photons";
+        const fs::path clusters_dir = analysis_path / "pixel_clusters";
+        const fs::path logs_dir =
+            analysis_path / "logs" / "photon_reconstruction";
+        std::vector<fs::path> directories = {photons_dir, logs_dir};
+        if (settings.save_photon_pixels) {
+            directories.push_back(clusters_dir);
+        }
+        for (const fs::path& directory : directories) {
             std::error_code ec;
             fs::create_directories(directory, ec);
             if (ec) {
@@ -224,17 +297,26 @@ int main(const int argc, char* argv[]) {
                 return 1;
             }
         }
+        photon_output_file =
+            (photons_dir / (pixel_name.raw_file_stem + "_photon_" +
+                            pixel_name.part_index + ".parquet"))
+                .string();
         pixels_output_file =
-            (parent / (stem + "-photon-pixels.parquet")).string();
+            (clusters_dir / (pixel_name.raw_file_stem + "_pixel_clusters_" +
+                             pixel_name.part_index + ".parquet"))
+                .string();
         summary_path =
-            (logs_dir / (stem + "-reconstruction-summary.json")).string();
+            (logs_dir / (pixel_name.raw_file_stem +
+                         "_photon_reconstruction_summary.json"))
+                .string();
     }
 
     const auto total_start = Clock::now();
 
-    // Photon-file metadata; provenance lives here, not in the summary.
+    // Photon-file metadata; provenance lives here as well as in the summary.
     hermes_photon_clusterer::PhotonFileMetadata metadata;
-    metadata.raw_file_stem = fs::path(input_file).stem().string();
+    metadata.raw_file_stem =
+        pixel_name.matched ? pixel_name.raw_file_stem : input_stem;
     metadata.canonical_tick_seconds = kCanonicalTickSeconds;
     metadata.clustering_algorithm = "connected_components";
     metadata.clustering_settings_json = settingsToJson(settings).dump();
@@ -253,6 +335,17 @@ int main(const int argc, char* argv[]) {
     metadata.save_photon_pixels = settings.save_photon_pixels;
 
     hermes_photon_clusterer::ReconstructionSummaryContent summary;
+    summary.measurement_id = measurement_id;
+    summary.run = run;
+    summary.clustering_algorithm = "connected_components";
+    summary.settings = settings;
+    summary.photon_time_estimator = settings.photon_time_estimator;
+    summary.has_correction = has_correction;
+    if (has_correction) {
+        summary.correction = correction;
+    }
+    summary.input_pixel_data_file = input_file;
+    summary.pixel_clusters_requested = settings.save_photon_pixels;
 
     const hermes_photon_clusterer::TimewalkCorrection* correction_ptr =
         has_correction ? &correction : nullptr;
@@ -289,46 +382,52 @@ int main(const int argc, char* argv[]) {
         next_hit, settings, correction_ptr, settings.save_photon_pixels);
     summary.clustering_and_filtering_seconds = secondsSince(cluster_start);
 
-    summary.pixel_rows_read = result.counts.pixel_rows_read;
-    summary.pixel_rows_below_min_tot = result.counts.pixel_rows_below_min_tot;
-    summary.components_formed = result.counts.components_formed;
-    summary.photon_count = result.counts.photon_count;
-    summary.rejected_component_count = result.counts.rejected_component_count;
-    summary.rejection_counts = result.counts.rejection_counts;
+    summary.pixels_read = result.counts.pixel_rows_read;
+    summary.clusters_formed = result.counts.components_formed;
+    summary.total_photons = result.counts.photon_count;
+    summary.rejected_clusters = result.counts.rejected_component_count;
+    summary.rejection_reasons = result.counts.rejection_counts;
     summary.saturated_pixel_count = result.counts.saturated_pixel_count;
     summary.bridged_components_count = result.counts.bridged_components_count;
 
-    std::cout << "Reconstructed " << summary.photon_count << " photons from "
-              << summary.pixel_rows_read << " pixel rows.\n";
+    std::cout << "Reconstructed " << summary.total_photons << " photons from "
+              << summary.pixels_read << " pixel rows.\n";
 
     // Without --output, print the summary counts and write no files.
     if (!have_output) {
-        std::cout << "Rejected " << summary.rejected_component_count
-                  << " component(s); no files written (no --output).\n";
+        std::cout << "Rejected " << summary.rejected_clusters
+                  << " cluster(s); no files written (no --output).\n";
         return 0;
     }
 
-    // Write the single photon file, plus a photon_pixels sidecar when enabled.
+    // Write the photon table, plus the pixel-to-cluster table when enabled. The
+    // summary records the paths written (empty when a table has no rows) and
+    // their row counts.
     const auto write_start = Clock::now();
     std::vector<std::string> write_errors;
-    hermes_photon_clusterer::writePhotonEventsParquet(
-        result.photons, output_file, metadata, overwrite, write_errors);
+    const auto photon_write = hermes_photon_clusterer::writePhotonEventsParquet(
+        result.photons, photon_output_file, metadata, overwrite, write_errors);
     if (!write_errors.empty()) {
         for (const auto& error : write_errors) {
             std::cerr << "Error: " << error << "\n";
         }
         return 1;
     }
+    summary.photons_file = photon_write.file;
+    summary.photons_row_count = photon_write.row_count;
     if (settings.save_photon_pixels) {
-        hermes_photon_clusterer::writePhotonPixelsParquet(
-            result.photon_pixels, pixels_output_file, metadata, overwrite,
-            write_errors);
+        const auto pixels_write =
+            hermes_photon_clusterer::writePhotonPixelsParquet(
+                result.photon_pixels, pixels_output_file, metadata, overwrite,
+                write_errors);
         if (!write_errors.empty()) {
             for (const auto& error : write_errors) {
                 std::cerr << "Error: " << error << "\n";
             }
             return 1;
         }
+        summary.pixel_clusters_file = pixels_write.file;
+        summary.pixel_clusters_row_count = pixels_write.row_count;
     }
     summary.parquet_writing_seconds = secondsSince(write_start);
     summary.total_seconds = secondsSince(total_start);
@@ -341,7 +440,7 @@ int main(const int argc, char* argv[]) {
         return 1;
     }
 
-    std::cout << "Wrote: " << output_file << "\n";
+    std::cout << "Wrote: " << photon_output_file << "\n";
     std::cout << "Summary: " << summary_path << "\n";
     return 0;
 }

--- a/src/backends/reconstruction/photons/cpp/src/summary_writer.cpp
+++ b/src/backends/reconstruction/photons/cpp/src/summary_writer.cpp
@@ -10,41 +10,111 @@ namespace hermes_photon_clusterer {
 
 using json = nlohmann::ordered_json;
 
+namespace {
+
+// The complete clustering settings, in the same key order the photon-file
+// metadata uses. The calibration path is null when no file was configured.
+json settingsJson(const ClusteringSettings& s) {
+    json j;
+    j["max_time_spread_ticks"] = s.max_time_spread_ticks;
+    j["min_cluster_size"] = s.min_cluster_size;
+    j["max_cluster_size"] = s.max_cluster_size;
+    j["min_pixel_tot_raw"] = s.min_pixel_tot_raw;
+    j["min_cluster_tot_raw"] = s.min_cluster_tot_raw;
+    j["max_cluster_tot_raw"] = s.max_cluster_tot_raw;
+    j["max_aspect_ratio"] = s.max_aspect_ratio;
+    j["min_filled_fraction"] = s.min_filled_fraction;
+    j["adjacency"] = s.adjacency;
+    j["position_averaging"] = s.position_averaging;
+    j["photon_time_estimator"] = s.photon_time_estimator;
+    j["timewalk_calibration_file"] =
+        s.timewalk_calibration_file.empty()
+            ? json(nullptr)
+            : json(s.timewalk_calibration_file);
+    j["save_photon_pixels"] = s.save_photon_pixels;
+    return j;
+}
+
+// The photon_timing block: the estimator, the correction model name, the
+// calibration path, the fitted parameters, and the high-ToT anchor. When no
+// correction was loaded the model is "none" with empty parameters and null
+// calibration path and anchor.
+json photonTimingJson(const ReconstructionSummaryContent& content) {
+    json timing;
+    timing["estimator"] = content.photon_time_estimator;
+    if (!content.has_correction) {
+        timing["correction_model"] = "none";
+        timing["calibration_file"] = nullptr;
+        timing["parameters"] = json::object();
+        timing["high_tot_anchor"] = nullptr;
+        return timing;
+    }
+
+    const bool inverse =
+        content.correction.model == TimewalkCorrection::Model::kInverse;
+    timing["correction_model"] = inverse ? "inverse" : "linear";
+    timing["calibration_file"] =
+        content.settings.timewalk_calibration_file.empty()
+            ? json(nullptr)
+            : json(content.settings.timewalk_calibration_file);
+    json parameters;
+    if (inverse) {
+        parameters["a"] = content.correction.a;
+        parameters["b"] = content.correction.b;
+    } else {
+        parameters["m"] = content.correction.m;
+    }
+    timing["parameters"] = parameters;
+    timing["high_tot_anchor"] = content.correction.high_tot_anchor;
+    return timing;
+}
+
+json fileListJson(const std::string& file) {
+    json files = json::array();
+    if (!file.empty()) {
+        files.push_back(file);
+    }
+    return files;
+}
+
+}  // namespace
+
 std::string generateReconstructionSummaryJson(
     const ReconstructionSummaryContent& content) {
     const double pixels_per_second =
         content.total_seconds > 0.0
-            ? static_cast<double>(content.pixel_rows_read) /
-                  content.total_seconds
+            ? static_cast<double>(content.pixels_read) / content.total_seconds
             : 0.0;
     const double photons_per_second =
         content.total_seconds > 0.0
-            ? static_cast<double>(content.photon_count) / content.total_seconds
+            ? static_cast<double>(content.total_photons) / content.total_seconds
             : 0.0;
 
     json j;
-    j["schema_version"] = 1;
+
+    j["measurement_info"] = {
+        {"measurement_id", content.measurement_id},
+        {"run", content.run},
+    };
 
     j["reconstruction"] = {
-        {"pixel_rows_read", content.pixel_rows_read},
-        {"pixel_rows_below_min_tot", content.pixel_rows_below_min_tot},
-        {"components_formed", content.components_formed},
-        {"photon_count", content.photon_count},
-        {"rejected_component_count", content.rejected_component_count},
-        {"rejection_counts",
+        {"pixels_read", content.pixels_read},
+        {"clusters_formed", content.clusters_formed},
+        {"rejected_clusters", content.rejected_clusters},
+        {"rejection_reasons",
          {
              {"below_min_cluster_size",
-              content.rejection_counts.below_min_cluster_size},
+              content.rejection_reasons.below_min_cluster_size},
              {"above_max_cluster_size",
-              content.rejection_counts.above_max_cluster_size},
+              content.rejection_reasons.above_max_cluster_size},
              {"below_min_cluster_tot",
-              content.rejection_counts.below_min_cluster_tot},
+              content.rejection_reasons.below_min_cluster_tot},
              {"above_max_cluster_tot",
-              content.rejection_counts.above_max_cluster_tot},
+              content.rejection_reasons.above_max_cluster_tot},
              {"above_max_aspect_ratio",
-              content.rejection_counts.above_max_aspect_ratio},
+              content.rejection_reasons.above_max_aspect_ratio},
              {"below_min_filled_fraction",
-              content.rejection_counts.below_min_filled_fraction},
+              content.rejection_reasons.below_min_filled_fraction},
          }},
         {"quality_flag_counts",
          {
@@ -53,6 +123,29 @@ std::string generateReconstructionSummaryJson(
          }},
         {"warnings", content.warnings},
         {"errors", content.errors},
+        {"total_photons", content.total_photons},
+    };
+
+    j["clustering"] = {
+        {"algorithm", content.clustering_algorithm},
+        {"settings", settingsJson(content.settings)},
+    };
+
+    j["photon_timing"] = photonTimingJson(content);
+
+    j["parquet_files"] = {
+        {"input_pixel_data_file", fileListJson(content.input_pixel_data_file)},
+        {"photons",
+         {
+             {"row_count", content.photons_row_count},
+             {"files", fileListJson(content.photons_file)},
+         }},
+        {"pixel_clusters",
+         {
+             {"requested", content.pixel_clusters_requested},
+             {"row_count", content.pixel_clusters_row_count},
+             {"files", fileListJson(content.pixel_clusters_file)},
+         }},
     };
 
     j["processing_times_seconds"] = {

--- a/src/backends/reconstruction/photons/cpp/tests/summary_writer_tests.cpp
+++ b/src/backends/reconstruction/photons/cpp/tests/summary_writer_tests.cpp
@@ -8,10 +8,12 @@
 
 #include "summary_writer.h"
 #include "test_helpers.h"
+#include "timewalk.h"
 
 namespace {
 
 using hermes_photon_clusterer::ReconstructionSummaryContent;
+using hermes_photon_clusterer::TimewalkCorrection;
 using hermes_photon_clusterer::generateReconstructionSummaryJson;
 using hermes_photon_clusterer::writeReconstructionSummaryJson;
 
@@ -22,21 +24,44 @@ std::string readFile(const std::string& path) {
     return buffer.str();
 }
 
-// A content struct whose counts satisfy the summary's cross-field validators:
-// pixel_rows_below_min_tot <= pixel_rows_read, photon_count +
-// rejected_component_count == components_formed, and quality flags <=
-// photon_count.
+// A content struct whose counts satisfy the summary's cross-field relationships:
+// total_photons + rejected_clusters == clusters_formed and quality flags <=
+// total_photons. It also carries the run identity, an inverse time-walk
+// correction, and the input/output Parquet paths the summary reports.
 ReconstructionSummaryContent consistentContent() {
     ReconstructionSummaryContent content;
-    content.pixel_rows_read = 1000;
-    content.pixel_rows_below_min_tot = 40;
-    content.components_formed = 100;
-    content.photon_count = 70;
-    content.rejected_component_count = 30;
-    content.rejection_counts.below_min_cluster_size = 10;
-    content.rejection_counts.above_max_aspect_ratio = 25;
+    content.measurement_id = "harness-test";
+    content.run = "unit-run";
+
+    content.pixels_read = 1000;
+    content.clusters_formed = 100;
+    content.total_photons = 70;
+    content.rejected_clusters = 30;
+    content.rejection_reasons.below_min_cluster_size = 10;
+    content.rejection_reasons.above_max_aspect_ratio = 25;
     content.saturated_pixel_count = 5;
     content.bridged_components_count = 3;
+
+    content.clustering_algorithm = "connected_components";
+    content.settings.timewalk_calibration_file =
+        "calibrations/tpx3/time-walk_example.json";
+    content.settings.save_photon_pixels = true;
+
+    content.photon_time_estimator = "leading_edge";
+    content.has_correction = true;
+    content.correction.model = TimewalkCorrection::Model::kInverse;
+    content.correction.a = 382443.0;
+    content.correction.b = 3.98;
+    content.correction.high_tot_anchor = 83.0;
+
+    content.input_pixel_data_file =
+        "analysis/pixel_hits/Example_chip_0_pixels_00000.parquet";
+    content.photons_file = "analysis/photons/Example_photon_00000.parquet";
+    content.photons_row_count = 70;
+    content.pixel_clusters_requested = true;
+    content.pixel_clusters_file =
+        "analysis/pixel_clusters/Example_pixel_clusters_00000.parquet";
+    content.pixel_clusters_row_count = 900;
 
     content.total_seconds = 2.0;
     content.parquet_reading_seconds = 0.5;
@@ -50,29 +75,82 @@ ReconstructionSummaryContent consistentContent() {
 int main() {
     TestContext test;
 
-    // Counts, rejection/quality tallies, and derived throughput render.
+    // Counts, rejection/quality tallies, settings echo, timing, file lists, and
+    // derived throughput render into the expected structure.
     {
         auto content = consistentContent();
         const auto text = generateReconstructionSummaryJson(content);
         auto j = nlohmann::json::parse(text);
 
-        test.expectEqual(j["schema_version"].get<int>(), 1, "schema_version");
-        test.expectEqual(j["reconstruction"]["photon_count"].get<int>(), 70,
-                         "photon_count rendered");
         test.expectEqual(
-            j["reconstruction"]["rejection_counts"]["above_max_aspect_ratio"]
+            j["measurement_info"]["measurement_id"].get<std::string>(),
+            std::string("harness-test"), "measurement_id rendered");
+        test.expectEqual(j["measurement_info"]["run"].get<std::string>(),
+                         std::string("unit-run"), "run rendered");
+
+        test.expectEqual(j["reconstruction"]["pixels_read"].get<int>(), 1000,
+                         "pixels_read rendered");
+        test.expectEqual(j["reconstruction"]["clusters_formed"].get<int>(), 100,
+                         "clusters_formed rendered");
+        test.expectEqual(j["reconstruction"]["rejected_clusters"].get<int>(), 30,
+                         "rejected_clusters rendered");
+        test.expectEqual(j["reconstruction"]["total_photons"].get<int>(), 70,
+                         "total_photons rendered");
+        test.expectEqual(
+            j["reconstruction"]["rejection_reasons"]["above_max_aspect_ratio"]
                 .get<int>(),
-            25, "rejection count rendered");
+            25, "rejection reason rendered");
         test.expectEqual(
             j["reconstruction"]["quality_flag_counts"]["saturated_pixel"]
                 .get<int>(),
             5, "quality flag count rendered");
-        // The slimmed summary carries no settings echo or timing provenance.
-        test.expect(!j.contains("clustering"),
-                    "summary omits clustering settings echo");
-        test.expect(!j.contains("photon_timing"),
-                    "summary omits photon_timing block");
-        test.expect(!j.contains("parquet"), "summary omits parquet file lists");
+        // The slimmed schema drops the schema_version tag and the low-ToT count.
+        test.expect(!j.contains("schema_version"), "no schema_version tag");
+        test.expect(!j["reconstruction"].contains("pixel_rows_below_min_tot"),
+                    "no low-ToT pixel count");
+
+        // Clustering echo carries the algorithm and the full settings block.
+        test.expectEqual(j["clustering"]["algorithm"].get<std::string>(),
+                         std::string("connected_components"),
+                         "clustering algorithm rendered");
+        test.expectEqual(
+            j["clustering"]["settings"]["timewalk_calibration_file"]
+                .get<std::string>(),
+            std::string("calibrations/tpx3/time-walk_example.json"),
+            "settings calibration path rendered");
+        test.expect(
+            j["clustering"]["settings"]["save_photon_pixels"].get<bool>(),
+            "settings save_photon_pixels rendered");
+
+        // Photon timing carries the correction model and fitted parameters.
+        test.expectEqual(
+            j["photon_timing"]["correction_model"].get<std::string>(),
+            std::string("inverse"), "correction model rendered");
+        test.expectEqual(j["photon_timing"]["parameters"]["a"].get<double>(),
+                         382443.0, "correction parameter a rendered");
+        test.expectEqual(j["photon_timing"]["high_tot_anchor"].get<double>(),
+                         83.0, "high_tot_anchor rendered");
+
+        // Parquet file lists report the input path and the written outputs.
+        test.expectEqual(
+            j["parquet_files"]["input_pixel_data_file"][0].get<std::string>(),
+            std::string(
+                "analysis/pixel_hits/Example_chip_0_pixels_00000.parquet"),
+            "input path rendered");
+        test.expectEqual(
+            j["parquet_files"]["photons"]["files"][0].get<std::string>(),
+            std::string("analysis/photons/Example_photon_00000.parquet"),
+            "photon path rendered");
+        test.expectEqual(
+            j["parquet_files"]["photons"]["row_count"].get<int>(), 70,
+            "photon row count rendered");
+        test.expect(
+            j["parquet_files"]["pixel_clusters"]["requested"].get<bool>(),
+            "pixel_clusters requested rendered");
+        test.expectEqual(
+            j["parquet_files"]["pixel_clusters"]["row_count"].get<int>(), 900,
+            "pixel_clusters row count rendered");
+
         // Throughput derived from counts and total time.
         test.expect(j["processing_times_seconds"]["throughput"]
                             ["pixels_per_second"]
@@ -82,6 +160,42 @@ int main() {
                             ["photons_per_second"]
                         .get<double>() == 35.0,
                     "photons_per_second derived");
+    }
+
+    // With no correction the photon_timing block reports "none" with empty
+    // parameters and null calibration path and anchor.
+    {
+        auto content = consistentContent();
+        content.has_correction = false;
+        content.settings.timewalk_calibration_file.clear();
+        auto j = nlohmann::json::parse(
+            generateReconstructionSummaryJson(content));
+        test.expectEqual(
+            j["photon_timing"]["correction_model"].get<std::string>(),
+            std::string("none"), "correction model none");
+        test.expect(j["photon_timing"]["calibration_file"].is_null(),
+                    "null calibration file");
+        test.expect(j["photon_timing"]["parameters"].empty(),
+                    "empty timing parameters");
+        test.expect(j["photon_timing"]["high_tot_anchor"].is_null(),
+                    "null high_tot_anchor");
+        test.expect(
+            j["clustering"]["settings"]["timewalk_calibration_file"].is_null(),
+            "null settings calibration path");
+    }
+
+    // An unwritten pixel-clusters table has zero files and a zero row count.
+    {
+        auto content = consistentContent();
+        content.pixel_clusters_file.clear();
+        content.pixel_clusters_row_count = 0;
+        auto j = nlohmann::json::parse(
+            generateReconstructionSummaryJson(content));
+        test.expect(j["parquet_files"]["pixel_clusters"]["files"].empty(),
+                    "empty pixel_clusters file list");
+        test.expectEqual(
+            j["parquet_files"]["pixel_clusters"]["row_count"].get<int>(), 0,
+            "zero pixel_clusters row count");
     }
 
     // Zero total time yields zero throughput without dividing by zero.
@@ -105,7 +219,6 @@ int main() {
         const auto path = (base / "summary.json").string();
 
         auto content = consistentContent();
-        content.photon_count = 70;
         writeReconstructionSummaryJson(path, content, false);
         test.expect(std::filesystem::exists(path), "summary written initially");
 
@@ -120,11 +233,11 @@ int main() {
 
         // With overwrite == true the file is replaced with the new content.
         auto replacement = consistentContent();
-        replacement.photon_count = 12;
-        replacement.rejected_component_count = 88;  // keeps components_formed
+        replacement.total_photons = 12;
+        replacement.rejected_clusters = 88;  // keeps clusters_formed
         writeReconstructionSummaryJson(path, replacement, true);
         auto j = nlohmann::json::parse(readFile(path));
-        test.expectEqual(j["reconstruction"]["photon_count"].get<int>(), 12,
+        test.expectEqual(j["reconstruction"]["total_photons"].get<int>(), 12,
                          "overwrite == true replaces the summary content");
 
         std::filesystem::remove_all(base);

--- a/src/backends/unpackers/tpx3-spidr/cpp/inc/summary_json.h
+++ b/src/backends/unpackers/tpx3-spidr/cpp/inc/summary_json.h
@@ -19,6 +19,9 @@ struct TimingDiagnostics {
 };
 
 struct SummaryJsonContent {
+    std::string measurement_id;
+    std::string run;
+    std::string inputfile;
     UnpackSummary unpack_summary;
     AnchorIndexDiagnostics anchor_diagnostics;
     EpochAssignmentDiagnostics epoch_diagnostics;

--- a/src/backends/unpackers/tpx3-spidr/cpp/inc/unpacker.h
+++ b/src/backends/unpackers/tpx3-spidr/cpp/inc/unpacker.h
@@ -31,6 +31,8 @@ struct WorkflowResult {
 WorkflowResult runTwoPassWorkflow(std::istream& input,
                                   const std::string& source_file_path,
                                   const std::string& analysis_directory,
+                                  const std::string& measurement_id,
+                                  const std::string& run,
                                   bool overwrite = false,
                                   bool time_sort = true);
 

--- a/src/backends/unpackers/tpx3-spidr/cpp/src/parquet_writer.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/src/parquet_writer.cpp
@@ -19,19 +19,21 @@ namespace hermes_tpx3_spidr {
 
 namespace {
 
-std::string makePartFileName(const std::string& prefix,
+std::string makePixelFileName(const std::string& raw_file_stem,
                               std::uint8_t chip_index,
                               std::uint64_t part_number) {
     std::ostringstream oss;
-    oss << prefix << "-chip-" << static_cast<int>(chip_index) << "-part-"
-        << std::setw(5) << std::setfill('0') << part_number << ".parquet";
+    oss << raw_file_stem << "_chip_" << static_cast<int>(chip_index)
+        << "_pixels_" << std::setw(5) << std::setfill('0') << part_number
+        << ".parquet";
     return oss.str();
 }
 
-std::string makePartFileNameWithoutChip(const std::string& prefix,
-                                        std::uint64_t part_number) {
+std::string makeLabeledFileName(const std::string& raw_file_stem,
+                                const std::string& data_label,
+                                std::uint64_t part_number) {
     std::ostringstream oss;
-    oss << prefix << "-part-"
+    oss << raw_file_stem << "_" << data_label << "_"
         << std::setw(5) << std::setfill('0') << part_number << ".parquet";
     return oss.str();
 }
@@ -368,7 +370,7 @@ void writeRowsToParquet(
             continue;
         }
 
-        category.files.push_back(relative_path);
+        category.files.push_back(full_path);
     }
 }
 
@@ -378,7 +380,7 @@ void writePixelHitsParquet(const std::vector<PixelOutputRow>& rows,
                            const ParquetWriterConfig& config,
                            ParquetWriterDiagnostics& diagnostics) {
     auto filename_gen = [](const ParquetWriterConfig& cfg, std::uint64_t part) {
-        return makePartFileName(cfg.raw_file_stem, cfg.chip_index, part);
+        return makePixelFileName(cfg.raw_file_stem, cfg.chip_index, part);
     };
     writeRowsToParquet(rows, config, diagnostics.pixel_hits,
                       diagnostics.errors, buildPixelTable, filename_gen);
@@ -388,7 +390,7 @@ void writeTdcTriggersParquet(const std::vector<TdcOutputRow>& rows,
                              const ParquetWriterConfig& config,
                              ParquetWriterDiagnostics& diagnostics) {
     auto filename_gen = [](const ParquetWriterConfig& cfg, std::uint64_t part) {
-        return makePartFileNameWithoutChip(cfg.raw_file_stem, part);
+        return makeLabeledFileName(cfg.raw_file_stem, "tdc_triggers", part);
     };
     writeRowsToParquet(rows, config, diagnostics.tdc_triggers,
                       diagnostics.errors, buildTdcTable, filename_gen);
@@ -398,7 +400,7 @@ void writeGlobalTimestampsParquet(const std::vector<GlobalOutputRow>& rows,
                                    const ParquetWriterConfig& config,
                                    ParquetWriterDiagnostics& diagnostics) {
     auto filename_gen = [](const ParquetWriterConfig& cfg, std::uint64_t part) {
-        return makePartFileNameWithoutChip(cfg.raw_file_stem, part);
+        return makeLabeledFileName(cfg.raw_file_stem, "global_timestamps", part);
     };
     writeRowsToParquet(rows, config, diagnostics.global_timestamps,
                       diagnostics.errors, buildGlobalTable, filename_gen);
@@ -408,7 +410,7 @@ void writeControlPacketsParquet(const std::vector<ControlOutputRow>& rows,
                                 const ParquetWriterConfig& config,
                                 ParquetWriterDiagnostics& diagnostics) {
     auto filename_gen = [](const ParquetWriterConfig& cfg, std::uint64_t part) {
-        return makePartFileNameWithoutChip(cfg.raw_file_stem, part);
+        return makeLabeledFileName(cfg.raw_file_stem, "control_packets", part);
     };
     writeRowsToParquet(rows, config, diagnostics.control_packets,
                       diagnostics.errors, buildControlTable, filename_gen);
@@ -418,7 +420,7 @@ void writeUnknownPacketsParquet(const std::vector<UnknownOutputRow>& rows,
                                 const ParquetWriterConfig& config,
                                 ParquetWriterDiagnostics& diagnostics) {
     auto filename_gen = [](const ParquetWriterConfig& cfg, std::uint64_t part) {
-        return makePartFileNameWithoutChip(cfg.raw_file_stem, part);
+        return makeLabeledFileName(cfg.raw_file_stem, "unrecognized_packets", part);
     };
     writeRowsToParquet(rows, config, diagnostics.unknown_packets,
                       diagnostics.errors, buildUnknownTable, filename_gen);

--- a/src/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/src/summary_json.cpp
@@ -34,6 +34,13 @@ std::string generateSummaryJson(const SummaryJsonContent& content) {
                   total_seconds / 1'000'000.0
             : 0.0;
 
+    j["measurement_info"] = {
+        {"measurement_id", content.measurement_id},
+        {"run", content.run}
+    };
+
+    j["inputfile"] = content.inputfile;
+
     j["unpacking"] = {
         {"bytes_read", content.unpack_summary.bytes_read},
         {"chunks_read", content.unpack_summary.chunks_read},
@@ -75,10 +82,10 @@ std::string generateSummaryJson(const SummaryJsonContent& content) {
              : "external_merge"},
         {"memory_budget_bytes", content.sorting_diagnostics.memory_budget_bytes},
         {"estimated_memory_bytes", content.sorting_diagnostics.estimated_memory_bytes},
-        {"temporary_runs_created", content.sorting_diagnostics.temporary_runs_created}
+        {"sorting_time_seconds", content.timing_diagnostics.sorting_seconds}
     };
 
-    j["parquet"] = {
+    j["output_parquet"] = {
         {"pixel_data", categoryJson(content.writer_diagnostics.pixel_hits)},
         {"tdc_timestamps", categoryJson(content.writer_diagnostics.tdc_triggers)},
         {"heartbeat_packets",

--- a/src/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/src/tpx3SpidrUnpacker.cpp
@@ -9,11 +9,16 @@ namespace {
 void printHelp(const char* program_name) {
     std::cout << "HERMES TPX3 SPIDR Unpacker v0.1.0\n\n";
     std::cout << "Usage: " << program_name
-              << " --input <input.tpx3> [--output <analysis_directory>]"
+              << " --input <input.tpx3> [--output <analysis_directory>"
+                 " --measurement-id <id> --run <run>]"
                  " [--overwrite] [--time-sort <true|false>]\n\n";
     std::cout << "Options:\n";
     std::cout << "  --input <input.tpx3>          Input TPX3 raw data file (required)\n";
     std::cout << "  --output <analysis_directory> Shared analysis directory (optional)\n";
+    std::cout << "  --measurement-id <id>         Measurement identifier copied into the\n";
+    std::cout << "                                summary JSON (required with --output)\n";
+    std::cout << "  --run <run>                   Run label copied into the summary JSON\n";
+    std::cout << "                                (required with --output)\n";
     std::cout << "  --overwrite                   Overwrite existing summary and Parquet files\n";
     std::cout << "  --time-sort <true|false>      Sort rows by timestamp (default: true).\n";
     std::cout << "                                false leaves rows in source packet order\n";
@@ -31,7 +36,7 @@ void printHelp(const char* program_name) {
     std::cout << "      - global_timestamps/   Global timestamp anchors\n";
     std::cout << "      - control_packets/     Control packets\n";
     std::cout << "      - unknownPackets/     Unknown packets\n";
-    std::cout << "      - logs/unpacker/      Input-specific summary JSON\n\n";
+    std::cout << "      - logs/unpacking/     Input-specific summary JSON\n\n";
     std::cout << "Examples:\n";
     std::cout << "  # Print summary only\n";
     std::cout << "  " << program_name << " --input data.tpx3\n\n";
@@ -50,8 +55,12 @@ int main(const int argc, char* argv[]) {
     bool time_sort = true;
     std::string input_path;
     std::string output_dir;
+    std::string measurement_id;
+    std::string run;
     bool have_input = false;
     bool have_output = false;
+    bool have_measurement_id = false;
+    bool have_run = false;
 
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
@@ -94,6 +103,24 @@ int main(const int argc, char* argv[]) {
             have_output = true;
             continue;
         }
+        if (arg == "--measurement-id") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --measurement-id requires a value\n";
+                return 2;
+            }
+            measurement_id = argv[++i];
+            have_measurement_id = true;
+            continue;
+        }
+        if (arg == "--run") {
+            if (i + 1 >= argc) {
+                std::cerr << "Error: --run requires a value\n";
+                return 2;
+            }
+            run = argv[++i];
+            have_run = true;
+            continue;
+        }
         std::cerr << "Error: unrecognized argument: " << arg << "\n\n";
         std::cerr << "Try '" << argv[0] << " --help' for more information.\n";
         return 2;
@@ -118,8 +145,15 @@ int main(const int argc, char* argv[]) {
         return result.summary.errors.empty() ? 0 : 1;
     }
 
+    if (!have_measurement_id || !have_run) {
+        std::cerr << "Error: --measurement-id and --run are required with "
+                     "--output\n";
+        return 2;
+    }
+
     const auto result = hermes_tpx3_spidr::runTwoPassWorkflow(
-        input, input_path, output_dir, overwrite, time_sort);
+        input, input_path, output_dir, measurement_id, run, overwrite,
+        time_sort);
 
     if (!result.success) {
         std::cerr << "Workflow failed with errors:\n";

--- a/src/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/src/unpacker.cpp
@@ -285,7 +285,7 @@ constexpr std::array<const char*, 6> analysis_directories = {
     "global_timestamps",
     "control_packets",
     "unknownPackets",
-    "logs/unpacker",
+    "logs/unpacking",
 };
 
 constexpr std::array<const char*, 5> parquet_directories = {
@@ -305,8 +305,7 @@ void findExistingOutputFiles(const std::filesystem::path& analysis_directory,
                          summary_path.string());
     }
 
-    const std::string parquet_prefix_with_chip = raw_file_stem + "-chip-";
-    const std::string parquet_prefix_without_chip = raw_file_stem + "-part-";
+    const std::string parquet_prefix = raw_file_stem + "_";
     for (const char* directory_name : parquet_directories) {
         const auto directory = analysis_directory / directory_name;
         if (!std::filesystem::exists(directory)) {
@@ -319,8 +318,7 @@ void findExistingOutputFiles(const std::filesystem::path& analysis_directory,
             }
             const auto filename = entry.path().filename().string();
             if (entry.path().extension() == ".parquet" &&
-                (filename.rfind(parquet_prefix_with_chip, 0) == 0 ||
-                 filename.rfind(parquet_prefix_without_chip, 0) == 0)) {
+                filename.rfind(parquet_prefix, 0) == 0) {
                 errors.push_back("Refusing to overwrite existing Parquet file " +
                                  entry.path().string());
             }
@@ -487,6 +485,8 @@ UnpackResult unpack(std::istream& input) {
 WorkflowResult runTwoPassWorkflow(std::istream& input,
                                   const std::string& source_file_path,
                                   const std::string& analysis_directory,
+                                  const std::string& measurement_id,
+                                  const std::string& run,
                                   const bool overwrite,
                                   const bool time_sort) {
     using Clock = std::chrono::high_resolution_clock;
@@ -496,6 +496,9 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
 
     WorkflowResult workflow_result;
     workflow_result.analysis_directory = analysis_directory;
+    workflow_result.summary.measurement_id = measurement_id;
+    workflow_result.summary.run = run;
+    workflow_result.summary.inputfile = source_file_path;
 
     const std::string raw_file_stem =
         std::filesystem::path(source_file_path).stem().string();
@@ -506,15 +509,14 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
     }
 
     const std::string summary_json_file =
-        "logs/unpacker/" + raw_file_stem + "-unpacker-summary.json";
+        "logs/unpacking/" + raw_file_stem + "_unpacker_summary.json";
     const auto summary_path = std::filesystem::path(analysis_directory) /
                               summary_json_file;
 
     try {
         if (overwrite) {
             std::filesystem::remove(summary_path);
-            const std::string parquet_prefix_with_chip = raw_file_stem + "-chip-";
-            const std::string parquet_prefix_without_chip = raw_file_stem + "-part-";
+            const std::string parquet_prefix = raw_file_stem + "_";
             for (const char* directory_name : parquet_directories) {
                 const auto directory =
                     std::filesystem::path(analysis_directory) / directory_name;
@@ -527,8 +529,7 @@ WorkflowResult runTwoPassWorkflow(std::istream& input,
                         continue;
                     }
                     const auto filename = entry.path().filename().string();
-                    if (filename.rfind(parquet_prefix_with_chip, 0) == 0 ||
-                        filename.rfind(parquet_prefix_without_chip, 0) == 0) {
+                    if (filename.rfind(parquet_prefix, 0) == 0) {
                         std::filesystem::remove(entry.path());
                     }
                 }

--- a/src/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
+++ b/src/backends/unpackers/tpx3-spidr/cpp/tests/workflow_tests.cpp
@@ -58,7 +58,8 @@ void testWorkflowWithEmptyInput(TestContext& test) {
     const auto analysis_directory = makeTestDirectory("empty");
     std::istringstream input("");
     const auto result = runTwoPassWorkflow(
-        input, "/tmp/empty.tpx3", analysis_directory.string());
+        input, "/tmp/empty.tpx3", analysis_directory.string(),
+        "test-measurement", "test-run");
 
     test.expect(result.success, "workflow succeeded with empty input");
     test.expectEqual(result.analysis_directory, analysis_directory.string(),
@@ -66,12 +67,12 @@ void testWorkflowWithEmptyInput(TestContext& test) {
 
     for (const auto* directory : {"pixel_hits", "tdc_triggers",
                                   "global_timestamps", "control_packets",
-                                  "unknownPackets", "logs/unpacker"}) {
+                                  "unknownPackets", "logs/unpacking"}) {
         test.expect(std::filesystem::is_directory(analysis_directory / directory),
                     std::string("created shared directory ") + directory);
     }
     test.expect(std::filesystem::exists(
-                    analysis_directory / "logs/unpacker/empty-unpacker-summary.json"),
+                    analysis_directory / "logs/unpacking/empty_unpacker_summary.json"),
                 "empty-input summary JSON written");
     test.expectEqual(result.summary.writer_diagnostics.pixel_hits.row_count,
                      std::uint64_t{0}, "empty pixel row count recorded");
@@ -88,11 +89,11 @@ void testSharedDirectoriesForTwoInputs(TestContext& test) {
     std::istringstream first_input(bytes);
     const auto first = runTwoPassWorkflow(
         first_input, "/tmp/DT_2p0V_000000.tpx3",
-        analysis_directory.string());
+        analysis_directory.string(), "test-measurement", "test-run");
     std::istringstream second_input(bytes);
     const auto second = runTwoPassWorkflow(
         second_input, "/tmp/DT_2p0V_000001.tpx3",
-        analysis_directory.string());
+        analysis_directory.string(), "test-measurement", "test-run");
 
     printWorkflowErrors(first, "first shared-directory run");
     printWorkflowErrors(second, "second shared-directory run");
@@ -101,13 +102,13 @@ void testSharedDirectoriesForTwoInputs(TestContext& test) {
     test.expect(second.success, "second input wrote shared analysis files");
 
     const auto first_parquet = analysis_directory /
-        "pixel_hits/DT_2p0V_000000-chip-0-part-00000.parquet";
+        "pixel_hits/DT_2p0V_000000_chip_0_pixels_00000.parquet";
     const auto second_parquet = analysis_directory /
-        "pixel_hits/DT_2p0V_000001-chip-0-part-00000.parquet";
+        "pixel_hits/DT_2p0V_000001_chip_0_pixels_00000.parquet";
     const auto first_summary = analysis_directory /
-        "logs/unpacker/DT_2p0V_000000-unpacker-summary.json";
+        "logs/unpacking/DT_2p0V_000000_unpacker_summary.json";
     const auto second_summary = analysis_directory /
-        "logs/unpacker/DT_2p0V_000001-unpacker-summary.json";
+        "logs/unpacking/DT_2p0V_000001_unpacker_summary.json";
 
     test.expect(std::filesystem::exists(first_parquet),
                 "first input-prefixed Parquet file exists");
@@ -121,14 +122,15 @@ void testSharedDirectoriesForTwoInputs(TestContext& test) {
     if (std::filesystem::exists(first_summary)) {
         const auto first_json = readJson(first_summary);
         test.expectEqual(
-            first_json["parquet"]["pixel_data"]["row_count"]
+            first_json["output_parquet"]["pixel_data"]["row_count"]
                 .get<std::uint64_t>(),
             std::uint64_t{1}, "summary records pixel row count");
         test.expectEqual(
-            first_json["parquet"]["pixel_data"]["files"][0]
+            first_json["output_parquet"]["pixel_data"]["files"][0]
                 .get<std::string>(),
-            std::string(
-                "pixel_hits/DT_2p0V_000000-chip-0-part-00000.parquet"),
+            (analysis_directory /
+             "pixel_hits/DT_2p0V_000000_chip_0_pixels_00000.parquet")
+                .string(),
             "summary records input-prefixed Parquet filename");
     }
 
@@ -142,28 +144,31 @@ void testExistingFilesAreNotOverwritten(TestContext& test) {
 
     std::istringstream first_input(bytes);
     const auto first = runTwoPassWorkflow(
-        first_input, source_path, analysis_directory.string());
+        first_input, source_path, analysis_directory.string(),
+        "test-measurement", "test-run");
     test.expect(first.success, "initial input wrote analysis files");
 
     std::istringstream summary_collision_input(bytes);
     const auto summary_collision = runTwoPassWorkflow(
-        summary_collision_input, source_path, analysis_directory.string());
+        summary_collision_input, source_path, analysis_directory.string(),
+        "test-measurement", "test-run");
     test.expect(!summary_collision.success,
                 "existing summary prevents repeated input");
     test.expect(!summary_collision.errors.empty(),
                 "existing summary reports an error");
 
     const auto summary_path =
-        analysis_directory / "logs/unpacker/repeated-unpacker-summary.json";
+        analysis_directory / "logs/unpacking/repeated_unpacker_summary.json";
     std::filesystem::remove(summary_path);
 
     const auto parquet_path = analysis_directory /
-        "pixel_hits/repeated-chip-0-part-00000.parquet";
+        "pixel_hits/repeated_chip_0_pixels_00000.parquet";
     if (std::filesystem::exists(parquet_path)) {
         const auto parquet_size = std::filesystem::file_size(parquet_path);
         std::istringstream parquet_collision_input(bytes);
         const auto parquet_collision = runTwoPassWorkflow(
-            parquet_collision_input, source_path, analysis_directory.string());
+            parquet_collision_input, source_path, analysis_directory.string(),
+            "test-measurement", "test-run");
         test.expect(!parquet_collision.success,
                     "existing Parquet file prevents repeated input");
         test.expectEqual(std::filesystem::file_size(parquet_path), parquet_size,
@@ -198,7 +203,7 @@ void testSummaryJsonGeneration(TestContext& test) {
     content.sorting_diagnostics.estimated_memory_bytes = 2048;
     content.writer_diagnostics.pixel_hits.row_count = 1;
     content.writer_diagnostics.pixel_hits.files.push_back(
-        "pixel_hits/test-chip-0-part-00000.parquet");
+        "pixel_hits/test_chip_0_pixels_00000.parquet");
     content.timing_diagnostics.conversion_seconds = 0.25;
     content.timing_diagnostics.epoch_assignment_seconds = 0.5;
     content.timing_diagnostics.total_seconds = 2.0;
@@ -268,13 +273,13 @@ void testSummaryJsonGeneration(TestContext& test) {
         parsed["sorting"]["estimated_memory_bytes"].get<std::uint64_t>(),
         std::uint64_t{2048}, "JSON contains sorting memory estimate");
     test.expectEqual(
-        parsed["parquet"]["pixel_data"]["row_count"].get<std::uint64_t>(),
+        parsed["output_parquet"]["pixel_data"]["row_count"].get<std::uint64_t>(),
         std::uint64_t{1}, "JSON contains pixel Parquet row count");
     test.expectEqual(
-        parsed["parquet"]["pixel_data"]["files"][0].get<std::string>(),
-        std::string("pixel_hits/test-chip-0-part-00000.parquet"),
-        "JSON contains relative pixel Parquet filename");
-    test.expect(parsed["parquet"]["tdc_timestamps"]["files"].empty(),
+        parsed["output_parquet"]["pixel_data"]["files"][0].get<std::string>(),
+        std::string("pixel_hits/test_chip_0_pixels_00000.parquet"),
+        "JSON contains pixel Parquet filename");
+    test.expect(parsed["output_parquet"]["tdc_timestamps"]["files"].empty(),
                 "JSON contains empty TDC file list");
     test.expectEqual(
         parsed["processing_times_seconds"]["total"].get<double>(),
@@ -306,10 +311,11 @@ void testSummaryJsonStructure(TestContext& test) {
     SummaryJsonContent content;
     const auto parsed = nlohmann::json::parse(generateSummaryJson(content));
 
-    test.expectEqual(parsed.size(), std::size_t{5},
-                     "JSON contains exactly five top-level sections");
-    for (const auto* section : {"unpacking", "timestamp_processing", "sorting",
-                                "parquet", "processing_times_seconds"}) {
+    test.expectEqual(parsed.size(), std::size_t{7},
+                     "JSON contains exactly seven top-level sections");
+    for (const auto* section : {"measurement_info", "inputfile", "unpacking",
+                                "timestamp_processing", "sorting",
+                                "output_parquet", "processing_times_seconds"}) {
         test.expect(parsed.contains(section),
                     std::string("JSON contains ") + section);
     }
@@ -324,7 +330,7 @@ void testSummaryJsonStructure(TestContext& test) {
     for (const auto* category : {"pixel_data", "tdc_timestamps",
                                  "heartbeat_packets", "control_packets",
                                  "unrecognized_packets"}) {
-        const auto& category_json = parsed["parquet"][category];
+        const auto& category_json = parsed["output_parquet"][category];
         test.expectEqual(category_json.size(), std::size_t{2},
                          std::string(category) +
                              " contains only row_count and files");
@@ -360,7 +366,8 @@ void testWorkflowErrorHandling(TestContext& test) {
 
     std::istringstream input(bytes);
     const auto result = runTwoPassWorkflow(
-        input, "/tmp/malformed.tpx3", analysis_directory.string());
+        input, "/tmp/malformed.tpx3", analysis_directory.string(),
+        "test-measurement", "test-run");
 
     test.expect(result.summary.unpack_summary.malformed_chunk_count > 0,
                 "malformed chunks detected");
@@ -377,6 +384,7 @@ void testTimeSortDisabledStillWritesRows(TestContext& test) {
     std::istringstream input(bytes);
     const auto result = runTwoPassWorkflow(
         input, "/tmp/no_time_sort.tpx3", analysis_directory.string(),
+        "test-measurement", "test-run",
         /*overwrite=*/false, /*time_sort=*/false);
 
     printWorkflowErrors(result, "time-sort-disabled run");

--- a/src/hermes/runner/analysis/hermes/photon_reconstruction.py
+++ b/src/hermes/runner/analysis/hermes/photon_reconstruction.py
@@ -22,6 +22,7 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3PhotonReconstruction,
     HermesTpx3PhotonReconstructionSummary,
 )
+from hermes.state.models.measurement import MeasurementInfo
 from hermes.state.models.shared_models import FileReference
 
 _LOG_TEXT_LIMIT = 4_000
@@ -70,16 +71,48 @@ def resolve_pixel_files(
     ]
 
 
+def _parse_pixel_file_name(input_file: FileReference) -> tuple[str, str]:
+    """Return the raw filename stem and part index of a pixel Parquet file.
+
+    The unpacker names pixel files
+    ``<raw-file-stem>_chip_<chip>_pixels_<part>.parquet``. Reconstruction reuses
+    the raw stem and part index when naming its own photon, pixel-cluster, and
+    summary files, so every output for one raw file shares a stem. This mirrors
+    the binary's own filename parsing.
+    """
+    stem = input_file.path.stem
+    chip_position = stem.find("_chip_")
+    pixels_position = stem.rfind("_pixels_")
+    if (
+        chip_position == -1
+        or pixels_position == -1
+        or pixels_position < chip_position
+    ):
+        raise HermesPhotonReconstructionPreflightError(
+            f"pixel filename does not match "
+            f"<stem>_chip_<chip>_pixels_<part>.parquet: {input_file.path}"
+        )
+    raw_file_stem = stem[:chip_position]
+    part_index = stem[pixels_position + len("_pixels_") :]
+    if not raw_file_stem or not part_index:
+        raise HermesPhotonReconstructionPreflightError(
+            f"pixel filename does not match "
+            f"<stem>_chip_<chip>_pixels_<part>.parquet: {input_file.path}"
+        )
+    return raw_file_stem, part_index
+
+
 def derive_output_path(
     analysis_root: Path,
     input_file: FileReference,
 ) -> Path:
-    """Return the photon file path for one pixel file (input basename kept).
+    """Return the photon file path the binary writes for one pixel file.
 
-    Photon files go in a ``photons`` directory the reconstruction stage makes
-    under the analysis directory.
+    Photon files go in a ``photons`` directory under the analysis directory,
+    named ``<raw-file-stem>_photon_<part>.parquet``.
     """
-    return analysis_root / "photons" / f"{input_file.path.stem}.parquet"
+    raw_file_stem, part_index = _parse_pixel_file_name(input_file)
+    return analysis_root / "photons" / f"{raw_file_stem}_photon_{part_index}.parquet"
 
 
 def check_previous_reconstructed_file(
@@ -92,36 +125,54 @@ def check_previous_reconstructed_file(
     (including zero-photon runs that produce no photon parquet), so its presence
     means the file is already done.
     """
-    output_file = derive_output_path(analysis_root, input_file)
-    return derive_summary_path(output_file).is_file()
+    return derive_summary_path(analysis_root, input_file).is_file()
 
 
-def derive_summary_path(output_file: Path) -> Path:
+def derive_summary_path(
+    analysis_root: Path,
+    input_file: FileReference,
+) -> Path:
     """Return the reconstruction-summary JSON file path written by the binary.
 
-    The binary writes the summary to a ``logs/photons`` directory beside the
-    photon output directory (the unpacker writes to ``logs/unpacker``), so it is
-    a log artifact rather than sitting next to the photon files themselves.
+    The binary writes one summary per raw filename stem to a
+    ``logs/photon_reconstruction`` directory under the analysis directory (the
+    unpacker writes to ``logs/unpacking``), named
+    ``<raw-file-stem>_photon_reconstruction_summary.json``.
     """
-    logs_directory = output_file.parent.parent / "logs" / "photons"
-    return logs_directory / f"{output_file.stem}-reconstruction-summary.json"
+    raw_file_stem, _ = _parse_pixel_file_name(input_file)
+    return (
+        analysis_root
+        / "logs"
+        / "photon_reconstruction"
+        / f"{raw_file_stem}_photon_reconstruction_summary.json"
+    )
 
 
 def derive_reconstruction_command(
     reconstruction: HermesTpx3PhotonReconstruction,
+    analysis_root: Path,
     input_file: FileReference,
-    output_file: Path,
     settings_file: Path,
+    measurement_info: MeasurementInfo,
     *,
     overwrite: bool = False,
 ) -> list[str]:
-    """Build the command line that launches the reconstruction binary."""
+    """Build the command line that launches the reconstruction binary.
+
+    ``--output`` is the analysis directory; the binary derives every output
+    filename from the input pixel filename and writes photons/, pixel_clusters/,
+    and logs/photon_reconstruction/ beneath it.
+    """
     command = [
         str(reconstruction.program.executable_path),
         "--input",
         str(input_file.path),
         "--output",
-        str(output_file),
+        str(analysis_root),
+        "--measurement-id",
+        measurement_info.measurement_id,
+        "--run",
+        measurement_info.run,
         "--settings",
         str(settings_file),
     ]
@@ -134,6 +185,7 @@ def execute_reconstruction(
     analysis: HermesTpx3AnalysisState,
     analysis_root: Path,
     input_file: FileReference,
+    measurement_info: MeasurementInfo,
     *,
     overwrite: bool = False,
 ) -> HermesTpx3PhotonReconstructionResult:
@@ -144,7 +196,7 @@ def execute_reconstruction(
     """
     reconstruction = _require_reconstruction(analysis)
     output_file = derive_output_path(analysis_root, input_file)
-    summary_path = derive_summary_path(output_file)
+    summary_path = derive_summary_path(analysis_root, input_file)
     started = perf_counter()
 
     # The complete clustering settings go to the binary in a temporary JSON
@@ -165,9 +217,10 @@ def execute_reconstruction(
 
     command = derive_reconstruction_command(
         reconstruction,
+        analysis_root,
         input_file,
-        output_file,
         settings_file,
+        measurement_info,
         overwrite=overwrite,
     )
     _ANALYSIS_LOGGER.info(
@@ -227,7 +280,7 @@ def execute_reconstruction(
 
     _ANALYSIS_LOGGER.info(
         "Reconstructed {pixel_file} in {elapsed_seconds:.2f}s: "
-        "{photon_count} photons",
+        "{total_photons} photons",
         event_type="analysis.tpx3_reconstruction.completed",
         pixel_file=str(input_file.path),
         output_file=str(output_file),
@@ -237,8 +290,8 @@ def execute_reconstruction(
         elapsed_seconds=elapsed_seconds,
         stdout_excerpt=stdout_excerpt,
         stderr_excerpt=stderr_excerpt,
-        photon_count=summary.reconstruction.photon_count,
-        rejected_component_count=summary.reconstruction.rejected_component_count,
+        total_photons=summary.reconstruction.total_photons,
+        rejected_clusters=summary.reconstruction.rejected_clusters,
     )
     return HermesTpx3PhotonReconstructionResult(
         input_file=input_file,

--- a/src/hermes/runner/analysis/hermes/run.py
+++ b/src/hermes/runner/analysis/hermes/run.py
@@ -62,6 +62,7 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3PhotonReconstructionResult,
     HermesTpx3UnpackingResult,
 )
+from hermes.state.models.measurement import MeasurementInfo
 from hermes.state.models.shared_models import FileReference
 from hermes.state_service.state_manager import StateManager
 
@@ -194,6 +195,8 @@ def run_hermes_analysis(
             "environment.analysis_directory must be set to run HERMES analysis"
         )
 
+    measurement_info = state.measurement_info
+
     unpacked_files: list[FileReference] = []
     try:
         if analysis.unpacking is not None:
@@ -229,7 +232,11 @@ def run_hermes_analysis(
                 worker_count = _calculate_worker_count(analysis, files_to_run)
                 completed = _run_parallel(
                     lambda raw_file: execute_unpacker(
-                        analysis, analysis_root, raw_file, overwrite=unpack_overwrite
+                        analysis,
+                        analysis_root,
+                        raw_file,
+                        measurement_info,
+                        overwrite=unpack_overwrite,
                     ),
                     files_to_run,
                     worker_count,
@@ -251,7 +258,11 @@ def run_hermes_analysis(
         current_analysis = _current_hermes_analysis(state_manager)
         if current_analysis.photon_reconstruction is not None:
             _run_photon_reconstruction(
-                state_manager, current_analysis, analysis_root, overwrite=overwrite
+                state_manager,
+                current_analysis,
+                analysis_root,
+                measurement_info,
+                overwrite=overwrite,
             )
 
         current_analysis = _current_hermes_analysis(state_manager)
@@ -286,6 +297,7 @@ def _run_photon_reconstruction(
     state_manager: StateManager,
     analysis: HermesTpx3AnalysisState,
     analysis_root: Path,
+    measurement_info: MeasurementInfo,
     *,
     overwrite: bool = False,
 ) -> None:
@@ -319,7 +331,11 @@ def _run_photon_reconstruction(
             worker_count = _calculate_worker_count(analysis, files_to_run)
             completed = _run_parallel(
                 lambda input_file: execute_reconstruction(
-                    analysis, analysis_root, input_file, overwrite=recon_overwrite
+                    analysis,
+                    analysis_root,
+                    input_file,
+                    measurement_info,
+                    overwrite=recon_overwrite,
                 ),
                 files_to_run,
                 worker_count,
@@ -343,7 +359,9 @@ def _run_photon_reconstruction(
             [
                 HermesTpx3PhotonReconstructionResult(
                     input_file=input_file,
-                    output_file=derive_output_path(analysis_root, input_file),
+                    output_file=_best_effort_output_path(
+                        analysis_root, input_file
+                    ),
                     status="failed",
                 )
                 for input_file in _reconstruction_inputs(analysis, analysis_root)
@@ -352,6 +370,17 @@ def _run_photon_reconstruction(
         )
         log_reconstruction_failure(exc)
         raise
+
+
+def _best_effort_output_path(
+    analysis_root: Path,
+    input_file: FileReference,
+) -> Path:
+    """Photon output path for failure reporting; never raises on a bad name."""
+    try:
+        return derive_output_path(analysis_root, input_file)
+    except Exception:
+        return analysis_root / "photons" / f"{input_file.path.stem}.parquet"
 
 
 def _reconstruction_inputs(

--- a/src/hermes/runner/analysis/hermes/unpacker.py
+++ b/src/hermes/runner/analysis/hermes/unpacker.py
@@ -14,15 +14,20 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
     Tpx3SpidrSummary,
 )
+from hermes.state.models.measurement import MeasurementInfo
 from hermes.state.models.shared_models import FileReference
 
-_PARQUET_DIRECTORIES = (
-    "pixel_hits",
-    "tdc_triggers",
-    "global_timestamps",
-    "control_packets",
-    "unknownPackets",
-)
+# Each Parquet category directory and the filename label the unpacker uses in it.
+# Pixel files are named "<stem>_chip_<chip>_pixels_<part>.parquet"; every other
+# category is named "<stem>_<label>_<part>.parquet".
+_PARQUET_DIRECTORY_LABELS = {
+    "pixel_hits": None,
+    "tdc_triggers": "tdc_triggers",
+    "global_timestamps": "global_timestamps",
+    "control_packets": "control_packets",
+    "unknownPackets": "unrecognized_packets",
+}
+_PARQUET_DIRECTORIES = tuple(_PARQUET_DIRECTORY_LABELS)
 _LOG_TEXT_LIMIT = 4_000
 _ANALYSIS_LOGGER = logger.bind(
     domain="analysis",
@@ -54,8 +59,8 @@ def derive_summary_path(
     return (
         analysis_root
         / "logs"
-        / "unpacker"
-        / f"{raw_file.path.stem}-unpacker-summary.json"
+        / "unpacking"
+        / f"{raw_file.path.stem}_unpacker_summary.json"
     )
 
 
@@ -75,6 +80,7 @@ def derive_unpacker_command(
     analysis: HermesTpx3AnalysisState,
     analysis_root: Path,
     raw_file: FileReference,
+    measurement_info: MeasurementInfo,
     *,
     overwrite: bool = False,
 ) -> list[str]:
@@ -84,6 +90,10 @@ def derive_unpacker_command(
         str(raw_file.path),
         "--output",
         str(analysis_root),
+        "--measurement-id",
+        measurement_info.measurement_id,
+        "--run",
+        measurement_info.run,
     ]
     if overwrite:
         command.append("--overwrite")
@@ -95,11 +105,12 @@ def execute_unpacker(
     analysis: HermesTpx3AnalysisState,
     analysis_root: Path,
     raw_file: FileReference,
+    measurement_info: MeasurementInfo,
     *,
     overwrite: bool = False,
 ) -> Tpx3SpidrSummary:
     command = derive_unpacker_command(
-        analysis, analysis_root, raw_file, overwrite=overwrite
+        analysis, analysis_root, raw_file, measurement_info, overwrite=overwrite
     )
     summary_path = derive_summary_path(analysis_root, raw_file)
     resolved_executable_path = (
@@ -302,46 +313,51 @@ def _validate_completed_files(
     analysis_directory: Path,
     raw_file_stem: str,
 ) -> None:
-    if summary.unpacking.errors or summary.parquet.errors:
+    if summary.unpacking.errors or summary.output_parquet.errors:
         raise HermesTpx3OutputError(
             f"summary reports unpacking or Parquet errors: {summary_path}"
         )
 
     analysis_root = analysis_directory.resolve()
     categories = (
-        ("pixel_hits", summary.parquet.pixel_data, True),  # includes chip ID
-        ("tdc_triggers", summary.parquet.tdc_timestamps, False),  # no chip ID
-        ("global_timestamps", summary.parquet.heartbeat_packets, False),
-        ("control_packets", summary.parquet.control_packets, False),
-        ("unknownPackets", summary.parquet.unrecognized_packets, False),
+        ("pixel_hits", summary.output_parquet.pixel_data, True),  # chip in name
+        ("tdc_triggers", summary.output_parquet.tdc_timestamps, False),
+        ("global_timestamps", summary.output_parquet.heartbeat_packets, False),
+        ("control_packets", summary.output_parquet.control_packets, False),
+        ("unknownPackets", summary.output_parquet.unrecognized_packets, False),
     )
     listed_files: set[Path] = set()
+    # The binary names pixel files "<stem>_chip_<chip>_pixels_<part>.parquet"
+    # and every other category "<stem>_<label>_<part>.parquet".
     filename_pattern_with_chip = re.compile(
-        rf"^{re.escape(raw_file_stem)}-chip-(\d+)-part-(\d{{5}})\.parquet$"
-    )
-    filename_pattern_without_chip = re.compile(
-        rf"^{re.escape(raw_file_stem)}-part-(\d{{5}})\.parquet$"
+        rf"^{re.escape(raw_file_stem)}_chip_(\d+)_pixels_(\d{{5}})\.parquet$"
     )
     for expected_directory, category, has_chip_id in categories:
         observed_rows = 0
         parts_by_chip: dict[int, list[int]] = {}
-        filename_pattern = filename_pattern_with_chip if has_chip_id else filename_pattern_without_chip
+        if has_chip_id:
+            filename_pattern = filename_pattern_with_chip
+        else:
+            label = _PARQUET_DIRECTORY_LABELS[expected_directory]
+            filename_pattern = re.compile(
+                rf"^{re.escape(raw_file_stem)}_{re.escape(label)}_"
+                rf"(\d{{5}})\.parquet$"
+            )
 
-        for relative_path in category.files:
-            filename_match = filename_pattern.fullmatch(relative_path.name)
+        for parquet_path in category.files:
+            filename_match = filename_pattern.fullmatch(parquet_path.name)
             if (
-                len(relative_path.parts) != 2
-                or relative_path.parts[0] != expected_directory
+                parquet_path.parent.name != expected_directory
                 or filename_match is None
             ):
                 raise HermesTpx3OutputError(
                     f"unexpected Parquet filename for {raw_file_stem}: "
-                    f"{relative_path}"
+                    f"{parquet_path}"
                 )
-            if relative_path in listed_files:
+            if parquet_path in listed_files:
                 raise HermesTpx3OutputError(
                     f"summary lists the same Parquet file more than once: "
-                    f"{relative_path}"
+                    f"{parquet_path}"
                 )
 
             if has_chip_id:
@@ -352,24 +368,23 @@ def _validate_completed_files(
                 part_index = int(filename_match.group(1))
 
             parts_by_chip.setdefault(chip_index, []).append(part_index)
-            parquet_path = analysis_directory / relative_path
             resolved_path = parquet_path.resolve()
             if not resolved_path.is_relative_to(analysis_root):
                 raise HermesTpx3OutputError(
                     f"summary lists a Parquet file outside the analysis "
-                    f"directory: {relative_path}"
+                    f"directory: {parquet_path}"
                 )
-            if not parquet_path.is_file():
+            if not resolved_path.is_file():
                 raise HermesTpx3OutputError(
-                    f"summary lists a missing Parquet file: {parquet_path}"
+                    f"summary lists a missing Parquet file: {resolved_path}"
                 )
             try:
-                observed_rows += pq.read_metadata(parquet_path).num_rows
+                observed_rows += pq.read_metadata(resolved_path).num_rows
             except Exception as exc:
                 raise HermesTpx3OutputError(
-                    f"cannot read Parquet metadata: {parquet_path}"
+                    f"cannot read Parquet metadata: {resolved_path}"
                 ) from exc
-            listed_files.add(relative_path)
+            listed_files.add(parquet_path)
 
         for chip_index, part_indexes in parts_by_chip.items():
             if sorted(part_indexes) != list(range(len(part_indexes))):
@@ -386,15 +401,16 @@ def _validate_completed_files(
             )
 
     matching_files = {
-        path.relative_to(analysis_directory)
+        path.resolve()
         for path in _matching_parquet_files(
             analysis_directory,
             raw_file_stem,
         )
     }
-    if matching_files != listed_files:
-        unexpected = sorted(str(path) for path in matching_files - listed_files)
-        missing = sorted(str(path) for path in listed_files - matching_files)
+    listed_resolved = {path.resolve() for path in listed_files}
+    if matching_files != listed_resolved:
+        unexpected = sorted(str(path) for path in matching_files - listed_resolved)
+        missing = sorted(str(path) for path in listed_resolved - matching_files)
         raise HermesTpx3OutputError(
             f"summary Parquet file list does not match files for "
             f"{raw_file_stem}; unexpected={unexpected}, missing={missing}"
@@ -406,7 +422,7 @@ def _matching_parquet_files(
     raw_file_stem: str,
 ) -> list[Path]:
     matches: list[Path] = []
-    pattern = f"{raw_file_stem}-*.parquet"
+    pattern = f"{raw_file_stem}_*.parquet"
     for directory in _PARQUET_DIRECTORIES:
         category_directory = analysis_directory / directory
         if category_directory.is_dir():

--- a/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
+++ b/src/hermes/state/models/analysis/hermes_tpx3_spidr.py
@@ -154,8 +154,15 @@ class HermesTpx3EventReconstructionSettings(StrictBaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Unpacker summary (parsed from the unpacker binary's sidecar JSON)
+# Unpacker summary (parsed from the unpacker binary's summary JSON)
 # ---------------------------------------------------------------------------
+
+
+class Tpx3MeasurementInfoSummary(StrictBaseModel):
+    # The measurement identity the binary copies from --measurement-id and --run
+    # so the summary names the measurement and run it belongs to.
+    measurement_id: str = Field(min_length=1)
+    run: str = Field(min_length=1)
 
 
 class Tpx3SpidrUnpackingSummary(StrictBaseModel):
@@ -197,7 +204,7 @@ class Tpx3SpidrSortingSummary(StrictBaseModel):
     strategy: SortingStrategy
     memory_budget_bytes: int = Field(ge=0)
     estimated_memory_bytes: int = Field(ge=0)
-    temporary_runs_created: int = Field(ge=0)
+    sorting_time_seconds: float = Field(ge=0)
 
 
 class Tpx3SpidrParquetCategorySummary(StrictBaseModel):
@@ -213,7 +220,7 @@ class Tpx3SpidrParquetCategorySummary(StrictBaseModel):
         return self
 
 
-class Tpx3SpidrParquetSummary(StrictBaseModel):
+class Tpx3SpidrOutputParquetSummary(StrictBaseModel):
     pixel_data: Tpx3SpidrParquetCategorySummary
     tdc_timestamps: Tpx3SpidrParquetCategorySummary
     heartbeat_packets: Tpx3SpidrParquetCategorySummary
@@ -222,21 +229,25 @@ class Tpx3SpidrParquetSummary(StrictBaseModel):
     errors: list[str]
 
     @model_validator(mode="after")
-    def require_category_relative_paths(self) -> Tpx3SpidrParquetSummary:
+    def require_category_directory(self) -> Tpx3SpidrOutputParquetSummary:
+        # The binary writes each Parquet path as the analysis directory it was
+        # given joined with the category subdirectory and filename, so every
+        # path ends with ``<category-directory>/<filename>``. Check that
+        # trailing directory segment without assuming where the analysis
+        # directory itself lives.
         for field_name, expected_directory in (
             TPX3_PARQUET_CATEGORY_DIRECTORIES.items()
         ):
             category = getattr(self, field_name)
             for file_path in category.files:
-                if file_path.is_absolute() or ".." in file_path.parts:
+                if ".." in file_path.parts:
                     raise ValueError(
-                        f"{field_name} Parquet paths must be relative to the "
-                        "analysis directory"
+                        f"{field_name} Parquet paths must not contain '..'"
                     )
-                if not file_path.parts or file_path.parts[0] != expected_directory:
+                if file_path.parent.name != expected_directory:
                     raise ValueError(
-                        f"{field_name} Parquet paths must begin with "
-                        f"{expected_directory}/"
+                        f"{field_name} Parquet paths must sit in a "
+                        f"{expected_directory}/ directory"
                     )
         return self
 
@@ -258,10 +269,12 @@ class Tpx3SpidrProcessingTimesSummary(StrictBaseModel):
 
 
 class Tpx3SpidrSummary(StrictBaseModel):
+    measurement_info: Tpx3MeasurementInfoSummary
+    inputfile: Path
     unpacking: Tpx3SpidrUnpackingSummary
     timestamp_processing: Tpx3SpidrTimestampProcessingSummary
     sorting: Tpx3SpidrSortingSummary
-    parquet: Tpx3SpidrParquetSummary
+    output_parquet: Tpx3SpidrOutputParquetSummary
     processing_times_seconds: Tpx3SpidrProcessingTimesSummary
 
 
@@ -285,38 +298,82 @@ class HermesTpx3PhotonQualityFlagCountsSummary(StrictBaseModel):
 
 
 class HermesTpx3PhotonReconstructionCountsSummary(StrictBaseModel):
-    pixel_rows_read: int = Field(ge=0)
-    pixel_rows_below_min_tot: int = Field(ge=0)
-    components_formed: int = Field(ge=0)
-    photon_count: int = Field(ge=0)
-    rejected_component_count: int = Field(ge=0)
-    rejection_counts: HermesTpx3PhotonRejectionCountsSummary
+    pixels_read: int = Field(ge=0)
+    clusters_formed: int = Field(ge=0)
+    rejected_clusters: int = Field(ge=0)
+    rejection_reasons: HermesTpx3PhotonRejectionCountsSummary
     quality_flag_counts: HermesTpx3PhotonQualityFlagCountsSummary
     warnings: list[str]
     errors: list[str]
+    total_photons: int = Field(ge=0)
 
     @model_validator(mode="after")
-    def require_component_counts_to_match(
+    def require_cluster_counts_to_match(
         self,
     ) -> HermesTpx3PhotonReconstructionCountsSummary:
-        if self.pixel_rows_below_min_tot > self.pixel_rows_read:
+        if self.total_photons + self.rejected_clusters != self.clusters_formed:
             raise ValueError(
-                "pixel_rows_below_min_tot cannot exceed pixel_rows_read"
+                "clusters_formed must equal total_photons plus rejected_clusters"
             )
         if (
-            self.photon_count + self.rejected_component_count
-            != self.components_formed
+            self.quality_flag_counts.saturated_pixel > self.total_photons
+            or self.quality_flag_counts.bridged_components > self.total_photons
         ):
-            raise ValueError(
-                "components_formed must equal photon_count plus "
-                "rejected_component_count"
-            )
-        if (
-            self.quality_flag_counts.saturated_pixel > self.photon_count
-            or self.quality_flag_counts.bridged_components > self.photon_count
-        ):
-            raise ValueError("quality flag counts cannot exceed photon_count")
+            raise ValueError("quality flag counts cannot exceed total_photons")
         return self
+
+
+class HermesTpx3PhotonClusteringEchoSummary(StrictBaseModel):
+    # The clustering algorithm and the complete settings the run used, echoed by
+    # the binary. The binary owns the settings shape and renders it verbatim, so
+    # it is kept as a plain mapping rather than re-validated field by field.
+    algorithm: ClusteringAlgorithm
+    settings: dict[str, float | int | bool | str | None]
+
+
+class HermesTpx3PhotonTimingSummary(StrictBaseModel):
+    estimator: PhotonTimeEstimator
+    correction_model: Literal["none", "inverse", "linear"]
+    calibration_file: Path | None
+    parameters: dict[str, float]
+    high_tot_anchor: float | None
+
+
+class HermesTpx3PhotonParquetCategorySummary(StrictBaseModel):
+    row_count: int = Field(ge=0)
+    files: list[Path]
+
+    @model_validator(mode="after")
+    def require_files_for_saved_rows(
+        self,
+    ) -> HermesTpx3PhotonParquetCategorySummary:
+        if self.row_count == 0 and self.files:
+            raise ValueError("a table with zero rows cannot list Parquet files")
+        if self.row_count > 0 and not self.files:
+            raise ValueError("a table with saved rows must list a Parquet file")
+        return self
+
+
+class HermesTpx3PhotonPixelClustersSummary(StrictBaseModel):
+    requested: bool
+    row_count: int = Field(ge=0)
+    files: list[Path]
+
+    @model_validator(mode="after")
+    def require_files_for_saved_rows(
+        self,
+    ) -> HermesTpx3PhotonPixelClustersSummary:
+        if self.row_count == 0 and self.files:
+            raise ValueError("a table with zero rows cannot list Parquet files")
+        if self.row_count > 0 and not self.files:
+            raise ValueError("a table with saved rows must list a Parquet file")
+        return self
+
+
+class HermesTpx3PhotonParquetSummary(StrictBaseModel):
+    input_pixel_data_file: list[Path]
+    photons: HermesTpx3PhotonParquetCategorySummary
+    pixel_clusters: HermesTpx3PhotonPixelClustersSummary
 
 
 class HermesTpx3PhotonThroughputSummary(StrictBaseModel):
@@ -333,8 +390,11 @@ class HermesTpx3PhotonProcessingTimesSummary(StrictBaseModel):
 
 
 class HermesTpx3PhotonReconstructionSummary(StrictBaseModel):
-    schema_version: Literal[1] = 1
+    measurement_info: Tpx3MeasurementInfoSummary
     reconstruction: HermesTpx3PhotonReconstructionCountsSummary
+    clustering: HermesTpx3PhotonClusteringEchoSummary
+    photon_timing: HermesTpx3PhotonTimingSummary
+    parquet_files: HermesTpx3PhotonParquetSummary
     processing_times_seconds: HermesTpx3PhotonProcessingTimesSummary
 
 

--- a/tests/unit/examples/analysis/test_two_stage.py
+++ b/tests/unit/examples/analysis/test_two_stage.py
@@ -128,12 +128,10 @@ analysis:
             assert isinstance(analysis, HermesTpx3AnalysisState)
             tpx3_files = analysis.unpacking.tpx3_files
             counts = HermesTpx3PhotonReconstructionCountsSummary(
-                pixel_rows_read=10,
-                pixel_rows_below_min_tot=0,
-                components_formed=5,
-                photon_count=3,
-                rejected_component_count=2,
-                rejection_counts=HermesTpx3PhotonRejectionCountsSummary(
+                pixels_read=10,
+                clusters_formed=5,
+                rejected_clusters=2,
+                rejection_reasons=HermesTpx3PhotonRejectionCountsSummary(
                     below_min_cluster_size=0,
                     above_max_cluster_size=0,
                     below_min_cluster_tot=0,
@@ -147,6 +145,7 @@ analysis:
                 ),
                 warnings=[],
                 errors=[],
+                total_photons=3,
             )
             completed_unpacking = analysis.unpacking.model_copy(
                 update={

--- a/tests/unit/hermes/runner/analysis/hermes/test_event_reconstruction.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_event_reconstruction.py
@@ -473,10 +473,13 @@ def _write_fake_unpacker(executable: Path) -> None:
         args = sys.argv[1:]
         raw_file = Path(args[args.index("--input") + 1])
         analysis_dir = Path(args[args.index("--output") + 1])
+        measurement_id = args[args.index("--measurement-id") + 1]
+        run = args[args.index("--run") + 1]
         stem = raw_file.stem
 
         pixel_hits = analysis_dir / "pixel_hits"
         pixel_hits.mkdir(parents=True, exist_ok=True)
+        pixel_file = pixel_hits / (stem + "_chip_0_pixels_00000.parquet")
         pq.write_table(
             pa.table({{
                 "local_x": pa.array([0], pa.uint16()),
@@ -484,9 +487,13 @@ def _write_fake_unpacker(executable: Path) -> None:
                 "tot_raw": pa.array([10], pa.uint16()),
                 "timestamp_canonical": pa.array([1], pa.uint64()),
             }}),
-            pixel_hits / (stem + "-chip-0-part-00000.parquet"),
+            pixel_file,
         )
         summary = {{
+            "measurement_info": {{
+                "measurement_id": measurement_id, "run": run,
+            }},
+            "inputfile": str(raw_file),
             "unpacking": {{
                 "bytes_read": 0, "chunks_read": 0, "packets_read": 1,
                 "pixel_data_packets": 1, "tdc_timestamps": 0,
@@ -505,12 +512,12 @@ def _write_fake_unpacker(executable: Path) -> None:
             }},
             "sorting": {{
                 "strategy": "in_memory", "memory_budget_bytes": 0,
-                "estimated_memory_bytes": 0, "temporary_runs_created": 0,
+                "estimated_memory_bytes": 0, "sorting_time_seconds": 0.0,
             }},
-            "parquet": {{
+            "output_parquet": {{
                 "pixel_data": {{
                     "row_count": 1,
-                    "files": ["pixel_hits/" + stem + "-chip-0-part-00000.parquet"],
+                    "files": [str(pixel_file)],
                 }},
                 "tdc_timestamps": {{"row_count": 0, "files": []}},
                 "heartbeat_packets": {{"row_count": 0, "files": []}},
@@ -527,9 +534,11 @@ def _write_fake_unpacker(executable: Path) -> None:
                 }},
             }},
         }}
-        logs = analysis_dir / "logs" / "unpacker"
+        logs = analysis_dir / "logs" / "unpacking"
         logs.mkdir(parents=True, exist_ok=True)
-        (logs / (stem + "-unpacker-summary.json")).write_text(json.dumps(summary))
+        (logs / (stem + "_unpacker_summary.json")).write_text(
+            json.dumps(summary)
+        )
         sys.exit(0)
         """
     )

--- a/tests/unit/hermes/runner/analysis/hermes/test_event_reconstruction.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_event_reconstruction.py
@@ -1,28 +1,19 @@
 from __future__ import annotations
 
-import json
-import stat
-import sys
-import tempfile
-import textwrap
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from hermes.runner.analysis.hermes.event_reconstruction import (
-    HermesEventReconstructionExecutionError,
-    HermesEventReconstructionOutputError,
     HermesEventReconstructionPreflightError,
     check_previous_reconstructed_file,
     derive_event_reconstruction_command,
     derive_output_path,
     derive_summary_path,
-    execute_event_reconstruction,
     resolve_photon_files,
     validate_program_and_algorithm,
 )
-from hermes.runner.analysis.hermes.run import run_hermes_analysis
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
     HermesTpx3EventReconstruction,
@@ -32,12 +23,7 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3PhotonReconstruction,
     Tpx3Unpacking,
 )
-from hermes.state.models.environment import RuntimeEnvironment
-from hermes.state.models.measurement import MeasurementInfo
 from hermes.state.models.shared_models import BinaryProgram, FileReference
-from hermes.state.state import HermesRecord
-from hermes.state_service.shared_types import StateServiceConfig
-from hermes.state_service.state_manager import StateManager
 
 
 def _settings(**overrides: Any) -> HermesTpx3EventReconstructionSettings:
@@ -128,107 +114,6 @@ def _analysis(
     )
 
 
-def _summary_dict(*, event_count: int = 3) -> dict[str, Any]:
-    return {
-        "schema_version": 1,
-        "reconstruction": {
-            "photons_read": event_count + 5,
-            "components_formed": event_count,
-            "event_count": event_count,
-            "quality_flag_counts": {
-                "single_photon": 1,
-                "duration_exceeded": 0,
-            },
-            "min_photon_count_below": 0,
-            "warnings": [],
-            "errors": [],
-        },
-        "clustering": {
-            "algorithm": "connected_components",
-            "settings": {
-                "spatial_link_radius_pixels": 10.0,
-                "spatial_cells_per_axis": 5,
-                "max_time_difference_ticks": 4915200.0,
-                "max_event_duration_ticks": 14745600.0,
-                "min_photon_count": 1,
-                "save_event_photons": False,
-                "derived_cell_width_pixels": 52,
-            },
-        },
-        "event_timing": {"estimator": "earliest_photon"},
-        "parquet": {
-            "input_photon_events_files": [
-                "photons/run_000000-chip-0-part-00000.parquet"
-            ],
-            "event_candidates": {
-                "row_count": event_count,
-                "files": ["events/run_000000-chip-0-part-00000.parquet"],
-            },
-        },
-        "processing_times_seconds": {
-            "photon_reading": 0.1,
-            "clustering": 0.2,
-            "parquet_writing": 0.1,
-            "total": 0.4,
-            "throughput": {
-                "photons_per_second": 20.0,
-                "events_per_second": 7.5,
-            },
-        },
-    }
-
-
-def _write_fake_reconstructor(
-    executable: Path,
-    *,
-    event_count: int = 3,
-    exit_code: int = 0,
-    write_summary: bool = True,
-) -> None:
-    """Write a fake reconstructor that creates the event file and summary JSON."""
-    summary_literal = json.dumps(_summary_dict(event_count=event_count))
-    script = textwrap.dedent(
-        f"""\
-        #!{sys.executable}
-        import json
-        import sys
-        from pathlib import Path
-
-        args = sys.argv[1:]
-        values = {{}}
-        i = 0
-        while i < len(args):
-            flag = args[i]
-            if flag == "--overwrite":
-                values[flag] = True
-                i += 1
-                continue
-            values[flag] = args[i + 1]
-            i += 2
-
-        output_file = Path(values["--output"])
-        # Prove the settings file is passed and readable.
-        json.loads(Path(values["--settings"]).read_text())
-
-        write_summary = {write_summary}
-        if write_summary:
-            output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_bytes(b"")
-            logs_directory = output_file.parent.parent / "logs" / "events"
-            logs_directory.mkdir(parents=True, exist_ok=True)
-            summary_path = (
-                logs_directory
-                / (output_file.stem + "-reconstruction-summary.json")
-            )
-            summary_path.write_text({summary_literal!r})
-
-        sys.exit({exit_code})
-        """
-    )
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(executable.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
-
-
 # ---- resolve_photon_files -----------------------------------------------
 
 
@@ -270,7 +155,6 @@ def test_fresh_file_is_not_previously_reconstructed(tmp_path: Path) -> None:
 
 
 def test_summary_marks_file_previously_reconstructed(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     analysis_root = tmp_path / "analysis"
     input_file = FileReference(
         path=analysis_root / "photons" / "run_000000-chip-0-part-00000.parquet"
@@ -288,7 +172,6 @@ def test_event_parquet_without_summary_is_not_complete(tmp_path: Path) -> None:
     # An event parquet without a summary is an incomplete run; the summary is the
     # completion marker, matching the binary's zero-event behavior where only the
     # summary is produced.
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     analysis_root = tmp_path / "analysis"
     input_file = FileReference(
         path=analysis_root / "photons" / "run_000000-chip-0-part-00000.parquet"
@@ -381,361 +264,3 @@ def test_command_appends_overwrite_when_requested(tmp_path: Path) -> None:
         overwrite=True,
     )
     assert command[-1] == "--overwrite"
-
-
-# ---- execute_event_reconstruction ---------------------------------------
-
-
-def test_execute_success_returns_summary(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_reconstructor(
-        analysis.event_reconstruction.program.executable_path,
-        event_count=5,
-    )
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "photons"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    result = execute_event_reconstruction(analysis, tmp_path / "analysis", input_file)
-    assert result.status == "completed"
-    assert result.counts is not None
-    assert result.counts.event_count == 5
-
-
-def test_execute_removes_temp_settings_file(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_reconstructor(
-        analysis.event_reconstruction.program.executable_path
-    )
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "photons"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    execute_event_reconstruction(analysis, tmp_path / "analysis", input_file)
-    leftover = list(
-        Path(tempfile.gettempdir()).glob(
-            "run_000000-chip-0-part-00000-event-settings-*.json"
-        )
-    )
-    assert leftover == []
-
-
-def test_execute_raises_on_nonzero_exit(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_reconstructor(
-        analysis.event_reconstruction.program.executable_path,
-        exit_code=1,
-        write_summary=False,
-    )
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "photons"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    with pytest.raises(
-        HermesEventReconstructionExecutionError, match="exited with code"
-    ):
-        execute_event_reconstruction(analysis, tmp_path / "analysis", input_file)
-
-
-def test_execute_raises_on_missing_summary(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_reconstructor(
-        analysis.event_reconstruction.program.executable_path,
-        write_summary=False,
-    )
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "photons"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    with pytest.raises(HermesEventReconstructionOutputError):
-        execute_event_reconstruction(analysis, tmp_path / "analysis", input_file)
-
-
-# ---- status flow through run_hermes_analysis ----------------------------
-
-
-def _write_fake_unpacker(executable: Path) -> None:
-    """A minimal unpacker that writes one pixel_data file and a valid summary."""
-    script = textwrap.dedent(
-        f"""\
-        #!{sys.executable}
-        import json
-        import sys
-        from pathlib import Path
-
-        import pyarrow as pa
-        import pyarrow.parquet as pq
-
-        args = sys.argv[1:]
-        raw_file = Path(args[args.index("--input") + 1])
-        analysis_dir = Path(args[args.index("--output") + 1])
-        measurement_id = args[args.index("--measurement-id") + 1]
-        run = args[args.index("--run") + 1]
-        stem = raw_file.stem
-
-        pixel_hits = analysis_dir / "pixel_hits"
-        pixel_hits.mkdir(parents=True, exist_ok=True)
-        pixel_file = pixel_hits / (stem + "_chip_0_pixels_00000.parquet")
-        pq.write_table(
-            pa.table({{
-                "local_x": pa.array([0], pa.uint16()),
-                "local_y": pa.array([0], pa.uint16()),
-                "tot_raw": pa.array([10], pa.uint16()),
-                "timestamp_canonical": pa.array([1], pa.uint64()),
-            }}),
-            pixel_file,
-        )
-        summary = {{
-            "measurement_info": {{
-                "measurement_id": measurement_id, "run": run,
-            }},
-            "inputfile": str(raw_file),
-            "unpacking": {{
-                "bytes_read": 0, "chunks_read": 0, "packets_read": 1,
-                "pixel_data_packets": 1, "tdc_timestamps": 0,
-                "heartbeat_packets": 0, "spidr_control_packets": 0,
-                "tpx3_control_packets": 0, "unrecognized_packets": 0,
-                "tdc1_rising": 0, "tdc1_falling": 0, "tdc2_rising": 0,
-                "tdc2_falling": 0, "unknown_tdc_edges": 0,
-                "errors": [], "warnings": [],
-            }},
-            "timestamp_processing": {{
-                "heartbeat_pairs": {{"number_of_beats": 0}},
-                "time_adjustments": {{
-                    "pixel_packets": 1, "tdc_packets": 0,
-                    "control_packets": 0, "failed": 0,
-                }},
-            }},
-            "sorting": {{
-                "strategy": "in_memory", "memory_budget_bytes": 0,
-                "estimated_memory_bytes": 0, "sorting_time_seconds": 0.0,
-            }},
-            "output_parquet": {{
-                "pixel_data": {{
-                    "row_count": 1,
-                    "files": [str(pixel_file)],
-                }},
-                "tdc_timestamps": {{"row_count": 0, "files": []}},
-                "heartbeat_packets": {{"row_count": 0, "files": []}},
-                "control_packets": {{"row_count": 0, "files": []}},
-                "unrecognized_packets": {{"row_count": 0, "files": []}},
-                "errors": [],
-            }},
-            "processing_times_seconds": {{
-                "canonical_time_seconds": 2.0345e-12, "unpacking": 0,
-                "canonical_conversion": 0, "time_adjustments": 0,
-                "sorting": 0, "parquet_writing": 0, "total": 0,
-                "throughput": {{
-                    "packets_per_second": 0, "megabytes_per_second": 0,
-                }},
-            }},
-        }}
-        logs = analysis_dir / "logs" / "unpacking"
-        logs.mkdir(parents=True, exist_ok=True)
-        (logs / (stem + "_unpacker_summary.json")).write_text(
-            json.dumps(summary)
-        )
-        sys.exit(0)
-        """
-    )
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(executable.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
-
-
-def _write_fake_clusterer(executable: Path) -> None:
-    """A minimal clusterer that writes one photon file and a valid summary."""
-    summary_literal = json.dumps(
-        {
-            "schema_version": 1,
-            "reconstruction": {
-                "pixel_rows_read": 1,
-                "pixel_rows_below_min_tot": 0,
-                "components_formed": 1,
-                "photon_count": 1,
-                "rejected_component_count": 0,
-                "rejection_counts": {
-                    "below_min_cluster_size": 0,
-                    "above_max_cluster_size": 0,
-                    "below_min_cluster_tot": 0,
-                    "above_max_cluster_tot": 0,
-                    "above_max_aspect_ratio": 0,
-                    "below_min_filled_fraction": 0,
-                },
-                "quality_flag_counts": {
-                    "saturated_pixel": 0,
-                    "bridged_components": 0,
-                },
-                "warnings": [],
-                "errors": [],
-            },
-            "processing_times_seconds": {
-                "parquet_reading": 0.1,
-                "clustering_and_filtering": 0.2,
-                "parquet_writing": 0.1,
-                "total": 0.4,
-                "throughput": {
-                    "pixels_per_second": 2.5,
-                    "photons_per_second": 2.5,
-                },
-            },
-        }
-    )
-    script = textwrap.dedent(
-        f"""\
-        #!{sys.executable}
-        import json
-        import sys
-        from pathlib import Path
-
-        args = sys.argv[1:]
-        values = {{}}
-        i = 0
-        while i < len(args):
-            flag = args[i]
-            if flag == "--overwrite":
-                values[flag] = True
-                i += 1
-                continue
-            values[flag] = args[i + 1]
-            i += 2
-
-        output_file = Path(values["--output"])
-        json.loads(Path(values["--settings"]).read_text())
-
-        output_file.parent.mkdir(parents=True, exist_ok=True)
-        output_file.write_bytes(b"")
-        logs_directory = output_file.parent.parent / "logs" / "photons"
-        logs_directory.mkdir(parents=True, exist_ok=True)
-        summary_path = (
-            logs_directory / (output_file.stem + "-reconstruction-summary.json")
-        )
-        summary_path.write_text({summary_literal!r})
-        sys.exit(0)
-        """
-    )
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(executable.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
-
-
-def _manager(analysis: HermesTpx3AnalysisState, tmp_path: Path) -> StateManager:
-    return StateManager(
-        HermesRecord(
-            measurement_info=MeasurementInfo(
-                measurement_id="stage-9c",
-                run="test-run",
-            ),
-            environment=RuntimeEnvironment(
-                working_directory=tmp_path,
-                analysis_directory=tmp_path / "analysis",
-            ),
-            acquisition=None,
-            analysis=analysis,
-        ),
-        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-    )
-
-
-def test_run_hermes_analysis_completes_event_reconstruction(
-    tmp_path: Path,
-) -> None:
-    analysis = _analysis(tmp_path)
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    _write_fake_clusterer(analysis.photon_reconstruction.program.executable_path)
-    _write_fake_reconstructor(
-        analysis.event_reconstruction.program.executable_path,
-        event_count=4,
-    )
-    manager = _manager(analysis, tmp_path)
-
-    run_hermes_analysis(manager)
-
-    result_analysis = manager.get_state().analysis
-    assert result_analysis.unpacking.results[0].status == "completed"
-    assert result_analysis.photon_reconstruction.results[0].status == "completed"
-    event_results = result_analysis.event_reconstruction.results
-    assert len(event_results) == 1
-    assert event_results[0].status == "completed"
-    assert event_results[0].counts.event_count == 4
-
-
-def test_run_hermes_analysis_marks_event_reconstruction_failed(
-    tmp_path: Path,
-) -> None:
-    analysis = _analysis(tmp_path)
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    _write_fake_clusterer(analysis.photon_reconstruction.program.executable_path)
-    _write_fake_reconstructor(
-        analysis.event_reconstruction.program.executable_path,
-        exit_code=1,
-        write_summary=False,
-    )
-    manager = _manager(analysis, tmp_path)
-
-    with pytest.raises(HermesEventReconstructionExecutionError):
-        run_hermes_analysis(manager)
-
-    result_analysis = manager.get_state().analysis
-    assert result_analysis.photon_reconstruction.results[0].status == "completed"
-    event_results = result_analysis.event_reconstruction.results
-    assert event_results
-    assert event_results[0].status == "failed"
-
-
-def test_run_hermes_analysis_without_event_reconstruction_leaves_none(
-    tmp_path: Path,
-) -> None:
-    analysis = _analysis(tmp_path, with_event_reconstruction=False)
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    _write_fake_clusterer(analysis.photon_reconstruction.program.executable_path)
-    manager = _manager(analysis, tmp_path)
-
-    run_hermes_analysis(manager)
-
-    result_analysis = manager.get_state().analysis
-    assert result_analysis.photon_reconstruction.results[0].status == "completed"
-    assert result_analysis.event_reconstruction is None
-
-
-def test_run_hermes_analysis_event_only_without_unpacking(
-    tmp_path: Path,
-) -> None:
-    # Unpacking is already done: the photon file is on disk and no unpacking or
-    # photon-reconstruction stage is configured, so only events are built.
-    analysis_directory = tmp_path / "analysis"
-    photon_path = (
-        analysis_directory / "photons" / "run_000000-chip-0-part-00000.parquet"
-    )
-    photon_path.parent.mkdir(parents=True, exist_ok=True)
-    photon_path.touch()
-
-    event_exe = tmp_path / "bin/hermes-event-reconstructor"
-    event_exe.parent.mkdir(parents=True, exist_ok=True)
-    event_exe.touch()
-
-    analysis = HermesTpx3AnalysisState(
-        event_reconstruction=HermesTpx3EventReconstruction(
-            program=BinaryProgram(
-                name="event-reconstructor-cpp",
-                executable_path=event_exe,
-                version="0.1.0",
-            ),
-            settings=_settings(),
-        ),
-    )
-    _write_fake_reconstructor(event_exe, event_count=4)
-    manager = _manager(analysis, tmp_path)
-
-    unpacked_files = run_hermes_analysis(manager)
-
-    assert unpacked_files == []
-    result_analysis = manager.get_state().analysis
-    assert result_analysis.unpacking is None
-    assert result_analysis.photon_reconstruction is None
-    event_results = result_analysis.event_reconstruction.results
-    assert len(event_results) == 1
-    assert event_results[0].status == "completed"
-    assert event_results[0].counts.event_count == 4

--- a/tests/unit/hermes/runner/analysis/hermes/test_photon_reconstruction.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_photon_reconstruction.py
@@ -1,28 +1,19 @@
 from __future__ import annotations
 
-import json
-import stat
-import sys
-import tempfile
-import textwrap
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from hermes.runner.analysis.hermes.photon_reconstruction import (
-    HermesPhotonReconstructionExecutionError,
-    HermesPhotonReconstructionOutputError,
     HermesPhotonReconstructionPreflightError,
     check_previous_reconstructed_file,
     derive_output_path,
     derive_reconstruction_command,
     derive_summary_path,
-    execute_reconstruction,
     resolve_pixel_files,
     validate_program_and_algorithm,
 )
-from hermes.runner.analysis.hermes.run import run_hermes_analysis
 from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3AnalysisState,
     HermesTpx3PhotonClustering,
@@ -30,12 +21,8 @@ from hermes.state.models.analysis.hermes_tpx3_spidr import (
     HermesTpx3PhotonReconstruction,
     Tpx3Unpacking,
 )
-from hermes.state.models.environment import RuntimeEnvironment
 from hermes.state.models.measurement import MeasurementInfo
 from hermes.state.models.shared_models import BinaryProgram, FileReference
-from hermes.state.state import HermesRecord
-from hermes.state_service.shared_types import StateServiceConfig
-from hermes.state_service.state_manager import StateManager
 
 
 def _settings(**overrides: Any) -> HermesTpx3PhotonClusteringSettings:
@@ -109,117 +96,26 @@ def _analysis(
     )
 
 
-def _summary_dict(
-    *,
-    photon_count: int = 3,
-    rejected: int = 1,
-) -> dict[str, Any]:
-    return {
-        "schema_version": 1,
-        "reconstruction": {
-            "pixel_rows_read": 100,
-            "pixel_rows_below_min_tot": 0,
-            "components_formed": photon_count + rejected,
-            "photon_count": photon_count,
-            "rejected_component_count": rejected,
-            "rejection_counts": {
-                "below_min_cluster_size": rejected,
-                "above_max_cluster_size": 0,
-                "below_min_cluster_tot": 0,
-                "above_max_cluster_tot": 0,
-                "above_max_aspect_ratio": 0,
-                "below_min_filled_fraction": 0,
-            },
-            "quality_flag_counts": {
-                "saturated_pixel": 0,
-                "bridged_components": 0,
-            },
-            "warnings": [],
-            "errors": [],
-        },
-        "processing_times_seconds": {
-            "parquet_reading": 0.1,
-            "clustering_and_filtering": 0.2,
-            "parquet_writing": 0.1,
-            "total": 0.4,
-            "throughput": {
-                "pixels_per_second": 250.0,
-                "photons_per_second": 7.5,
-            },
-        },
-    }
-
-
-def _write_fake_clusterer(
-    executable: Path,
-    *,
-    photon_count: int = 3,
-    exit_code: int = 0,
-    write_summary: bool = True,
-) -> None:
-    """Write a fake clusterer that creates the photon file and sidecar summary."""
-    summary_literal = json.dumps(_summary_dict(photon_count=photon_count))
-    script = textwrap.dedent(
-        f"""\
-        #!{sys.executable}
-        import json
-        import sys
-        from pathlib import Path
-
-        args = sys.argv[1:]
-        values = {{}}
-        i = 0
-        while i < len(args):
-            flag = args[i]
-            if flag == "--overwrite":
-                values[flag] = True
-                i += 1
-                continue
-            values[flag] = args[i + 1]
-            i += 2
-
-        output_file = Path(values["--output"])
-        # Prove the settings file is passed and readable.
-        json.loads(Path(values["--settings"]).read_text())
-
-        write_summary = {write_summary}
-        if write_summary:
-            output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_bytes(b"")
-            logs_directory = output_file.parent.parent / "logs" / "photons"
-            logs_directory.mkdir(parents=True, exist_ok=True)
-            summary_path = (
-                logs_directory
-                / (output_file.stem + "-reconstruction-summary.json")
-            )
-            summary_path.write_text({summary_literal!r})
-
-        sys.exit({exit_code})
-        """
-    )
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(executable.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
+def _measurement_info() -> MeasurementInfo:
+    return MeasurementInfo(measurement_id="stage-5", run="test-run")
 
 
 # ---- skip detection -----------------------------------------------------
 
 
 def test_fresh_file_is_not_previously_reconstructed(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    analysis = _analysis(tmp_path, "run_000000_chip_0_pixels_00000.parquet")
     analysis_root = tmp_path / "analysis"
     input_file = resolve_pixel_files(analysis, analysis_root)[0]
     assert not check_previous_reconstructed_file(analysis_root, input_file)
 
 
 def test_summary_marks_file_previously_reconstructed(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     analysis_root = tmp_path / "analysis"
     input_file = FileReference(
-        path=analysis_root / "pixel_hits" / "run_000000-chip-0-part-00000.parquet"
+        path=analysis_root / "pixel_hits" / "run_000000_chip_0_pixels_00000.parquet"
     )
-    summary_path = derive_summary_path(
-        derive_output_path(analysis_root, input_file)
-    )
+    summary_path = derive_summary_path(analysis_root, input_file)
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     summary_path.touch()
 
@@ -230,10 +126,9 @@ def test_photon_parquet_without_summary_is_not_complete(tmp_path: Path) -> None:
     # A photon parquet without a summary is an incomplete run; the summary is the
     # completion marker, matching the binary's zero-photon behavior where only
     # the summary is produced.
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
     analysis_root = tmp_path / "analysis"
     input_file = FileReference(
-        path=analysis_root / "pixel_hits" / "run_000000-chip-0-part-00000.parquet"
+        path=analysis_root / "pixel_hits" / "run_000000_chip_0_pixels_00000.parquet"
     )
     output_file = derive_output_path(analysis_root, input_file)
     output_file.parent.mkdir(parents=True, exist_ok=True)
@@ -248,7 +143,7 @@ def test_photon_parquet_without_summary_is_not_complete(tmp_path: Path) -> None:
 def test_validate_rejects_dbscan(tmp_path: Path) -> None:
     analysis = _analysis(
         tmp_path,
-        "run_000000-chip-0-part-00000.parquet",
+        "run_000000_chip_0_pixels_00000.parquet",
         clustering_algorithm="dbscan",
     )
     with pytest.raises(
@@ -258,7 +153,7 @@ def test_validate_rejects_dbscan(tmp_path: Path) -> None:
 
 
 def test_validate_rejects_missing_executable(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    analysis = _analysis(tmp_path, "run_000000_chip_0_pixels_00000.parquet")
     analysis.photon_reconstruction.program.executable_path.unlink()
     with pytest.raises(
         HermesPhotonReconstructionPreflightError, match="executable does not exist"
@@ -269,7 +164,7 @@ def test_validate_rejects_missing_executable(tmp_path: Path) -> None:
 def test_resolve_requires_reconstruction_config(tmp_path: Path) -> None:
     analysis = _analysis(
         tmp_path,
-        "run_000000-chip-0-part-00000.parquet",
+        "run_000000_chip_0_pixels_00000.parquet",
         with_reconstruction=False,
     )
     with pytest.raises(
@@ -282,25 +177,30 @@ def test_resolve_requires_reconstruction_config(tmp_path: Path) -> None:
 
 
 def test_command_passes_named_flags_and_settings(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    analysis = _analysis(tmp_path, "run_000000_chip_0_pixels_00000.parquet")
     reconstruction = analysis.photon_reconstruction
+    analysis_root = tmp_path / "analysis"
     input_file = FileReference(
-        path=tmp_path / "analysis"
+        path=analysis_root
         / "pixel_hits"
-        / "run_000000-chip-0-part-00000.parquet"
+        / "run_000000_chip_0_pixels_00000.parquet"
     )
-    output_file = derive_output_path(tmp_path / "analysis", input_file)
     command = derive_reconstruction_command(
         reconstruction,
+        analysis_root,
         input_file,
-        output_file,
         tmp_path / "settings.json",
+        _measurement_info(),
     )
     assert command[1:] == [
         "--input",
         str(input_file.path),
         "--output",
-        str(output_file),
+        str(analysis_root),
+        "--measurement-id",
+        "stage-5",
+        "--run",
+        "test-run",
         "--settings",
         str(tmp_path / "settings.json"),
     ]
@@ -308,241 +208,20 @@ def test_command_passes_named_flags_and_settings(tmp_path: Path) -> None:
 
 
 def test_command_appends_overwrite_when_requested(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
+    analysis = _analysis(tmp_path, "run_000000_chip_0_pixels_00000.parquet")
     reconstruction = analysis.photon_reconstruction
+    analysis_root = tmp_path / "analysis"
     input_file = FileReference(
-        path=tmp_path / "analysis"
+        path=analysis_root
         / "pixel_hits"
-        / "run_000000-chip-0-part-00000.parquet"
+        / "run_000000_chip_0_pixels_00000.parquet"
     )
     command = derive_reconstruction_command(
         reconstruction,
+        analysis_root,
         input_file,
-        derive_output_path(tmp_path / "analysis", input_file),
         tmp_path / "settings.json",
+        _measurement_info(),
         overwrite=True,
     )
     assert command[-1] == "--overwrite"
-
-
-# ---- execute_reconstruction ---------------------------------------------
-
-
-def test_execute_success_returns_summary(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_clusterer(
-        analysis.photon_reconstruction.program.executable_path,
-        photon_count=5,
-    )
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "pixel_hits"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    result = execute_reconstruction(analysis, tmp_path / "analysis", input_file)
-    assert result.status == "completed"
-    assert result.counts is not None
-    assert result.counts.photon_count == 5
-
-
-def test_execute_removes_temp_settings_file(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_clusterer(analysis.photon_reconstruction.program.executable_path)
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "pixel_hits"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    execute_reconstruction(analysis, tmp_path / "analysis", input_file)
-    leftover = list(
-        Path(tempfile.gettempdir()).glob(
-            "run_000000-chip-0-part-00000-clustering-settings-*.json"
-        )
-    )
-    assert leftover == []
-
-
-def test_execute_raises_on_nonzero_exit(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_clusterer(
-        analysis.photon_reconstruction.program.executable_path,
-        exit_code=1,
-        write_summary=False,
-    )
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "pixel_hits"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    with pytest.raises(
-        HermesPhotonReconstructionExecutionError, match="exited with code"
-    ):
-        execute_reconstruction(analysis, tmp_path / "analysis", input_file)
-
-
-def test_execute_raises_on_missing_summary(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "run_000000-chip-0-part-00000.parquet")
-    _write_fake_clusterer(
-        analysis.photon_reconstruction.program.executable_path,
-        write_summary=False,
-    )
-    input_file = FileReference(
-        path=tmp_path / "analysis"
-        / "pixel_hits"
-        / "run_000000-chip-0-part-00000.parquet"
-    )
-    with pytest.raises(HermesPhotonReconstructionOutputError):
-        execute_reconstruction(analysis, tmp_path / "analysis", input_file)
-
-
-# ---- status flow through run_hermes_analysis ----------------------------
-
-
-def _write_fake_unpacker(executable: Path) -> None:
-    """A minimal unpacker that writes one pixel_data file and a valid summary."""
-    script = textwrap.dedent(
-        f"""\
-        #!{sys.executable}
-        import json
-        import sys
-        from pathlib import Path
-
-        import pyarrow as pa
-        import pyarrow.parquet as pq
-
-        args = sys.argv[1:]
-        raw_file = Path(args[args.index("--input") + 1])
-        analysis_dir = Path(args[args.index("--output") + 1])
-        stem = raw_file.stem
-
-        pixel_hits = analysis_dir / "pixel_hits"
-        pixel_hits.mkdir(parents=True, exist_ok=True)
-        pq.write_table(
-            pa.table({{
-                "local_x": pa.array([0], pa.uint16()),
-                "local_y": pa.array([0], pa.uint16()),
-                "tot_raw": pa.array([10], pa.uint16()),
-                "timestamp_canonical": pa.array([1], pa.uint64()),
-            }}),
-            pixel_hits / (stem + "-chip-0-part-00000.parquet"),
-        )
-        summary = {{
-            "unpacking": {{
-                "bytes_read": 0, "chunks_read": 0, "packets_read": 1,
-                "pixel_data_packets": 1, "tdc_timestamps": 0,
-                "heartbeat_packets": 0, "spidr_control_packets": 0,
-                "tpx3_control_packets": 0, "unrecognized_packets": 0,
-                "tdc1_rising": 0, "tdc1_falling": 0, "tdc2_rising": 0,
-                "tdc2_falling": 0, "unknown_tdc_edges": 0,
-                "errors": [], "warnings": [],
-            }},
-            "timestamp_processing": {{
-                "heartbeat_pairs": {{"number_of_beats": 0}},
-                "time_adjustments": {{
-                    "pixel_packets": 1, "tdc_packets": 0,
-                    "control_packets": 0, "failed": 0,
-                }},
-            }},
-            "sorting": {{
-                "strategy": "in_memory", "memory_budget_bytes": 0,
-                "estimated_memory_bytes": 0, "temporary_runs_created": 0,
-            }},
-            "parquet": {{
-                "pixel_data": {{
-                    "row_count": 1,
-                    "files": ["pixel_hits/" + stem + "-chip-0-part-00000.parquet"],
-                }},
-                "tdc_timestamps": {{"row_count": 0, "files": []}},
-                "heartbeat_packets": {{"row_count": 0, "files": []}},
-                "control_packets": {{"row_count": 0, "files": []}},
-                "unrecognized_packets": {{"row_count": 0, "files": []}},
-                "errors": [],
-            }},
-            "processing_times_seconds": {{
-                "canonical_time_seconds": 2.0345e-12, "unpacking": 0,
-                "canonical_conversion": 0, "time_adjustments": 0,
-                "sorting": 0, "parquet_writing": 0, "total": 0,
-                "throughput": {{
-                    "packets_per_second": 0, "megabytes_per_second": 0,
-                }},
-            }},
-        }}
-        logs = analysis_dir / "logs" / "unpacker"
-        logs.mkdir(parents=True, exist_ok=True)
-        (logs / (stem + "-unpacker-summary.json")).write_text(json.dumps(summary))
-        sys.exit(0)
-        """
-    )
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(executable.stat().st_mode | stat.S_IEXEC | stat.S_IRWXU)
-
-
-def _manager(analysis: HermesTpx3AnalysisState, tmp_path: Path) -> StateManager:
-    return StateManager(
-        HermesRecord(
-            measurement_info=MeasurementInfo(
-                measurement_id="stage-5",
-                run="test-run",
-            ),
-            environment=RuntimeEnvironment(
-                working_directory=tmp_path,
-                analysis_directory=tmp_path / "analysis",
-            ),
-            acquisition=None,
-            analysis=analysis,
-        ),
-        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-    )
-
-
-def test_run_hermes_analysis_completes_reconstruction(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path)
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    _write_fake_clusterer(
-        analysis.photon_reconstruction.program.executable_path,
-        photon_count=4,
-    )
-    manager = _manager(analysis, tmp_path)
-
-    run_hermes_analysis(manager)
-
-    result_analysis = manager.get_state().analysis
-    assert result_analysis.unpacking.results[0].status == "completed"
-    reconstruction_results = result_analysis.photon_reconstruction.results
-    assert len(reconstruction_results) == 1
-    assert reconstruction_results[0].status == "completed"
-    assert reconstruction_results[0].counts.photon_count == 4
-
-
-def test_run_hermes_analysis_marks_reconstruction_failed(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path)
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    _write_fake_clusterer(
-        analysis.photon_reconstruction.program.executable_path,
-        exit_code=1,
-        write_summary=False,
-    )
-    manager = _manager(analysis, tmp_path)
-
-    with pytest.raises(HermesPhotonReconstructionExecutionError):
-        run_hermes_analysis(manager)
-
-    result_analysis = manager.get_state().analysis
-    assert result_analysis.unpacking.results[0].status == "completed"
-    reconstruction_results = result_analysis.photon_reconstruction.results
-    assert reconstruction_results
-    assert reconstruction_results[0].status == "failed"
-
-
-def test_run_hermes_analysis_without_reconstruction_leaves_result_none(
-    tmp_path: Path,
-) -> None:
-    analysis = _analysis(tmp_path, with_reconstruction=False)
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    manager = _manager(analysis, tmp_path)
-
-    run_hermes_analysis(manager)
-
-    result_analysis = manager.get_state().analysis
-    assert result_analysis.unpacking.results[0].status == "completed"
-    assert result_analysis.photon_reconstruction is None

--- a/tests/unit/hermes/runner/analysis/hermes/test_unpacker.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_unpacker.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-import textwrap
 from pathlib import Path
 from typing import Any
 
@@ -12,8 +10,6 @@ from loguru import logger
 
 from hermes.runner.analysis.hermes.run import HermesAnalysisError, run_hermes_analysis
 from hermes.runner.analysis.hermes.unpacker import (
-    HermesTpx3ExecutionError,
-    HermesTpx3OutputError,
     HermesTpx3PreflightError,
     check_previous_unpacked_file,
     derive_summary_path,
@@ -31,15 +27,8 @@ from hermes.state.models.measurement import MeasurementInfo
 from hermes.state.models.shared_models import BinaryProgram, FileReference
 from hermes.state.state import HermesRecord
 from hermes.state_service.change_requests import ChangeRequest
-from hermes.state_service.shared_types import (
-    ChangeApprovalError,
-    StateServiceConfig,
-)
+from hermes.state_service.shared_types import StateServiceConfig
 from hermes.state_service.state_manager import StateManager
-from hermes.state_service.state_io import (
-    load_hermes_record_from_yaml,
-    save_hermes_record_to_yaml,
-)
 
 
 class CapturingStateLogger:
@@ -66,6 +55,10 @@ class CapturingStateLogger:
 
 def _analysis_root(tmp_path: Path) -> Path:
     return tmp_path / "analysis"
+
+
+def _measurement_info() -> MeasurementInfo:
+    return MeasurementInfo(measurement_id="stage-3", run="test-run")
 
 
 def _analysis(tmp_path: Path, *raw_names: str) -> HermesTpx3AnalysisState:
@@ -110,14 +103,32 @@ def _record(
     )
 
 
-def _summary(raw_stem: str, *, pixel_rows: int = 0) -> Tpx3SpidrSummary:
+def _summary(
+    analysis_root: Path,
+    raw_stem: str,
+    *,
+    pixel_rows: int = 0,
+) -> Tpx3SpidrSummary:
+    # The binary writes each Parquet path as the analysis directory it was given
+    # joined with the category subdirectory and filename.
     pixel_files = (
-        [f"pixel_hits/{raw_stem}-chip-0-part-00000.parquet"]
+        [
+            str(
+                analysis_root
+                / "pixel_hits"
+                / f"{raw_stem}_chip_0_pixels_00000.parquet"
+            )
+        ]
         if pixel_rows
         else []
     )
     return Tpx3SpidrSummary.model_validate(
         {
+            "measurement_info": {
+                "measurement_id": "stage-3",
+                "run": "test-run",
+            },
+            "inputfile": f"rawTpx3/{raw_stem}.tpx3",
             "unpacking": {
                 "bytes_read": 0,
                 "chunks_read": 0,
@@ -151,9 +162,9 @@ def _summary(raw_stem: str, *, pixel_rows: int = 0) -> Tpx3SpidrSummary:
                 "strategy": "in_memory",
                 "memory_budget_bytes": 0,
                 "estimated_memory_bytes": 0,
-                "temporary_runs_created": 0,
+                "sorting_time_seconds": 0.0,
             },
-            "parquet": {
+            "output_parquet": {
                 "pixel_data": {
                     "row_count": pixel_rows,
                     "files": pixel_files,
@@ -187,9 +198,8 @@ def _save_completed_files(
     *,
     pixel_rows: int = 0,
 ) -> None:
-    summary = _summary(raw_file.path.stem, pixel_rows=pixel_rows)
-    for relative_path in summary.parquet.pixel_data.files:
-        parquet_path = analysis_root / relative_path
+    summary = _summary(analysis_root, raw_file.path.stem, pixel_rows=pixel_rows)
+    for parquet_path in summary.output_parquet.pixel_data.files:
         parquet_path.parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(pa.table({"value": [1]}), parquet_path)
     summary_path = derive_summary_path(analysis_root, raw_file)
@@ -197,156 +207,26 @@ def _save_completed_files(
     summary_path.write_text(summary.model_dump_json(), encoding="utf-8")
 
 
-def _write_fake_unpacker(executable: Path) -> None:
-    script = textwrap.dedent(
-        f"""\
-        #!{sys.executable}
-        import json
-        import sys
-        from pathlib import Path
-
-        import pyarrow as pa
-        import pyarrow.parquet as pq
-
-        args = sys.argv[1:]
-        raw_file = Path(args[args.index("--input") + 1])
-        analysis_directory = Path(args[args.index("--output") + 1])
-        raw_stem = raw_file.stem
-        mode = raw_file.read_text(encoding="utf-8").strip() or "success"
-
-        print("o" * 5000)
-        print("e" * 5000, file=sys.stderr)
-        if mode == "nonzero":
-            raise SystemExit(7)
-
-        summary_path = (
-            analysis_directory
-            / "logs"
-            / "unpacker"
-            / f"{{raw_stem}}-unpacker-summary.json"
-        )
-        summary_path.parent.mkdir(parents=True, exist_ok=True)
-        if mode == "missing_summary":
-            raise SystemExit(0)
-        if mode == "invalid_summary":
-            summary_path.write_text("not JSON", encoding="utf-8")
-            raise SystemExit(0)
-
-        if mode == "unsafe_path":
-            relative_parquet = Path("../outside.parquet")
-        elif mode == "bad_prefix":
-            relative_parquet = Path("pixel_hits/other-chip-0-part-00000.parquet")
-        elif mode == "bad_part":
-            relative_parquet = Path(
-                f"pixel_hits/{{raw_stem}}-chip-0-part-00001.parquet"
-            )
-        else:
-            relative_parquet = Path(
-                f"pixel_hits/{{raw_stem}}-chip-0-part-00000.parquet"
-            )
-
-        parquet_path = analysis_directory / relative_parquet
-        if mode not in {{"missing_parquet", "unsafe_path"}}:
-            parquet_path.parent.mkdir(parents=True, exist_ok=True)
-            pq.write_table(pa.table({{"value": [1]}}), parquet_path)
-
-        if mode == "unexpected_parquet":
-            unexpected = (
-                analysis_directory
-                / "pixel_hits"
-                / f"{{raw_stem}}-chip-0-part-00001.parquet"
-            )
-            pq.write_table(pa.table({{"value": [2]}}), unexpected)
-
-        row_count = 2 if mode == "row_mismatch" else 1
-        summary = {{
-            "unpacking": {{
-                "bytes_read": 16,
-                "chunks_read": 1,
-                "packets_read": 1,
-                "pixel_data_packets": 1,
-                "tdc_timestamps": 0,
-                "heartbeat_packets": 0,
-                "spidr_control_packets": 0,
-                "tpx3_control_packets": 0,
-                "unrecognized_packets": 0,
-                "tdc1_rising": 0,
-                "tdc1_falling": 0,
-                "tdc2_rising": 0,
-                "tdc2_falling": 0,
-                "unknown_tdc_edges": 0,
-                "errors": (
-                    ["test unpacking error"]
-                    if mode == "unpacking_errors"
-                    else []
-                ),
-                "warnings": ["test warning"],
-            }},
-            "timestamp_processing": {{
-                "heartbeat_pairs": {{
-                    "number_of_beats": 0,
-                }},
-                "time_adjustments": {{
-                    "pixel_packets": 1,
-                    "tdc_packets": 0,
-                    "control_packets": 0,
-                    "failed": 0,
-                }},
-            }},
-            "sorting": {{
-                "strategy": "in_memory",
-                "memory_budget_bytes": 1000,
-                "estimated_memory_bytes": 100,
-                "temporary_runs_created": 0,
-            }},
-            "parquet": {{
-                "pixel_data": {{
-                    "row_count": row_count,
-                    "files": [str(relative_parquet)],
-                }},
-                "tdc_timestamps": {{"row_count": 0, "files": []}},
-                "heartbeat_packets": {{"row_count": 0, "files": []}},
-                "control_packets": {{"row_count": 0, "files": []}},
-                "unrecognized_packets": {{"row_count": 0, "files": []}},
-                "errors": (
-                    ["test Parquet error"] if mode == "summary_errors" else []
-                ),
-            }},
-            "processing_times_seconds": {{
-                "canonical_time_seconds": 2.0345e-12,
-                "unpacking": 0.1,
-                "canonical_conversion": 0.1,
-                "time_adjustments": 0.1,
-                "sorting": 0.1,
-                "parquet_writing": 0.1,
-                "total": 0.5,
-                "throughput": {{
-                    "packets_per_second": 2.0,
-                    "megabytes_per_second": 0.000032,
-                }},
-            }},
-        }}
-        summary_path.write_text(json.dumps(summary), encoding="utf-8")
-        """
-    )
-    executable.write_text(script, encoding="utf-8")
-    executable.chmod(0o755)
-
-
 def test_derives_command_and_input_specific_summary_path(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "first.tpx3")
     analysis_root = _analysis_root(tmp_path)
     raw_file = analysis.unpacking.tpx3_files[0]
 
-    assert derive_unpacker_command(analysis, analysis_root, raw_file) == [
+    assert derive_unpacker_command(
+        analysis, analysis_root, raw_file, _measurement_info()
+    ) == [
         str(analysis.unpacking.program.executable_path),
         "--input",
         str(raw_file.path),
         "--output",
         str(analysis_root),
+        "--measurement-id",
+        "stage-3",
+        "--run",
+        "test-run",
     ]
     assert derive_summary_path(analysis_root, raw_file) == (
-        analysis_root / "logs/unpacker/first-unpacker-summary.json"
+        analysis_root / "logs/unpacking/first_unpacker_summary.json"
     )
 
 
@@ -358,12 +238,18 @@ def test_command_includes_time_sort_false_when_time_sort_disabled(
     analysis.unpacking.runtime_options.time_sort = False
     raw_file = analysis.unpacking.tpx3_files[0]
 
-    assert derive_unpacker_command(analysis, analysis_root, raw_file) == [
+    assert derive_unpacker_command(
+        analysis, analysis_root, raw_file, _measurement_info()
+    ) == [
         str(analysis.unpacking.program.executable_path),
         "--input",
         str(raw_file.path),
         "--output",
         str(analysis_root),
+        "--measurement-id",
+        "stage-3",
+        "--run",
+        "test-run",
         "--time-sort",
         "false",
     ]
@@ -432,8 +318,8 @@ def test_run_marks_analysis_only_state_running_through_state_manager(
     )
     monkeypatch.setattr(
         "hermes.runner.analysis.hermes.run.execute_unpacker",
-        lambda analysis, analysis_root, raw_file, **kwargs: _summary(
-            raw_file.path.stem
+        lambda analysis, analysis_root, raw_file, measurement_info, **kwargs: (
+            _summary(analysis_root, raw_file.path.stem)
         ),
     )
 
@@ -523,195 +409,6 @@ def test_run_rejects_missing_analysis(tmp_path: Path) -> None:
     assert invalid_mode["extra"]["actual_analysis_mode"] is None
 
 
-def test_disabled_bypass_leaves_results_change_pending(
-    tmp_path: Path,
-) -> None:
-    analysis = _analysis(tmp_path, "first.tpx3")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    analysis.unpacking.tpx3_files[0].path.write_text("success", encoding="utf-8")
-    state_logger = CapturingStateLogger()
-    manager = StateManager(
-        _record(tmp_path, analysis),
-        state_logger=state_logger,
-    )
-
-    with pytest.raises(ChangeApprovalError, match="requires approval"):
-        run_hermes_analysis(manager)
-
-    assert manager.get_state().analysis.unpacking.results == []
-    pending = manager.list_pending_changes()
-    assert len(pending) == 1
-    assert pending[0].path == "analysis.unpacking.results"
-    assert pending[0].origin == "trusted_workflow"
-    assert pending[0].proposer == "tpx3_spidr_unpacking"
-
-
-def test_run_executes_fake_unpacker_logs_details_and_round_trips_yaml(
-    tmp_path: Path,
-) -> None:
-    analysis = _analysis(tmp_path, "success.tpx3")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    state_logger = CapturingStateLogger()
-    manager = StateManager(
-        _record(tmp_path, analysis),
-        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-        state_logger=state_logger,
-    )
-    records: list[dict[str, Any]] = []
-    sink_id = logger.add(
-        lambda message: records.append(message.record),
-        filter=lambda record: record["extra"].get("domain") == "analysis",
-    )
-    try:
-        files_run = run_hermes_analysis(manager)
-    finally:
-        logger.remove(sink_id)
-
-    assert files_run == analysis.unpacking.tpx3_files
-    results = manager.get_state().analysis.unpacking.results
-    assert len(results) == 1
-    assert results[0].status == "completed"
-
-    started = next(
-        record
-        for record in records
-        if record["extra"].get("event_type")
-        == "analysis.tpx3_unpacking.started"
-    )
-    assert started["extra"]["command"] == derive_unpacker_command(
-        analysis,
-        _analysis_root(tmp_path),
-        analysis.unpacking.tpx3_files[0],
-    )
-    completed = next(
-        record
-        for record in records
-        if record["extra"].get("summary") is not None
-    )
-    assert completed["extra"]["exit_code"] == 0
-    assert len(completed["extra"]["stdout_excerpt"]) == 4_000
-    assert len(completed["extra"]["stderr_excerpt"]) == 4_000
-    assert completed["extra"]["summary"]["unpacking"]["pixel_data_packets"] == 1
-    assert completed["extra"]["summary"]["sorting"]["strategy"] == "in_memory"
-    assert completed["extra"]["summary"]["parquet"]["pixel_data"][
-        "row_count"
-    ] == 1
-
-    record_path = tmp_path / "hermes-record.yaml"
-    save_hermes_record_to_yaml(manager.get_state(), record_path)
-    loaded = load_hermes_record_from_yaml(record_path)
-    assert loaded == manager.get_state()
-
-
-def test_run_processes_multiple_inputs_and_then_skips_them(
-    tmp_path: Path,
-) -> None:
-    analysis = _analysis(tmp_path, "first.tpx3", "second.tpx3")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    manager = StateManager(
-        _record(tmp_path, analysis),
-        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-        state_logger=CapturingStateLogger(),
-    )
-
-    analysis_root = _analysis_root(tmp_path)
-    assert run_hermes_analysis(manager) == analysis.unpacking.tpx3_files
-    for raw_file in analysis.unpacking.tpx3_files:
-        assert (
-            analysis_root
-            / "pixel_hits"
-            / f"{raw_file.path.stem}-chip-0-part-00000.parquet"
-        ).is_file()
-
-    records: list[dict[str, Any]] = []
-    sink_id = logger.add(
-        lambda message: records.append(message.record),
-        filter=lambda record: record["extra"].get("domain") == "analysis",
-    )
-    try:
-        assert run_hermes_analysis(manager) == []
-    finally:
-        logger.remove(sink_id)
-
-    skipped = [
-        record
-        for record in records
-        if record["extra"].get("event_type")
-        == "analysis.tpx3_unpacking.skipped"
-    ]
-    assert [Path(record["extra"]["raw_tpx3_file"]).name for record in skipped] == [
-        "first.tpx3",
-        "second.tpx3",
-    ]
-
-
-@pytest.mark.parametrize(
-    ("mode", "expected_exception", "message"),
-    [
-        ("nonzero", HermesTpx3ExecutionError, "code 7"),
-        ("missing_summary", HermesTpx3PreflightError, "summary path"),
-        ("invalid_summary", HermesTpx3PreflightError, "invalid summary"),
-        ("summary_errors", HermesTpx3OutputError, "reports"),
-        ("unpacking_errors", HermesTpx3OutputError, "reports"),
-        ("unsafe_path", HermesTpx3PreflightError, "invalid summary"),
-        ("missing_parquet", HermesTpx3OutputError, "missing Parquet"),
-        ("bad_prefix", HermesTpx3OutputError, "unexpected Parquet filename"),
-        ("bad_part", HermesTpx3OutputError, "part numbers"),
-        ("unexpected_parquet", HermesTpx3OutputError, "does not match"),
-        ("row_mismatch", HermesTpx3OutputError, "row count mismatch"),
-    ],
-)
-def test_run_saves_failed_state_before_raising_for_output_failures(
-    tmp_path: Path,
-    mode: str,
-    expected_exception: type[Exception],
-    message: str,
-) -> None:
-    analysis = _analysis(tmp_path, f"{mode}.tpx3")
-    analysis.unpacking.tpx3_files[0].path.write_text(mode, encoding="utf-8")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    manager = StateManager(
-        _record(tmp_path, analysis),
-        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-        state_logger=CapturingStateLogger(),
-    )
-
-    records: list[dict[str, Any]] = []
-    sink_id = logger.add(
-        lambda log_message: records.append(log_message.record),
-        filter=lambda record: record["extra"].get("domain") == "analysis",
-    )
-    try:
-        with pytest.raises(expected_exception, match=message):
-            run_hermes_analysis(manager)
-    finally:
-        logger.remove(sink_id)
-
-    results = manager.get_state().analysis.unpacking.results
-    assert results
-    assert all(result.status == "failed" for result in results)
-    failures = [
-        record
-        for record in records
-        if record["extra"].get("event_type")
-        == "analysis.tpx3_unpacking.failed"
-    ]
-    assert failures
-    if mode == "nonzero":
-        process_failure = next(
-            record for record in failures if record["extra"].get("exit_code") == 7
-        )
-        assert len(process_failure["extra"]["stdout_excerpt"]) == 4_000
-        assert len(process_failure["extra"]["stderr_excerpt"]) == 4_000
-    if mode == "summary_errors":
-        summary_failure = next(
-            record for record in failures if record["extra"].get("summary")
-        )
-        assert summary_failure["extra"]["summary"]["parquet"]["errors"] == [
-            "test Parquet error"
-        ]
-
-
 def test_resource_limit_percent_field_defaults_to_90(tmp_path: Path) -> None:
     analysis = _analysis(tmp_path, "file.tpx3")
     assert analysis.resource_limit_percent == 90
@@ -757,165 +454,3 @@ def test_resource_limit_percent_rejects_zero_and_above_100(tmp_path: Path) -> No
                     tpx3_files=[FileReference(path=raw_file)],
                 ),
             )
-
-
-def test_parallel_unpacking_returns_files_in_input_order(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "c.tpx3", "a.tpx3", "b.tpx3")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    for raw_file in analysis.unpacking.tpx3_files:
-        raw_file.path.write_text("success", encoding="utf-8")
-
-    records: list[dict[str, Any]] = []
-    sink_id = logger.add(lambda msg: records.append(msg.record))
-
-    try:
-        manager = StateManager(
-            _record(tmp_path, analysis),
-            config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-            state_logger=CapturingStateLogger(),
-        )
-        unpacked_files = run_hermes_analysis(manager)
-    finally:
-        logger.remove(sink_id)
-
-    assert len(unpacked_files) == 3
-    assert unpacked_files[0].path.name == "c.tpx3"
-    assert unpacked_files[1].path.name == "a.tpx3"
-    assert unpacked_files[2].path.name == "b.tpx3"
-
-
-def test_parallel_unpacking_logs_resource_calculation(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "a.tpx3", "b.tpx3")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    for raw_file in analysis.unpacking.tpx3_files:
-        raw_file.path.write_text("success", encoding="utf-8")
-
-    records: list[dict[str, Any]] = []
-    sink_id = logger.add(lambda msg: records.append(msg.record))
-
-    try:
-        manager = StateManager(
-            _record(tmp_path, analysis),
-            config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-            state_logger=CapturingStateLogger(),
-        )
-        run_hermes_analysis(manager)
-    finally:
-        logger.remove(sink_id)
-
-    resource_records = [
-        r
-        for r in records
-        if r["extra"].get("event_type")
-        == "analysis.tpx3_unpacking.resource_calculation"
-    ]
-    assert len(resource_records) == 1
-    resource_record = resource_records[0]
-    assert resource_record["extra"]["resource_limit_percent"] == 90
-    assert resource_record["extra"]["pending_file_count"] == 2
-    assert resource_record["extra"]["worker_count"] >= 1
-    assert "physical_cpu_count" in resource_record["extra"]
-    assert "cpu_slots" in resource_record["extra"]
-    assert "memory_slots" in resource_record["extra"]
-
-
-def test_parallel_unpacking_one_failure_stops_remaining_work(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "a.tpx3", "failing.tpx3", "c.tpx3", "d.tpx3")
-    analysis.resource_limit_percent = 1
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    analysis.unpacking.tpx3_files[0].path.write_text("success", encoding="utf-8")
-    analysis.unpacking.tpx3_files[1].path.write_text("nonzero", encoding="utf-8")
-    analysis.unpacking.tpx3_files[2].path.write_text("success", encoding="utf-8")
-    analysis.unpacking.tpx3_files[3].path.write_text("success", encoding="utf-8")
-
-    manager = StateManager(
-        _record(tmp_path, analysis),
-        config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-        state_logger=CapturingStateLogger(),
-    )
-
-    with pytest.raises(HermesTpx3ExecutionError, match="exited with code 7"):
-        run_hermes_analysis(manager)
-
-    results = manager.get_state().analysis.unpacking.results
-    assert results
-    assert all(result.status == "failed" for result in results)
-
-    summary_files = list(
-        (_analysis_root(tmp_path) / "logs" / "unpacker").glob("*.json")
-    )
-    completed_count = len(summary_files)
-    assert completed_count < 4
-
-
-def test_parallel_unpacking_skips_valid_files(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "skip-me.tpx3", "run-me.tpx3")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-    _save_completed_files(
-        _analysis_root(tmp_path), analysis.unpacking.tpx3_files[0], pixel_rows=1
-    )
-    analysis.unpacking.tpx3_files[1].path.write_text("success", encoding="utf-8")
-
-    records: list[dict[str, Any]] = []
-    sink_id = logger.add(lambda msg: records.append(msg.record))
-
-    try:
-        manager = StateManager(
-            _record(tmp_path, analysis),
-            config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-            state_logger=CapturingStateLogger(),
-        )
-        unpacked_files = run_hermes_analysis(manager)
-    finally:
-        logger.remove(sink_id)
-
-    assert len(unpacked_files) == 1
-    assert unpacked_files[0].path.name == "run-me.tpx3"
-
-    skipped_records = [
-        r
-        for r in records
-        if r["extra"].get("event_type") == "analysis.tpx3_unpacking.skipped"
-    ]
-    assert len(skipped_records) == 1
-    assert "skip-me" in skipped_records[0]["extra"]["raw_tpx3_file"]
-
-
-def test_resource_calculation_uses_only_pending_files(tmp_path: Path) -> None:
-    analysis = _analysis(tmp_path, "large-skip.tpx3", "small-run.tpx3")
-    _write_fake_unpacker(analysis.unpacking.program.executable_path)
-
-    # Make the first file large but already completed (will be skipped)
-    analysis.unpacking.tpx3_files[0].path.write_bytes(b"x" * (100 * 1024 * 1024))
-    _save_completed_files(
-        _analysis_root(tmp_path), analysis.unpacking.tpx3_files[0], pixel_rows=1
-    )
-
-    # Make the second file small (will be run)
-    analysis.unpacking.tpx3_files[1].path.write_text("success", encoding="utf-8")
-
-    records: list[dict[str, Any]] = []
-    sink_id = logger.add(lambda msg: records.append(msg.record))
-
-    try:
-        manager = StateManager(
-            _record(tmp_path, analysis),
-            config=StateServiceConfig(allow_trusted_workflow_bypass=True),
-            state_logger=CapturingStateLogger(),
-        )
-        run_hermes_analysis(manager)
-    finally:
-        logger.remove(sink_id)
-
-    resource_records = [
-        r
-        for r in records
-        if r["extra"].get("event_type")
-        == "analysis.tpx3_unpacking.resource_calculation"
-    ]
-    assert len(resource_records) == 1
-    resource_record = resource_records[0]
-
-    # The resource calculation should be based on the small file, not the large skipped one
-    assert resource_record["extra"]["pending_file_count"] == 1
-    assert resource_record["extra"]["largest_pending_file_mb"] < 1.0

--- a/tests/unit/hermes/runner/analysis/hermes/test_unpacker_integration.py
+++ b/tests/unit/hermes/runner/analysis/hermes/test_unpacker_integration.py
@@ -43,6 +43,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
 
     raw_directory = tmp_path / "rawTpx3"
     raw_directory.mkdir()
+    analysis_root = tmp_path / "analysis"
     raw_paths = [
         raw_directory / "example-first.tpx3",
         raw_directory / "example-second.tpx3",
@@ -68,7 +69,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
             ),
             environment=RuntimeEnvironment(
                 working_directory=tmp_path,
-                analysis_directory=tmp_path / "analysis",
+                analysis_directory=analysis_root,
             ),
             acquisition=None,
             analysis=analysis,
@@ -96,40 +97,35 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     summaries: list[Tpx3SpidrSummary] = []
     generated_paths: set[Path] = set()
     for raw_file in analysis.unpacking.tpx3_files:
-        summary_path = derive_summary_path(
-            analysis.unpacking.output_directory, raw_file
-        )
+        summary_path = derive_summary_path(analysis_root, raw_file)
         assert summary_path.is_file()
         summary = Tpx3SpidrSummary.model_validate_json(summary_path.read_bytes())
         summaries.append(summary)
 
         listed_paths = {
-            relative_path
+            parquet_path
             for category in (
-                summary.parquet.pixel_data,
-                summary.parquet.tdc_timestamps,
-                summary.parquet.heartbeat_packets,
-                summary.parquet.control_packets,
-                summary.parquet.unrecognized_packets,
+                summary.output_parquet.pixel_data,
+                summary.output_parquet.tdc_timestamps,
+                summary.output_parquet.heartbeat_packets,
+                summary.output_parquet.control_packets,
+                summary.output_parquet.unrecognized_packets,
             )
-            for relative_path in category.files
+            for parquet_path in category.files
         }
         assert listed_paths
         assert all(
-            relative_path.name.startswith(f"{raw_file.path.stem}-")
-            for relative_path in listed_paths
+            parquet_path.name.startswith(f"{raw_file.path.stem}_")
+            for parquet_path in listed_paths
         )
         assert generated_paths.isdisjoint(listed_paths)
         generated_paths.update(listed_paths)
-        assert all(
-            (analysis.unpacking.output_directory / relative_path).is_file()
-            for relative_path in listed_paths
-        )
+        assert all(parquet_path.is_file() for parquet_path in listed_paths)
 
     assert all(not summary.unpacking.errors for summary in summaries)
-    assert all(not summary.parquet.errors for summary in summaries)
+    assert all(not summary.output_parquet.errors for summary in summaries)
     assert sum(
-        summary.parquet.pixel_data.row_count for summary in summaries
+        summary.output_parquet.pixel_data.row_count for summary in summaries
     ) > 0
 
     saved_analysis = completed_state.analysis.model_dump(mode="json")
@@ -144,7 +140,6 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     assert set(saved_analysis["unpacking"]) == {
         "program",
         "tpx3_files",
-        "output_directory",
         "runtime_options",
         "results",
     }
@@ -157,7 +152,7 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
         saved_analysis,
         {
             "summary_json_file",
-            "parquet",
+            "output_parquet",
             "warnings",
             "errors",
             "exit_code",
@@ -177,12 +172,9 @@ def test_real_cpp_unpacker_handles_two_inputs_and_skips_completed_files(
     ]
 
     saved_files = [
-        derive_summary_path(analysis.unpacking.output_directory, raw_file)
+        derive_summary_path(analysis_root, raw_file)
         for raw_file in analysis.unpacking.tpx3_files
-    ] + [
-        analysis.unpacking.output_directory / relative_path
-        for relative_path in generated_paths
-    ]
+    ] + list(generated_paths)
     modification_times = {
         path: path.stat().st_mtime_ns
         for path in saved_files

--- a/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
+++ b/tests/unit/hermes/state/models/test_hermes_tpx3_spidr.py
@@ -48,6 +48,11 @@ def _analysis_state(tmp_path: Path, *raw_names: str) -> HermesTpx3AnalysisState:
 
 def _summary_data() -> dict[str, object]:
     return {
+        "measurement_info": {
+            "measurement_id": "harness-unit",
+            "run": "raw",
+        },
+        "inputfile": "tests/data/tpx3/raw.tpx3",
         "unpacking": {
             "bytes_read": 24,
             "chunks_read": 2,
@@ -81,13 +86,13 @@ def _summary_data() -> dict[str, object]:
             "strategy": "in_memory",
             "memory_budget_bytes": 1_000_000,
             "estimated_memory_bytes": 128,
-            "temporary_runs_created": 0,
+            "sorting_time_seconds": 0.0,
         },
-        "parquet": {
+        "output_parquet": {
             "pixel_data": {
                 "row_count": 1,
                 "files": [
-                    "pixel_hits/raw-chip-0-part-00000.parquet",
+                    "analysis/pixel_hits/raw_chip_0_pixels_00000.parquet",
                 ],
             },
             "tdc_timestamps": {"row_count": 0, "files": []},
@@ -127,17 +132,18 @@ def _clustering_settings_data() -> dict[str, object]:
 
 def _photon_summary_data() -> dict[str, object]:
     return {
-        "schema_version": 1,
+        "measurement_info": {
+            "measurement_id": "harness-unit",
+            "run": "raw",
+        },
         "reconstruction": {
-            "pixel_rows_read": 12,
-            "pixel_rows_below_min_tot": 1,
-            "components_formed": 3,
-            "photon_count": 2,
-            "rejected_component_count": 1,
-            "rejection_counts": {
+            "pixels_read": 12,
+            "clusters_formed": 3,
+            "rejected_clusters": 1,
+            "rejection_reasons": {
                 "below_min_cluster_size": 1,
                 "above_max_cluster_size": 0,
-                "below_min_cluster_tot": 1,
+                "below_min_cluster_tot": 0,
                 "above_max_cluster_tot": 0,
                 "above_max_aspect_ratio": 0,
                 "below_min_filled_fraction": 0,
@@ -148,6 +154,48 @@ def _photon_summary_data() -> dict[str, object]:
             },
             "warnings": [],
             "errors": [],
+            "total_photons": 2,
+        },
+        "clustering": {
+            "algorithm": "connected_components",
+            "settings": {
+                "max_time_spread_ticks": 491_520,
+                "min_cluster_size": 2,
+                "max_cluster_size": 64,
+                "min_pixel_tot_raw": 1,
+                "min_cluster_tot_raw": 2,
+                "max_cluster_tot_raw": 65_472,
+                "max_aspect_ratio": 3.0,
+                "min_filled_fraction": 0.5,
+                "adjacency": 8,
+                "position_averaging": "arithmetic",
+                "photon_time_estimator": "leading_edge",
+                "timewalk_calibration_file": None,
+                "save_photon_pixels": False,
+            },
+        },
+        "photon_timing": {
+            "estimator": "leading_edge",
+            "correction_model": "none",
+            "calibration_file": None,
+            "parameters": {},
+            "high_tot_anchor": None,
+        },
+        "parquet_files": {
+            "input_pixel_data_file": [
+                "analysis/pixel_hits/raw_chip_0_pixels_00000.parquet",
+            ],
+            "photons": {
+                "row_count": 2,
+                "files": [
+                    "analysis/photons/raw_photon_00000.parquet",
+                ],
+            },
+            "pixel_clusters": {
+                "requested": False,
+                "row_count": 0,
+                "files": [],
+            },
         },
         "processing_times_seconds": {
             "parquet_reading": 0.1,
@@ -420,12 +468,16 @@ def test_hermes_analysis_state_accepts_photon_reconstruction(
 def test_summary_validates_every_section() -> None:
     summary = Tpx3SpidrSummary.model_validate(_summary_data())
 
+    assert summary.measurement_info.measurement_id == "harness-unit"
+    assert summary.measurement_info.run == "raw"
+    assert summary.inputfile == Path("tests/data/tpx3/raw.tpx3")
     assert summary.unpacking.pixel_data_packets == 1
     assert summary.timestamp_processing.time_adjustments.pixel_packets == 1
     assert summary.sorting.strategy == "in_memory"
-    assert summary.parquet.pixel_data.row_count == 1
-    assert summary.parquet.pixel_data.files == [
-        Path("pixel_hits/raw-chip-0-part-00000.parquet")
+    assert summary.sorting.sorting_time_seconds == 0.0
+    assert summary.output_parquet.pixel_data.row_count == 1
+    assert summary.output_parquet.pixel_data.files == [
+        Path("analysis/pixel_hits/raw_chip_0_pixels_00000.parquet")
     ]
     assert summary.processing_times_seconds.canonical_time_seconds == 2.0345e-12
     assert (
@@ -467,16 +519,16 @@ def test_summary_rejects_unknown_and_removed_fields() -> None:
 @pytest.mark.parametrize(
     "file_path",
     [
-        "/absolute/raw-chip-0-part-00000.parquet",
-        "../pixel_hits/raw-chip-0-part-00000.parquet",
-        "tdc_triggers/raw-chip-0-part-00000.parquet",
+        "/absolute/raw_chip_0_pixels_00000.parquet",
+        "../pixel_hits/raw_chip_0_pixels_00000.parquet",
+        "tdc_triggers/raw_chip_0_pixels_00000.parquet",
     ],
 )
 def test_summary_rejects_invalid_pixel_parquet_paths(file_path: str) -> None:
     summary_data = _summary_data()
-    parquet = summary_data["parquet"]
-    assert isinstance(parquet, dict)
-    pixel_data = parquet["pixel_data"]
+    output_parquet = summary_data["output_parquet"]
+    assert isinstance(output_parquet, dict)
+    pixel_data = output_parquet["pixel_data"]
     assert isinstance(pixel_data, dict)
     pixel_data["files"] = [file_path]
 
@@ -487,7 +539,7 @@ def test_summary_rejects_invalid_pixel_parquet_paths(file_path: str) -> None:
 @pytest.mark.parametrize(
     ("row_count", "files"),
     [
-        (0, ["pixel_hits/raw-chip-0-part-00000.parquet"]),
+        (0, ["analysis/pixel_hits/raw_chip_0_pixels_00000.parquet"]),
         (1, []),
     ],
 )
@@ -496,9 +548,9 @@ def test_summary_requires_parquet_files_to_match_saved_rows(
     files: list[str],
 ) -> None:
     summary_data = _summary_data()
-    parquet = summary_data["parquet"]
-    assert isinstance(parquet, dict)
-    pixel_data = parquet["pixel_data"]
+    output_parquet = summary_data["output_parquet"]
+    assert isinstance(output_parquet, dict)
+    pixel_data = output_parquet["pixel_data"]
     assert isinstance(pixel_data, dict)
     pixel_data["row_count"] = row_count
     pixel_data["files"] = files
@@ -512,11 +564,16 @@ def test_photon_reconstruction_summary_validates_every_section() -> None:
         _photon_summary_data()
     )
 
-    assert summary.schema_version == 1
-    assert summary.reconstruction.photon_count == 2
-    assert summary.reconstruction.components_formed == 3
-    assert summary.reconstruction.rejection_counts.below_min_cluster_size == 1
+    assert summary.measurement_info.measurement_id == "harness-unit"
+    assert summary.reconstruction.total_photons == 2
+    assert summary.reconstruction.clusters_formed == 3
+    assert summary.reconstruction.rejected_clusters == 1
+    assert summary.reconstruction.rejection_reasons.below_min_cluster_size == 1
     assert summary.reconstruction.quality_flag_counts.saturated_pixel == 1
+    assert summary.clustering.algorithm == "connected_components"
+    assert summary.clustering.settings["save_photon_pixels"] is False
+    assert summary.photon_timing.correction_model == "none"
+    assert summary.parquet_files.pixel_clusters.requested is False
     assert summary.processing_times_seconds.total == 0.4
     assert summary.processing_times_seconds.throughput.photons_per_second == 5.0
 
@@ -524,8 +581,8 @@ def test_photon_reconstruction_summary_validates_every_section() -> None:
 @pytest.mark.parametrize(
     ("field", "value", "error"),
     [
-        ("components_formed", 4, "components_formed"),
-        ("pixel_rows_below_min_tot", 13, "cannot exceed"),
+        ("clusters_formed", 4, "clusters_formed"),
+        ("total_photons", 3, "clusters_formed"),
     ],
 )
 def test_photon_reconstruction_summary_rejects_inconsistent_values(


### PR DESCRIPTION
This pull request updates the documentation, configuration, and C++ implementation for the unpacker and photon reconstruction pipeline to clarify and standardize file naming, directory structure, and summary output formats. It introduces explicit measurement and run identifiers throughout the workflow, improves the clarity of output locations, and aligns the summary JSON structure and command-line interfaces with these conventions.

**Key changes include:**

### Documentation and Output Structure Standardization

* Updated documentation in `photon_reconstruction.md` and `unpacker.md` to clarify directory structures, file naming conventions, and the inclusion of measurement/run identifiers in both unpacker and reconstruction outputs. This includes new directory paths (e.g., `analysis/logs/photon_reconstruction/`, `analysis/logs/unpacking/`) and standardized filename patterns for Parquet and summary files. [[1]](diffhunk://#diff-d9b5e9f4178d839088b8dfad09e7816649ba0e2f9a84999ef5e5f71d2b89d1e2L169-R189) [[2]](diffhunk://#diff-d9b5e9f4178d839088b8dfad09e7816649ba0e2f9a84999ef5e5f71d2b89d1e2L220-R251) [[3]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afL282-R324)

* The summary JSON files for both unpacker and reconstruction now open with a `measurement_info` section, including `measurement_id` and `run`, and all file paths are specified exactly as written, so downstream tools can locate outputs directly. [[1]](diffhunk://#diff-d9b5e9f4178d839088b8dfad09e7816649ba0e2f9a84999ef5e5f71d2b89d1e2L220-R251) [[2]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afL282-R324)

### Command-Line Interface and Configuration

* Both the unpacker and photon reconstruction binaries now require `--measurement-id` and `--run` arguments when writing outputs, and these are copied into the summary JSON for provenance. The help message and documentation have been updated accordingly. [[1]](diffhunk://#diff-55a030ca33e850803192f431357fc6c49f397ea1b25c2e24efb9b804c7ca5176L37-R52) [[2]](diffhunk://#diff-6f926e4a481d6cdd0d4f0d31624700a2ce408054bbd146005601024de00e80afR40-R53)

* Updated example and test configuration files (`config.yaml`) to use new relative directory conventions and reflect the simplified structure. [[1]](diffhunk://#diff-08a4fe6f8478c302a17545615518ea92f16c3c99c372d3ab2cb519971387da08L9-R13) [[2]](diffhunk://#diff-8dd3fbaf0db3b3d181aa8fbd2c99ff8e56eb7e2ea0955c6362b3e41cb5595fd7L9-R13)

### Photon Reconstruction Summary and Output

* The photon reconstruction summary structure has been expanded to include measurement/run identity, detailed clustering settings, explicit input/output file paths, and updated count field names for clarity (e.g., `pixels_read`, `clusters_formed`, `total_photons`, `rejected_clusters`). [[1]](diffhunk://#diff-426e938e5b09f1627d5dc4f761e41c3dfb31a7aa7f62635a19c49ec1145f1c7eR9-R53) [[2]](diffhunk://#diff-426e938e5b09f1627d5dc4f761e41c3dfb31a7aa7f62635a19c49ec1145f1c7eR9-R53) [[3]](diffhunk://#diff-744632a6045f717b32f1f672efe4203dca2a86187169f54a77b32f9b270324e1L51-R56)

* Output Parquet files for photons and pixel clusters are now written to `photons/` and `pixel_clusters/` directories, with filenames following the new conventions. [[1]](diffhunk://#diff-d9b5e9f4178d839088b8dfad09e7816649ba0e2f9a84999ef5e5f71d2b89d1e2L169-R189) [[2]](diffhunk://#diff-d9b5e9f4178d839088b8dfad09e7816649ba0e2f9a84999ef5e5f71d2b89d1e2L195-R207)

### Minor Consistency and Clarity Improvements

* Updated field names and descriptions throughout the documentation and code to match the new conventions and improve clarity (e.g., `photon_pixels` → `pixel_clusters`, `components_formed` → `clusters_formed`). [[1]](diffhunk://#diff-d9b5e9f4178d839088b8dfad09e7816649ba0e2f9a84999ef5e5f71d2b89d1e2R263) [[2]](diffhunk://#diff-744632a6045f717b32f1f672efe4203dca2a86187169f54a77b32f9b270324e1L51-R56)

* Help messages and documentation have been revised to clearly describe all required and optional command-line arguments, their effects, and the new output locations.

These changes ensure that all outputs are traceable to their measurement/run context, that file locations are predictable and machine-readable, and that the workflow is easier to use and maintain.